### PR TITLE
Refactor health checks, trending API, and deployment config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Test Mukoko News
+name: Test & Deploy Mukoko News
 
 on:
   push:
@@ -12,6 +12,10 @@ permissions:
   pull-requests: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Tests — run in parallel on every push and PR
+  # ---------------------------------------------------------------------------
+
   test-frontend:
     runs-on: ubuntu-latest
     name: Test Frontend (Next.js)
@@ -101,3 +105,98 @@ jobs:
       run: |
         cd processing
         uv run pyright
+
+  # ---------------------------------------------------------------------------
+  # Deployments — push to main only, ordered by service-binding dependency:
+  #   mongo-proxy  ->  Python Worker (MONGO service binding)
+  #              ->  backend (DATA_PROCESSOR service binding)
+  # ---------------------------------------------------------------------------
+
+  deploy-mongo-proxy:
+    runs-on: ubuntu-latest
+    name: Deploy MongoDB Proxy Worker
+    if: github.event_name == 'push'
+    needs: [test-backend]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: 'processing/mongo-proxy/package-lock.json'
+
+    - name: Install mongo-proxy dependencies
+      run: |
+        cd processing/mongo-proxy
+        npm ci
+
+    - name: Deploy mongo-proxy to Cloudflare Workers
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: |
+        cd processing/mongo-proxy
+        npx wrangler deploy
+
+  deploy-python-worker:
+    runs-on: ubuntu-latest
+    name: Deploy Python API Worker
+    if: github.event_name == 'push'
+    needs: [test-api, deploy-mongo-proxy]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install Python dependencies
+      run: |
+        cd processing
+        uv sync
+
+    - name: Deploy Python Worker to Cloudflare Workers
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: |
+        cd processing
+        uv run pywrangler deploy
+
+  deploy-backend:
+    runs-on: ubuntu-latest
+    name: Deploy Backend Worker
+    if: github.event_name == 'push'
+    needs: [test-backend, deploy-python-worker]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js for backend
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: 'backend/package-lock.json'
+
+    - name: Install backend dependencies
+      run: |
+        cd backend
+        npm ci
+
+    - name: Deploy backend to Cloudflare Workers
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      run: |
+        cd backend
+        npm run deploy
+
+    - name: Health check
+      run: |
+        sleep 10
+        curl --fail --silent --show-error \
+          https://mukoko-news-backend.nyuchi.workers.dev/api/health

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Test & Deploy Mukoko News
+name: Test Mukoko News
 
 on:
   push:
@@ -12,10 +12,6 @@ permissions:
   pull-requests: read
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Tests — run in parallel on every push and PR
-  # ---------------------------------------------------------------------------
-
   test-frontend:
     runs-on: ubuntu-latest
     name: Test Frontend (Next.js)
@@ -105,98 +101,3 @@ jobs:
       run: |
         cd processing
         uv run pyright
-
-  # ---------------------------------------------------------------------------
-  # Deployments — push to main only, ordered by service-binding dependency:
-  #   mongo-proxy  ->  Python Worker (MONGO service binding)
-  #              ->  backend (DATA_PROCESSOR service binding)
-  # ---------------------------------------------------------------------------
-
-  deploy-mongo-proxy:
-    runs-on: ubuntu-latest
-    name: Deploy MongoDB Proxy Worker
-    if: github.event_name == 'push'
-    needs: [test-backend]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: 'processing/mongo-proxy/package-lock.json'
-
-    - name: Install mongo-proxy dependencies
-      run: |
-        cd processing/mongo-proxy
-        npm ci
-
-    - name: Deploy mongo-proxy to Cloudflare Workers
-      env:
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: |
-        cd processing/mongo-proxy
-        npx wrangler deploy
-
-  deploy-python-worker:
-    runs-on: ubuntu-latest
-    name: Deploy Python API Worker
-    if: github.event_name == 'push'
-    needs: [test-api, deploy-mongo-proxy]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-
-    - name: Install Python dependencies
-      run: |
-        cd processing
-        uv sync
-
-    - name: Deploy Python Worker to Cloudflare Workers
-      env:
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: |
-        cd processing
-        uv run pywrangler deploy
-
-  deploy-backend:
-    runs-on: ubuntu-latest
-    name: Deploy Backend Worker
-    if: github.event_name == 'push'
-    needs: [test-backend, deploy-python-worker]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js for backend
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: 'backend/package-lock.json'
-
-    - name: Install backend dependencies
-      run: |
-        cd backend
-        npm ci
-
-    - name: Deploy backend to Cloudflare Workers
-      env:
-        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      run: |
-        cd backend
-        npm run deploy
-
-    - name: Health check
-      run: |
-        sleep 10
-        curl --fail --silent --show-error \
-          https://mukoko-news-backend.nyuchi.workers.dev/api/health

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,10 +168,11 @@ Services follow a class-based pattern with D1 database access:
 ## Deployment
 
 - **Frontend**: Auto-deploys to Vercel on push to main
-- **Python Worker**: Deployed via GitHub Actions on push to main (pytest → pywrangler deploy). Deploys **before** backend (service binding dependency). Manual: `cd processing && uv run pywrangler deploy`
-- **Backend**: Deployed via GitHub Actions after Python Worker (tests → migrations → wrangler deploy → health check). Manual: `cd backend && npm run deploy`
-- **Cloudflare Workers native CI/CD is disabled** — only GitHub Actions deploys
-- See `.github/workflows/deploy.yml` for full pipeline
+- **Python Worker** (`mukoko-news-api`): Deployed by Cloudflare GitHub App on push to main. Manual: `cd processing && uv run pywrangler deploy`
+- **MongoDB Proxy Worker** (`mukoko-mongo-proxy`): Deployed by Cloudflare GitHub App on push to main. Manual: `cd processing/mongo-proxy && npx wrangler deploy`
+- **Backend** (`mukoko-news-backend`): Deployed by Cloudflare GitHub App on push to main. Manual: `cd backend && npm run deploy`
+- **Cloudflare GitHub App** manages all three Workers — configure each worker's root directory in the Cloudflare dashboard (Workers & Pages → Settings → Build). Deploy order must be: mongo-proxy → Python Worker → backend (service binding dependency).
+- `.github/workflows/deploy.yml` runs tests only (CI); deployment is handled by Cloudflare
 
 ## Environment Variables
 

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -926,15 +926,16 @@ app.get("/api/feeds/personalized", async (c) => {
 
     // Initialize personalized feed service
     const feedService = new PersonalizedFeedService(c.env.DB);
+    const processingClient = new ProcessingClient(c.env.DATA_PROCESSOR);
 
-    // Get personalized feed (will use user's country preferences if no override)
+    // Get personalized feed — Python Worker handles ranking (numpy vectorised)
     const result = await feedService.getPersonalizedFeed(userId, {
       limit,
       offset,
       excludeRead,
       diversityFactor,
       countries,  // Pan-African: pass country override
-    });
+    }, processingClient);
 
     // Fetch keywords for each article
     for (const article of result.articles) {
@@ -1043,9 +1044,6 @@ app.get("/api/feeds/sectioned", async (c) => {
           .filter(cat => VALID_CATEGORIES.has(cat))
       : [];
 
-    // normalizeTitle and titleSimilarity imported from StoryClusteringService
-    // with DoS prevention (title length limit: 500 chars, word limit: 50)
-
     // Build country filter clause
     let countryClause = '';
     const countryParams: string[] = [];
@@ -1097,42 +1095,50 @@ app.get("/api/feeds/sectioned", async (c) => {
       articleCount: number;
     }
 
-    const clusters: StoryCluster[] = [];
-    const clusteredIds = new Set<string>();
-
-    for (const article of topStoriesRaw) {
-      if (clusteredIds.has(article.id)) continue;
-
-      const articleWords = normalizeTitle(article.title);
-      const cluster: StoryCluster = {
-        id: `cluster-${article.id}`,
-        primaryArticle: article,
-        relatedArticles: [],
-        articleCount: 1,
-      };
-
-      clusteredIds.add(article.id);
-
-      // Find related articles (same story from different sources)
-      for (const other of topStoriesRaw) {
-        if (clusteredIds.has(other.id)) continue;
-        if (article.source === other.source) continue; // Must be different sources
-
-        const otherWords = normalizeTitle(other.title);
-        const similarity = titleSimilarity(articleWords, otherWords);
-
-        // Group stories that exceed similarity threshold
-        if (similarity > CLUSTERING_CONFIG.SIMILARITY_THRESHOLD) {
-          cluster.relatedArticles.push(other);
-          cluster.articleCount++;
-          clusteredIds.add(other.id);
-
-          if (cluster.relatedArticles.length >= CLUSTERING_CONFIG.MAX_RELATED_PER_CLUSTER) break;
+    // Cluster similar stories — try Python Worker first, fall back to Jaccard TS
+    let clusters: StoryCluster[];
+    try {
+      const processingClient = new ProcessingClient(c.env.DATA_PROCESSOR);
+      const clusterResult = await processingClient.clusterArticles(topStoriesRaw, {
+        similarityThreshold: CLUSTERING_CONFIG.SIMILARITY_THRESHOLD,
+        maxRelatedPerCluster: CLUSTERING_CONFIG.MAX_RELATED_PER_CLUSTER,
+        maxClusters: CLUSTERING_CONFIG.MAX_CLUSTERS,
+      });
+      // Map snake_case Python response to camelCase for frontend compatibility
+      clusters = clusterResult.clusters.map(cl => ({
+        id: cl.id,
+        primaryArticle: cl.primary_article,
+        relatedArticles: cl.related_articles,
+        articleCount: cl.article_count,
+      }));
+    } catch (clusterErr) {
+      console.error('[feeds/sectioned] Python clustering failed, using Jaccard fallback:', clusterErr);
+      // TS Jaccard fallback
+      clusters = [];
+      const clusteredIds = new Set<string>();
+      for (const article of topStoriesRaw) {
+        if (clusteredIds.has(article.id)) continue;
+        const articleWords = normalizeTitle(article.title);
+        const cluster: StoryCluster = {
+          id: `cluster-${article.id}`,
+          primaryArticle: article,
+          relatedArticles: [],
+          articleCount: 1,
+        };
+        clusteredIds.add(article.id);
+        for (const other of topStoriesRaw) {
+          if (clusteredIds.has(other.id)) continue;
+          if (article.source === other.source) continue;
+          if (titleSimilarity(articleWords, normalizeTitle(other.title)) > CLUSTERING_CONFIG.SIMILARITY_THRESHOLD) {
+            cluster.relatedArticles.push(other);
+            cluster.articleCount++;
+            clusteredIds.add(other.id);
+            if (cluster.relatedArticles.length >= CLUSTERING_CONFIG.MAX_RELATED_PER_CLUSTER) break;
+          }
         }
+        clusters.push(cluster);
+        if (clusters.length >= CLUSTERING_CONFIG.MAX_CLUSTERS) break;
       }
-
-      clusters.push(cluster);
-      if (clusters.length >= CLUSTERING_CONFIG.MAX_CLUSTERS) break;
     }
 
     // Phase 2: Fetch category-based content with batch query (fixes N+1 pattern)

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -924,11 +924,12 @@ app.get("/api/feeds/personalized", async (c) => {
     // Get user ID from header or session
     const userId = c.req.header("x-user-id") || c.req.header("x-session-id") || null;
 
-    // Initialize personalized feed service
     const feedService = new PersonalizedFeedService(c.env.DB);
-    const processingClient = new ProcessingClient(c.env.DATA_PROCESSOR);
 
-    // Get personalized feed — Python Worker handles ranking (numpy vectorised)
+    // Pass ProcessingClient so the service can try Python numpy ranking.
+    // PersonalizedFeedService.getPersonalizedFeed() catches rankFeed() failures
+    // internally and falls back to the built-in TS scorer — no outer fallback needed.
+    const processingClient = new ProcessingClient(c.env.DATA_PROCESSOR);
     const result = await feedService.getPersonalizedFeed(userId, {
       limit,
       offset,

--- a/backend/middleware/__tests__/oidcAuth.test.ts
+++ b/backend/middleware/__tests__/oidcAuth.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../services/OIDCAuthService.js', () => {
   }));
 
   // Add static method
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (MockOIDCAuthService as any).extractBearerToken = (authHeader: string | null): string | null => {
     if (!authHeader) return null;
     const parts = authHeader.split(' ');

--- a/backend/middleware/__tests__/oidcAuth.test.ts
+++ b/backend/middleware/__tests__/oidcAuth.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../services/OIDCAuthService.js', () => {
   }));
 
   // Add static method
-  MockOIDCAuthService.extractBearerToken = (authHeader: string | null): string | null => {
+  (MockOIDCAuthService as any).extractBearerToken = (authHeader: string | null): string | null => {
     if (!authHeader) return null;
     const parts = authHeader.split(' ');
     if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') return null;

--- a/backend/services/PersonalizedFeedService.ts
+++ b/backend/services/PersonalizedFeedService.ts
@@ -54,6 +54,21 @@ interface PersonalizedFeedOptions {
   countries?: string[] | null; // Pan-African support: override user's country preferences
 }
 
+// Minimal interface for the Python Worker ranking call (subset of ProcessingClient)
+interface RankFeedClient {
+  rankFeed(
+    articles: Array<Record<string, unknown>>,
+    preferences: {
+      followedSources?: string[];
+      followedAuthors?: string[];
+      followedCategories?: string[];
+      preferredCountries?: string[];
+      primaryCountry?: string | null;
+      categoryInterests?: Record<string, number>;
+    }
+  ): Promise<{ articles: Array<Record<string, unknown> & { score: number; score_breakdown: Record<string, number> }> }>;
+}
+
 // Scoring weights
 const WEIGHTS = {
   FOLLOWED_SOURCE: 50,      // Strong boost for followed sources
@@ -77,11 +92,15 @@ export class PersonalizedFeedService {
   }
 
   /**
-   * Get personalized feed for a user
+   * Get personalized feed for a user.
+   * When processingClient is provided, ranking is delegated to the Python Worker
+   * (numpy-vectorised scoring with source-quality signal). Falls back to the
+   * built-in TS scorer if the Python call fails.
    */
   async getPersonalizedFeed(
     userId: string | null,
-    options: PersonalizedFeedOptions = {}
+    options: PersonalizedFeedOptions = {},
+    processingClient?: RankFeedClient
   ): Promise<{
     articles: ScoredArticle[];
     total: number;
@@ -129,13 +148,29 @@ export class PersonalizedFeedService {
       effectiveCountries.length > 0 ? effectiveCountries : null  // Pan-African: pass countries
     );
 
-    // Score and rank articles
-    const scoredArticles = this.scoreArticles(
-      candidates,
-      preferences,
-      recencyWeight,
-      diversityFactor
-    );
+    // Score and rank articles — try Python Worker first, fall back to TS scorer
+    let scoredArticles: ScoredArticle[];
+    if (processingClient) {
+      try {
+        const rankResult = await processingClient.rankFeed(
+          candidates as unknown as Array<Record<string, unknown>>,
+          {
+            followedSources: preferences.followedSources,
+            followedAuthors: preferences.followedAuthors,
+            followedCategories: preferences.followedCategories,
+            preferredCountries: preferences.preferredCountries,
+            primaryCountry: preferences.primaryCountry,
+            categoryInterests: Object.fromEntries(preferences.categoryInterests),
+          }
+        );
+        scoredArticles = rankResult.articles as unknown as ScoredArticle[];
+      } catch (err) {
+        console.error('[PersonalizedFeedService] Python ranking failed, using TS fallback:', err);
+        scoredArticles = this.scoreArticles(candidates, preferences, recencyWeight, diversityFactor);
+      }
+    } else {
+      scoredArticles = this.scoreArticles(candidates, preferences, recencyWeight, diversityFactor);
+    }
 
     // Apply pagination
     const paginatedArticles = scoredArticles.slice(offset, offset + limit);

--- a/backend/services/PersonalizedFeedService.ts
+++ b/backend/services/PersonalizedFeedService.ts
@@ -54,6 +54,39 @@ interface PersonalizedFeedOptions {
   countries?: string[] | null; // Pan-African support: override user's country preferences
 }
 
+// Shape of each article returned by the Python Worker's /feed/rank endpoint.
+// Fields mirror the Python feed_ranker.py output (snake_case).
+interface PythonRankedArticle {
+  id: number;
+  title: string;
+  slug: string;
+  description: string;
+  content_snippet: string;
+  author: string;
+  source: string;
+  source_id: string;
+  published_at: string;
+  image_url: string;
+  original_url: string;
+  category_id: string;
+  country_id: string;
+  view_count: number;
+  like_count: number;
+  bookmark_count: number;
+  score: number;
+  score_breakdown: {
+    followed_source: number;
+    followed_author: number;
+    followed_category: number;
+    category_interest: number;
+    primary_country: number;
+    recency: number;
+    engagement: number;
+    source_quality: number;
+    diversity: number;
+  };
+}
+
 // Minimal interface for the Python Worker ranking call (subset of ProcessingClient)
 interface RankFeedClient {
   rankFeed(
@@ -163,23 +196,40 @@ export class PersonalizedFeedService {
             categoryInterests: Object.fromEntries(preferences.categoryInterests),
           }
         );
-        // Python returns snake_case score_breakdown keys — map to camelCase ScoredArticle fields
-        scoredArticles = rankResult.articles.map(a => {
-          const sb = a.score_breakdown as Record<string, number> | undefined;
+        // Explicitly map PythonRankedArticle (snake_case) → ScoredArticle (camelCase).
+        // Single assertion to PythonRankedArticle gives us typed field access;
+        // the explicit mapping below replaces the previous `as unknown as ScoredArticle[]` cast.
+        scoredArticles = rankResult.articles.map((a): ScoredArticle => {
+          const p = a as unknown as PythonRankedArticle;
           return {
-            ...a,
-            score: a.score,
-            scoreBreakdown: sb ? {
-              followedSource: sb.followed_source ?? 0,
-              followedAuthor: sb.followed_author ?? 0,
-              followedCategory: sb.followed_category ?? 0,
-              categoryInterest: sb.category_interest ?? 0,
-              primaryCountry: sb.primary_country ?? 0,
-              recency: sb.recency ?? 0,
-              engagement: sb.engagement ?? 0,
-              diversity: sb.diversity ?? 0,
-            } : undefined,
-          } as unknown as ScoredArticle;
+          id: p.id,
+          title: p.title,
+          slug: p.slug,
+          description: p.description,
+          content_snippet: p.content_snippet,
+          author: p.author,
+          source: p.source,
+          source_id: p.source_id,
+          published_at: p.published_at,
+          image_url: p.image_url,
+          original_url: p.original_url,
+          category_id: p.category_id,
+          country_id: p.country_id,
+          view_count: p.view_count,
+          like_count: p.like_count,
+          bookmark_count: p.bookmark_count,
+          score: p.score,
+          scoreBreakdown: {
+            followedSource: p.score_breakdown.followed_source,
+            followedAuthor: p.score_breakdown.followed_author,
+            followedCategory: p.score_breakdown.followed_category,
+            categoryInterest: p.score_breakdown.category_interest,
+            primaryCountry: p.score_breakdown.primary_country,
+            recency: p.score_breakdown.recency,
+            engagement: p.score_breakdown.engagement,
+            diversity: p.score_breakdown.diversity,
+          },
+        };
         });
       } catch (err) {
         console.error('[PersonalizedFeedService] Python ranking failed, using TS fallback:', err);

--- a/backend/services/PersonalizedFeedService.ts
+++ b/backend/services/PersonalizedFeedService.ts
@@ -5,6 +5,8 @@
  * reading history, follows, and engagement patterns.
  */
 
+import { PythonRankedArticle } from './ProcessingClient.js';
+
 interface UserPreferences {
   followedSources: string[];
   followedAuthors: string[];
@@ -54,40 +56,9 @@ interface PersonalizedFeedOptions {
   countries?: string[] | null; // Pan-African support: override user's country preferences
 }
 
-// Shape of each article returned by the Python Worker's /feed/rank endpoint.
-// Fields mirror the Python feed_ranker.py output (snake_case).
-interface PythonRankedArticle {
-  id: number;
-  title: string;
-  slug: string;
-  description: string;
-  content_snippet: string;
-  author: string;
-  source: string;
-  source_id: string;
-  published_at: string;
-  image_url: string;
-  original_url: string;
-  category_id: string;
-  country_id: string;
-  view_count: number;
-  like_count: number;
-  bookmark_count: number;
-  score: number;
-  score_breakdown: {
-    followed_source: number;
-    followed_author: number;
-    followed_category: number;
-    category_interest: number;
-    primary_country: number;
-    recency: number;
-    engagement: number;
-    source_quality: number;
-    diversity: number;
-  };
-}
-
-// Minimal interface for the Python Worker ranking call (subset of ProcessingClient)
+// Minimal interface for the Python Worker ranking call (subset of ProcessingClient).
+// Uses PythonRankedArticle (defined in ProcessingClient.ts) so the return type is
+// structurally verified — no as-unknown-as cast needed in the mapping below.
 interface RankFeedClient {
   rankFeed(
     articles: Array<Record<string, unknown>>,
@@ -99,7 +70,7 @@ interface RankFeedClient {
       primaryCountry?: string | null;
       categoryInterests?: Record<string, number>;
     }
-  ): Promise<{ articles: Array<Record<string, unknown> & { score: number; score_breakdown: Record<string, number> }> }>;
+  ): Promise<{ articles: PythonRankedArticle[] }>;
 }
 
 // Scoring weights
@@ -196,41 +167,40 @@ export class PersonalizedFeedService {
             categoryInterests: Object.fromEntries(preferences.categoryInterests),
           }
         );
-        // Explicitly map PythonRankedArticle (snake_case) → ScoredArticle (camelCase).
-        // Single assertion to PythonRankedArticle gives us typed field access;
-        // the explicit mapping below replaces the previous `as unknown as ScoredArticle[]` cast.
-        scoredArticles = rankResult.articles.map((a): ScoredArticle => {
-          const p = a as unknown as PythonRankedArticle;
-          return {
-          id: p.id,
-          title: p.title,
-          slug: p.slug,
-          description: p.description,
-          content_snippet: p.content_snippet,
-          author: p.author,
-          source: p.source,
-          source_id: p.source_id,
-          published_at: p.published_at,
-          image_url: p.image_url,
-          original_url: p.original_url,
-          category_id: p.category_id,
-          country_id: p.country_id,
-          view_count: p.view_count,
-          like_count: p.like_count,
-          bookmark_count: p.bookmark_count,
-          score: p.score,
+        // Map PythonRankedArticle (snake_case) → ScoredArticle (camelCase).
+        // RankFeedClient now returns PythonRankedArticle[] so no cast is needed here.
+        // source_quality is intentionally excluded from scoreBreakdown: ScoredArticle
+        // doesn't model this signal (TS scorer doesn't produce it). See PythonRankedArticle
+        // in ProcessingClient.ts for the full breakdown including source_quality.
+        scoredArticles = rankResult.articles.map((a): ScoredArticle => ({
+          id: a.id,
+          title: a.title,
+          slug: a.slug,
+          description: a.description,
+          content_snippet: a.content_snippet,
+          author: a.author,
+          source: a.source,
+          source_id: a.source_id,
+          published_at: a.published_at,
+          image_url: a.image_url,
+          original_url: a.original_url,
+          category_id: a.category_id,
+          country_id: a.country_id,
+          view_count: a.view_count,
+          like_count: a.like_count,
+          bookmark_count: a.bookmark_count,
+          score: a.score,
           scoreBreakdown: {
-            followedSource: p.score_breakdown.followed_source,
-            followedAuthor: p.score_breakdown.followed_author,
-            followedCategory: p.score_breakdown.followed_category,
-            categoryInterest: p.score_breakdown.category_interest,
-            primaryCountry: p.score_breakdown.primary_country,
-            recency: p.score_breakdown.recency,
-            engagement: p.score_breakdown.engagement,
-            diversity: p.score_breakdown.diversity,
+            followedSource: a.score_breakdown.followed_source,
+            followedAuthor: a.score_breakdown.followed_author,
+            followedCategory: a.score_breakdown.followed_category,
+            categoryInterest: a.score_breakdown.category_interest,
+            primaryCountry: a.score_breakdown.primary_country,
+            recency: a.score_breakdown.recency,
+            engagement: a.score_breakdown.engagement,
+            diversity: a.score_breakdown.diversity,
           },
-        };
-        });
+        }));
       } catch (err) {
         console.error('[PersonalizedFeedService] Python ranking failed, using TS fallback:', err);
         scoredArticles = this.scoreArticles(candidates, preferences, recencyWeight, diversityFactor);

--- a/backend/services/PersonalizedFeedService.ts
+++ b/backend/services/PersonalizedFeedService.ts
@@ -44,6 +44,7 @@ interface ScoredArticle {
     recency: number;
     engagement: number;
     diversity: number;
+    sourceQuality: number;  // Python Worker signal; 0 when TS scorer is used
   };
 }
 
@@ -169,9 +170,9 @@ export class PersonalizedFeedService {
         );
         // Map PythonRankedArticle (snake_case) → ScoredArticle (camelCase).
         // RankFeedClient now returns PythonRankedArticle[] so no cast is needed here.
-        // source_quality is intentionally excluded from scoreBreakdown: ScoredArticle
-        // doesn't model this signal (TS scorer doesn't produce it). See PythonRankedArticle
-        // in ProcessingClient.ts for the full breakdown including source_quality.
+        // sourceQuality is populated from the Python Worker; the TS scorer sets it to 0.
+        // This ensures scoreBreakdown values always sum to score regardless of which
+        // path produced the ranking.
         scoredArticles = rankResult.articles.map((a): ScoredArticle => ({
           id: a.id,
           title: a.title,
@@ -199,6 +200,7 @@ export class PersonalizedFeedService {
             recency: a.score_breakdown.recency,
             engagement: a.score_breakdown.engagement,
             diversity: a.score_breakdown.diversity,
+            sourceQuality: a.score_breakdown.source_quality,
           },
         }));
       } catch (err) {
@@ -212,7 +214,11 @@ export class PersonalizedFeedService {
     // Apply pagination
     const paginatedArticles = scoredArticles.slice(offset, offset + limit);
 
-    // Get total count (filtered by countries if applicable)
+    // Get total count from D1 (filtered by countries if applicable).
+    // NOTE: total reflects published articles in D1, not the number of Python-ranked
+    // candidates. When Python ranking is active it scores a candidateLimit-sized sample
+    // (up to 200), so total may exceed the actual rankable set. This is a known limitation
+    // of the in-memory scoring pattern shared by both the TS and Python paths.
     let countQuery = 'SELECT COUNT(*) as total FROM articles WHERE status = \'published\'';
     const countParams: string[] = [];
     if (effectiveCountries.length > 0) {
@@ -376,6 +382,7 @@ export class PersonalizedFeedService {
         recency: 0,
         engagement: 0,
         diversity: 0,
+        sourceQuality: 0,   // Python Worker only; TS scorer does not compute this
       };
 
       // Followed source boost

--- a/backend/services/PersonalizedFeedService.ts
+++ b/backend/services/PersonalizedFeedService.ts
@@ -163,7 +163,24 @@ export class PersonalizedFeedService {
             categoryInterests: Object.fromEntries(preferences.categoryInterests),
           }
         );
-        scoredArticles = rankResult.articles as unknown as ScoredArticle[];
+        // Python returns snake_case score_breakdown keys — map to camelCase ScoredArticle fields
+        scoredArticles = rankResult.articles.map(a => {
+          const sb = a.score_breakdown as Record<string, number> | undefined;
+          return {
+            ...a,
+            score: a.score,
+            scoreBreakdown: sb ? {
+              followedSource: sb.followed_source ?? 0,
+              followedAuthor: sb.followed_author ?? 0,
+              followedCategory: sb.followed_category ?? 0,
+              categoryInterest: sb.category_interest ?? 0,
+              primaryCountry: sb.primary_country ?? 0,
+              recency: sb.recency ?? 0,
+              engagement: sb.engagement ?? 0,
+              diversity: sb.diversity ?? 0,
+            } : undefined,
+          } as unknown as ScoredArticle;
+        });
       } catch (err) {
         console.error('[PersonalizedFeedService] Python ranking failed, using TS fallback:', err);
         scoredArticles = this.scoreArticles(candidates, preferences, recencyWeight, diversityFactor);

--- a/backend/services/ProcessingClient.ts
+++ b/backend/services/ProcessingClient.ts
@@ -25,9 +25,8 @@ type ServiceBinding = { fetch(input: RequestInfo, init?: RequestInit): Promise<R
  * can use it as the canonical type without duplicating the definition.
  *
  * Note: score_breakdown includes source_quality (a new signal not in the TS scorer).
- * That field is intentionally excluded from ScoredArticle.scoreBreakdown because the
- * TS scorer doesn't produce it — adding it to ScoredArticle would require a broader
- * schema change. Consumers wanting the full breakdown should use PythonRankedArticle directly.
+ * It is mapped to ScoredArticle.scoreBreakdown.sourceQuality; the TS scorer always
+ * sets sourceQuality to 0, ensuring scoreBreakdown values sum to score on both paths.
  */
 export interface PythonRankedArticle {
   id: number;
@@ -287,8 +286,10 @@ export class ProcessingClient {
   async getSourceHealth() {
     return this._get<{
       sources: Array<{
-        source_id: number;
+        source_id: string; // Python coerces MongoDB _id to str() — never a number
         name: string;
+        url: string | null;
+        country_id: string | null;
         status: string;
         consecutive_failures: number;
         last_successful_fetch: string | null;

--- a/backend/services/ProcessingClient.ts
+++ b/backend/services/ProcessingClient.ts
@@ -19,6 +19,47 @@
 
 type ServiceBinding = { fetch(input: RequestInfo, init?: RequestInit): Promise<Response> };
 
+/**
+ * Shape of each article returned by the Python Worker's /feed/rank endpoint.
+ * Fields mirror feed_ranker.py output (snake_case). Exported so PersonalizedFeedService
+ * can use it as the canonical type without duplicating the definition.
+ *
+ * Note: score_breakdown includes source_quality (a new signal not in the TS scorer).
+ * That field is intentionally excluded from ScoredArticle.scoreBreakdown because the
+ * TS scorer doesn't produce it — adding it to ScoredArticle would require a broader
+ * schema change. Consumers wanting the full breakdown should use PythonRankedArticle directly.
+ */
+export interface PythonRankedArticle {
+  id: number;
+  title: string;
+  slug: string;
+  description: string;
+  content_snippet: string;
+  author: string;
+  source: string;
+  source_id: string;
+  published_at: string;
+  image_url: string;
+  original_url: string;
+  category_id: string;
+  country_id: string;
+  view_count: number;
+  like_count: number;
+  bookmark_count: number;
+  score: number;
+  score_breakdown: {
+    followed_source: number;
+    followed_author: number;
+    followed_category: number;
+    category_interest: number;
+    primary_country: number;
+    recency: number;
+    engagement: number;
+    source_quality: number; // Python-only signal; not mapped to ScoredArticle.scoreBreakdown
+    diversity: number;
+  };
+}
+
 export class ProcessingClient {
   private binding: ServiceBinding;
 
@@ -202,9 +243,7 @@ export class ProcessingClient {
       categoryInterests?: Record<string, number>;
     }
   ) {
-    return this._post<{
-      articles: Array<Record<string, unknown> & { score: number; score_breakdown: Record<string, number> }>;
-    }>('/feed/rank', { articles, preferences });
+    return this._post<{ articles: PythonRankedArticle[] }>('/feed/rank', { articles, preferences });
   }
 
   // ---------------------------------------------------------------------------

--- a/backend/services/__tests__/PersonalizedFeedService.test.ts
+++ b/backend/services/__tests__/PersonalizedFeedService.test.ts
@@ -370,6 +370,72 @@ describe('PersonalizedFeedService', () => {
     });
   });
 
+  describe('Python Worker ranking integration', () => {
+    // Mock DB returning a user with preferences and candidate articles
+    const setupPreferenceMocks = (db: ReturnType<typeof createMockD1>) => {
+      db._statement.all
+        .mockResolvedValueOnce({ results: [{ follow_id: 'herald' }] })      // sources
+        .mockResolvedValueOnce({ results: [{ follow_id: 'John Doe' }] })    // authors
+        .mockResolvedValueOnce({ results: [{ follow_id: 'politics' }] })    // categories
+        .mockResolvedValueOnce({ results: [{ country_id: 'ZW', is_primary: true }] }) // countries
+        .mockResolvedValueOnce({ results: [] })                             // history
+        .mockResolvedValueOnce({ results: [] })                             // recent reads
+        .mockResolvedValue({ results: sampleArticles });                    // candidates
+      db._statement.first.mockResolvedValue({ total: 3 });
+    };
+
+    it('uses Python rankFeed when processingClient is provided (happy path)', async () => {
+      setupPreferenceMocks(mockDb);
+
+      const rankedArticles = [
+        { ...sampleArticles[1], score: 95.5, score_breakdown: { followed_source: 0, followed_author: 0, followed_category: 0, category_interest: 0, primary_country: 0, recency: 25, engagement: 15, diversity: 0, source_quality: 10 } },
+        { ...sampleArticles[0], score: 80.0, score_breakdown: { followed_source: 50, followed_author: 40, followed_category: 30, category_interest: 0, primary_country: 35, recency: 24, engagement: 12, diversity: 0, source_quality: 9 } },
+        { ...sampleArticles[2], score: 10.0, score_breakdown: { followed_source: 0, followed_author: 0, followed_category: 0, category_interest: 0, primary_country: 0, recency: 10, engagement: 8, diversity: -10, source_quality: 5 } },
+      ];
+
+      const mockProcessingClient = {
+        rankFeed: vi.fn().mockResolvedValue({ articles: rankedArticles }),
+      };
+
+      const result = await service.getPersonalizedFeed('user-123', {}, mockProcessingClient);
+
+      expect(mockProcessingClient.rankFeed).toHaveBeenCalledOnce();
+      expect(result.isPersonalized).toBe(true);
+      // Python-ranked order: sports (95.5) first
+      expect(result.articles[0].category_id).toBe('sports');
+      // snake_case score_breakdown mapped to camelCase scoreBreakdown
+      expect(result.articles[0].scoreBreakdown?.recency).toBe(25);
+      expect(result.articles[1].scoreBreakdown?.followedSource).toBe(50);
+    });
+
+    it('falls back to TS scorer when Python rankFeed throws', async () => {
+      setupPreferenceMocks(mockDb);
+
+      const mockProcessingClient = {
+        rankFeed: vi.fn().mockRejectedValue(new Error('Python Worker unavailable')),
+      };
+
+      const result = await service.getPersonalizedFeed('user-123', {}, mockProcessingClient);
+
+      expect(mockProcessingClient.rankFeed).toHaveBeenCalledOnce();
+      expect(result.isPersonalized).toBe(true);
+      // TS scorer still produces results
+      expect(result.articles.length).toBeGreaterThan(0);
+      // TS scorer sets camelCase scoreBreakdown directly
+      expect(result.articles[0].scoreBreakdown).toBeDefined();
+    });
+
+    it('uses TS scorer when no processingClient provided', async () => {
+      setupPreferenceMocks(mockDb);
+
+      // No processingClient — pure TS path
+      const result = await service.getPersonalizedFeed('user-123');
+
+      expect(result.isPersonalized).toBe(true);
+      expect(result.articles.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('getFeedExplanation', () => {
     it('should return explanation of why articles are recommended', async () => {
       mockDb._statement.all

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitAny": false,
     "strictNullChecks": false
   },
-  "include": ["*.ts", "services/**/*.ts", "admin/**/*.ts"],
+  "include": ["*.ts", "services/**/*.ts", "admin/**/*.ts", "middleware/**/*.ts"],
   "exclude": [
     "node_modules",
     "build",

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -26,6 +26,7 @@
     "ADMIN_ROLES": "admin",
     "MODERATOR_ROLES": "admin,moderator",
     "AUTHOR_ROLES": "admin,moderator,author",
+    "CREATOR_ROLES": "admin,moderator,author",
     "CLOUDFLARE_ACCOUNT_ID": "125a2dfbc21f76a25c980609609e8218",
     "AI_INSIGHTS_ENABLED": "true",
     "AI_SEARCH_ENABLED": "true",

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -26,7 +26,7 @@
     "ADMIN_ROLES": "admin",
     "MODERATOR_ROLES": "admin,moderator",
     "AUTHOR_ROLES": "admin,moderator,author",
-    "CREATOR_ROLES": "admin,moderator,author",
+    "CREATOR_ROLES": "admin,moderator,author",  // Scaffolding for creator/publisher role tier; read by index.ts Bindings type
     "CLOUDFLARE_ACCOUNT_ID": "125a2dfbc21f76a25c980609609e8218",
     "AI_INSIGHTS_ENABLED": "true",
     "AI_SEARCH_ENABLED": "true",

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -26,7 +26,9 @@
     "ADMIN_ROLES": "admin",
     "MODERATOR_ROLES": "admin,moderator",
     "AUTHOR_ROLES": "admin,moderator,author",
-    "CREATOR_ROLES": "admin,moderator,author",  // Scaffolding for creator/publisher role tier; read by index.ts Bindings type
+    // TODO: expand CREATOR_ROLES when the creator/publisher tier diverges from AUTHOR_ROLES
+    // (e.g. to add a "creator" role with content-submission but no moderation rights).
+    "CREATOR_ROLES": "admin,moderator,author"
     "CLOUDFLARE_ACCOUNT_ID": "125a2dfbc21f76a25c980609609e8218",
     "AI_INSIGHTS_ENABLED": "true",
     "AI_SEARCH_ENABLED": "true",

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -28,7 +28,7 @@
     "AUTHOR_ROLES": "admin,moderator,author",
     // TODO: expand CREATOR_ROLES when the creator/publisher tier diverges from AUTHOR_ROLES
     // (e.g. to add a "creator" role with content-submission but no moderation rights).
-    "CREATOR_ROLES": "admin,moderator,author"
+    "CREATOR_ROLES": "admin,moderator,author",
     "CLOUDFLARE_ACCOUNT_ID": "125a2dfbc21f76a25c980609609e8218",
     "AI_INSIGHTS_ENABLED": "true",
     "AI_SEARCH_ENABLED": "true",

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -161,7 +161,7 @@ async def get_source_health_summary(env) -> dict:
         })
 
     # Sort worst-first (critical → failing → degraded → healthy), then quality descending within tier
-    sources.sort(key=lambda s: (_rank.get(s["status"], 0), -s["quality_score"]), reverse=True)
+    sources.sort(key=lambda s: (_rank.get(s["status"], 0), s["quality_score"]), reverse=True)
     return {"sources": sources, "summary": summary}
 
 

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -5,7 +5,7 @@ Goes beyond the TS SourceHealthService's simple consecutive_failures counter
 by incorporating article quality, engagement data, and adaptive scheduling.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from services.mongodb import MongoDBClient
 
 
@@ -127,7 +127,7 @@ async def check_source_health(env) -> dict:
 async def get_source_health_summary(env) -> dict:
     """Get health summary for all sources (used by /sources/health route)."""
     db = MongoDBClient(env)
-    sources = await db.find(
+    raw = await db.find(
         "rss_sources",
         {"enabled": True},
         projection={
@@ -138,15 +138,34 @@ async def get_source_health_summary(env) -> dict:
         sort={"health_status": 1, "source_quality_score": -1},
         limit=500,
     )
-    return {"sources": sources}
+
+    sources = []
+    summary = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
+
+    for s in raw:
+        failures = s.get("consecutive_failures", 0)
+        status = classify_health(failures)
+        if status in summary:
+            summary[status] += 1
+        sources.append({
+            "source_id": str(s.get("_id") or s.get("id", "")),
+            "name": s.get("name", ""),
+            "status": status,
+            "consecutive_failures": failures,
+            "last_successful_fetch": s.get("last_successful_fetch"),
+            "quality_score": s.get("source_quality_score", 0.5),
+        })
+
+    return {"sources": sources, "summary": summary}
 
 
 async def _compute_source_quality(db: MongoDBClient, source_id) -> dict:
     """Compute quality metrics for a source from its recent articles."""
+    week_ago = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
     pipeline = [
         {"$match": {
             "source_id": source_id,
-            "published_at": {"$gte": {"$date": {"$subtract": ["$$NOW", 604800000]}}},
+            "published_at": {"$gte": week_ago},
         }},
         {"$group": {
             "_id": None,

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -115,6 +115,8 @@ async def check_source_health(env) -> dict:
             {"$set": item["update"]},
         )
 
+    # Every source in `sources` unconditionally appends to `updates` in the loop above,
+    # so iterating updates is equivalent to iterating sources for counting purposes.
     counts: dict[str, int] = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
     for item in updates:
         counts[item["update"]["health_status"]] += 1

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -5,6 +5,7 @@ Goes beyond the TS SourceHealthService's simple consecutive_failures counter
 by incorporating article quality, engagement data, and adaptive scheduling.
 """
 
+import math
 from datetime import datetime, timezone, timedelta
 from services.mongodb import MongoDBClient
 
@@ -114,33 +115,36 @@ async def check_source_health(env) -> dict:
             {"$set": item["update"]},
         )
 
+    counts: dict[str, int] = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
+    for item in updates:
+        counts[item["update"]["health_status"]] = counts.get(item["update"]["health_status"], 0) + 1
+
     return {
         "sources": len(sources),
         "alerts": alerts,
-        "healthy": sum(1 for s in sources if classify_health(s.get("consecutive_failures", 0)) == "healthy"),
-        "degraded": sum(1 for s in sources if classify_health(s.get("consecutive_failures", 0)) == "degraded"),
-        "failing": sum(1 for s in sources if classify_health(s.get("consecutive_failures", 0)) == "failing"),
-        "critical": sum(1 for s in sources if classify_health(s.get("consecutive_failures", 0)) == "critical"),
+        **counts,
     }
 
 
 async def get_source_health_summary(env) -> dict:
     """Get health summary for all sources (used by /sources/health route)."""
     db = MongoDBClient(env)
+    # published_at is stored as ISO strings throughout this codebase
     raw = await db.find(
         "rss_sources",
         {"enabled": True},
         projection={
-            "name": 1, "url": 1, "country_id": 1,
-            "health_status": 1, "consecutive_failures": 1,
-            "source_quality_score": 1, "last_successful_fetch": 1,
+            "name": 1,
+            "consecutive_failures": 1,
+            "source_quality_score": 1,
+            "last_successful_fetch": 1,
         },
-        sort={"health_status": 1, "source_quality_score": -1},
         limit=500,
     )
 
     sources = []
     summary = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
+    _rank = {"healthy": 0, "degraded": 1, "failing": 2, "critical": 3}
 
     for s in raw:
         failures = s.get("consecutive_failures", 0)
@@ -156,6 +160,8 @@ async def get_source_health_summary(env) -> dict:
             "quality_score": s.get("source_quality_score", 0.5),
         })
 
+    # Sort by recomputed status (worst first) then quality descending
+    sources.sort(key=lambda s: (_rank.get(s["status"], 0), -s["quality_score"]), reverse=False)
     return {"sources": sources, "summary": summary}
 
 
@@ -190,7 +196,6 @@ async def _compute_source_quality(db: MongoDBClient, source_id) -> dict:
             count = r.get("count", 0)
 
             # Composite score: 60% quality + 30% engagement + 10% volume
-            import math
             eng_score = min(math.log10(max(avg_engagement, 1) + 1) / 3, 1.0)
             vol_score = min(count / 50, 1.0)
             score = round(avg_quality * 0.6 + eng_score * 0.3 + vol_score * 0.1, 2)

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -137,6 +137,8 @@ async def get_source_health_summary(env) -> dict:
         {"enabled": True},
         projection={
             "name": 1,
+            "url": 1,
+            "country_id": 1,
             "consecutive_failures": 1,
             "source_quality_score": 1,
             "last_successful_fetch": 1,
@@ -155,6 +157,8 @@ async def get_source_health_summary(env) -> dict:
         sources.append({
             "source_id": str(s.get("_id") or s.get("id", "")),
             "name": s.get("name", ""),
+            "url": s.get("url"),
+            "country_id": s.get("country_id"),
             "status": status,
             "consecutive_failures": failures,
             "last_successful_fetch": s.get("last_successful_fetch"),
@@ -216,5 +220,9 @@ async def _compute_source_quality(db: MongoDBClient, source_id) -> dict:
 
 
 def _health_rank(status: str) -> int:
-    """Rank health status (higher = worse)."""
-    return {"healthy": 0, "degraded": 1, "failing": 2, "critical": 3}.get(status, 0)
+    """Rank health status (higher = worse). Logs a warning for unrecognised values."""
+    rank = {"healthy": 0, "degraded": 1, "failing": 2, "critical": 3}.get(status)
+    if rank is None:
+        print(f"[SOURCE_HEALTH] Unknown health status: {status!r}, treating as healthy")
+        return 0
+    return rank

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -117,8 +117,10 @@ async def check_source_health(env) -> dict:
 
     # Every source in `sources` unconditionally appends to `updates` in the loop above,
     # so iterating updates is equivalent to iterating sources for counting purposes.
-    # Use .get() + re-assignment to stay defensive against unexpected status values
-    # (consistent with the _health_rank() fallback added for the same reason).
+    # classify_health() always returns one of the four known keys, so counts[status] += 1
+    # would be safe here. The .get() fallback is purely defensive for hypothetical future
+    # callers that pass raw MongoDB health_status strings (which may not have been
+    # re-classified through classify_health first).
     counts: dict[str, int] = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
     for item in updates:
         status = item["update"]["health_status"]

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -175,8 +175,13 @@ async def get_source_health_summary(env) -> dict:
 
 async def _compute_source_quality(db: MongoDBClient, source_id) -> dict:
     """Compute quality metrics for a source from its recent articles."""
-    # Use Z-suffix to match the ISO storage format produced by datetime.isoformat() callers
-    # that normalize with .replace('+00:00', 'Z') — ensures consistent lexicographic $gte comparison.
+    # Use Z-suffix ISO string for the $gte comparison.
+    # ASSUMPTION: published_at is stored as an ISO string (e.g. "2026-02-24T12:00:00Z"),
+    # not as a BSON Date / {$date: ...} object. MongoDB does not compare strings against
+    # BSON dates — a mismatch silently returns zero results instead of an error.
+    # All ingestion paths in this codebase store published_at as ISO strings
+    # (see rss_parser.py, article_ai.py). If a future ingestion path uses native BSON dates,
+    # this query must be updated to use {$date: ...} syntax instead.
     week_ago = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat().replace("+00:00", "Z")
     pipeline = [
         {"$match": {

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -117,7 +117,7 @@ async def check_source_health(env) -> dict:
 
     counts: dict[str, int] = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
     for item in updates:
-        counts[item["update"]["health_status"]] = counts.get(item["update"]["health_status"], 0) + 1
+        counts[item["update"]["health_status"]] += 1
 
     return {
         "sources": len(sources),
@@ -160,14 +160,16 @@ async def get_source_health_summary(env) -> dict:
             "quality_score": s.get("source_quality_score", 0.5),
         })
 
-    # Sort by recomputed status (worst first) then quality descending
-    sources.sort(key=lambda s: (_rank.get(s["status"], 0), -s["quality_score"]), reverse=False)
+    # Sort worst-first (critical → failing → degraded → healthy), then quality descending within tier
+    sources.sort(key=lambda s: (_rank.get(s["status"], 0), -s["quality_score"]), reverse=True)
     return {"sources": sources, "summary": summary}
 
 
 async def _compute_source_quality(db: MongoDBClient, source_id) -> dict:
     """Compute quality metrics for a source from its recent articles."""
-    week_ago = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+    # Use Z-suffix to match the ISO storage format produced by datetime.isoformat() callers
+    # that normalize with .replace('+00:00', 'Z') — ensures consistent lexicographic $gte comparison.
+    week_ago = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat().replace("+00:00", "Z")
     pipeline = [
         {"$match": {
             "source_id": source_id,

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -117,9 +117,12 @@ async def check_source_health(env) -> dict:
 
     # Every source in `sources` unconditionally appends to `updates` in the loop above,
     # so iterating updates is equivalent to iterating sources for counting purposes.
+    # Use .get() + re-assignment to stay defensive against unexpected status values
+    # (consistent with the _health_rank() fallback added for the same reason).
     counts: dict[str, int] = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
     for item in updates:
-        counts[item["update"]["health_status"]] += 1
+        status = item["update"]["health_status"]
+        counts[status] = counts.get(status, 0) + 1
 
     return {
         "sources": len(sources),

--- a/processing/src/services/source_health.py
+++ b/processing/src/services/source_health.py
@@ -144,7 +144,6 @@ async def get_source_health_summary(env) -> dict:
 
     sources = []
     summary = {"healthy": 0, "degraded": 0, "failing": 0, "critical": 0}
-    _rank = {"healthy": 0, "degraded": 1, "failing": 2, "critical": 3}
 
     for s in raw:
         failures = s.get("consecutive_failures", 0)
@@ -161,7 +160,7 @@ async def get_source_health_summary(env) -> dict:
         })
 
     # Sort worst-first (critical → failing → degraded → healthy), then quality descending within tier
-    sources.sort(key=lambda s: (_rank.get(s["status"], 0), s["quality_score"]), reverse=True)
+    sources.sort(key=lambda s: (_health_rank(s["status"]), s["quality_score"]), reverse=True)
     return {"sources": sources, "summary": summary}
 
 

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -8,6 +8,7 @@ Supports country-specific trending via country_id filtering.
 """
 
 import json
+from datetime import datetime, timezone, timedelta
 from services.mongodb import MongoDBClient
 
 
@@ -82,8 +83,8 @@ async def get_trending(env, country_id: str | None = None) -> dict:
                     if "topics" in data:
                         return {"topics": data["topics"], "cached": True}
                     # "topics" key absent — stale/unexpected format, fall through to live compute
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[TRENDING] KV read failed for {cache_key}: {e}")
 
     # Cache miss — compute live
     db = MongoDBClient(env)
@@ -173,10 +174,8 @@ async def _compute_trending(db: MongoDBClient, country_id: str | None = None) ->
 
 
 def _now_iso() -> str:
-    from datetime import datetime, timezone
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _hours_ago_iso(hours: int) -> str:
-    from datetime import datetime, timezone, timedelta
     return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat().replace("+00:00", "Z")

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -70,12 +70,18 @@ async def get_trending(env, country_id: str | None = None) -> dict:
             raw = await env.CACHE_STORAGE.get(cache_key)
             if raw:
                 data = json.loads(raw)
-                # Global cache format: {"global": [...], "countries": {...}, "updated_at": "..."}
-                if country_id is None and "global" in data:
-                    return {"topics": data["global"], "cached": True}
-                # Country cache format: {"topics": [...], "updated_at": "..."}
-                if "topics" in data:
-                    return {"topics": data["topics"], "cached": True}
+                if country_id is None:
+                    # Global cache format: {"global": [...], "countries": {...}, "updated_at": "..."}
+                    # Scoped to the None branch so a stale/mismatched payload can't fall through
+                    # to the country branch and return wrong data.
+                    if "global" in data:
+                        return {"topics": data["global"], "cached": True}
+                    # "global" key absent — unexpected format, fall through to live compute
+                else:
+                    # Country cache format: {"topics": [...], "updated_at": "..."}
+                    if "topics" in data:
+                        return {"topics": data["topics"], "cached": True}
+                    # "topics" key absent — stale/unexpected format, fall through to live compute
         except Exception:
             pass
 

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -154,7 +154,6 @@ async def _compute_trending(db: MongoDBClient, country_id: str | None = None) ->
         {"$project": {
             "keyword": {"$ifNull": ["$keyword_info.name", "$_id"]},
             "article_count": 1,
-            "engagement_score": 1,
             "weighted_score": 1,
         }},
     ]
@@ -181,4 +180,4 @@ def _now_iso() -> str:
 
 def _hours_ago_iso(hours: int) -> str:
     from datetime import datetime, timezone, timedelta
-    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    return (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat().replace("+00:00", "Z")

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -181,7 +181,7 @@ async def _compute_trending(db: MongoDBClient, country_id: str | None = None) ->
 
 def _now_iso() -> str:
     from datetime import datetime, timezone
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def _hours_ago_iso(hours: int) -> str:

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -75,7 +75,7 @@ async def get_trending(env, country_id: str | None = None) -> dict:
                     return {"topics": data["global"], "cached": True}
                 # Country cache format: {"topics": [...], "updated_at": "..."}
                 if "topics" in data:
-                    return {**data, "cached": True}
+                    return {"topics": data["topics"], "cached": True}
         except Exception:
             pass
 

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -8,7 +8,6 @@ Supports country-specific trending via country_id filtering.
 """
 
 import json
-import time
 from services.mongodb import MongoDBClient
 
 
@@ -68,16 +67,22 @@ async def get_trending(env, country_id: str | None = None) -> dict:
     # Try KV cache first
     if env and hasattr(env, "CACHE_STORAGE"):
         try:
-            cached = await env.CACHE_STORAGE.get(cache_key)
-            if cached:
-                return json.loads(cached)
+            raw = await env.CACHE_STORAGE.get(cache_key)
+            if raw:
+                data = json.loads(raw)
+                # Global cache format: {"global": [...], "countries": {...}, "updated_at": "..."}
+                if country_id is None and "global" in data:
+                    return {"topics": data["global"], "cached": True}
+                # Country cache format: {"topics": [...], "updated_at": "..."}
+                if "topics" in data:
+                    return {**data, "cached": True}
         except Exception:
             pass
 
     # Cache miss — compute live
     db = MongoDBClient(env)
     topics = await _compute_trending(db, country_id=country_id)
-    return {"topics": topics, "updated_at": _now_iso()}
+    return {"topics": topics, "cached": False}
 
 
 async def _compute_trending(db: MongoDBClient, country_id: str | None = None) -> list[dict]:
@@ -159,9 +164,8 @@ async def _compute_trending(db: MongoDBClient, country_id: str | None = None) ->
         return [
             {
                 "keyword": r.get("keyword", ""),
-                "article_count": r.get("article_count", 0),
-                "engagement_score": round(r.get("engagement_score", 0), 1),
-                "score": round(r.get("weighted_score", 0), 2),
+                "count": r.get("article_count", 0),
+                "velocity": round(r.get("weighted_score", 0), 2),
             }
             for r in results
         ]

--- a/processing/src/services/trending.py
+++ b/processing/src/services/trending.py
@@ -126,13 +126,6 @@ async def _compute_trending(db: MongoDBClient, country_id: str | None = None) ->
             "avg_relevance": {"$avg": "$keyword_links.relevance_score"},
         }},
         {"$addFields": {
-            "engagement_score": {
-                "$add": [
-                    "$total_views",
-                    {"$multiply": ["$total_likes", 3]},
-                    {"$multiply": ["$total_bookmarks", 2]},
-                ]
-            },
             "weighted_score": {
                 "$multiply": [
                     "$article_count",

--- a/processing/tests/test_source_health.py
+++ b/processing/tests/test_source_health.py
@@ -148,7 +148,8 @@ class TestGetSourceHealthSummary:
         assert result["sources"][0]["status"] == "failing"
 
     @pytest.mark.asyncio
-    async def test_sources_sorted_worst_first(self):
+    async def test_sources_sorted_critical_first(self):
+        # Worst-first: critical(10 failures) → failing(4 failures) → healthy(0 failures)
         mock_raw = [
             {"_id": "a", "name": "A", "consecutive_failures": 0, "source_quality_score": 0.9, "last_successful_fetch": None},
             {"_id": "b", "name": "B", "consecutive_failures": 10, "source_quality_score": 0.2, "last_successful_fetch": None},
@@ -159,4 +160,4 @@ class TestGetSourceHealthSummary:
             result = await get_source_health_summary(env=None)
 
         statuses = [s["status"] for s in result["sources"]]
-        assert statuses == ["healthy", "failing", "critical"]
+        assert statuses == ["critical", "failing", "healthy"]

--- a/processing/tests/test_source_health.py
+++ b/processing/tests/test_source_health.py
@@ -8,7 +8,21 @@ and get_source_health_summary response shape.
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, patch
-from services.source_health import classify_health, should_fetch, FETCH_INTERVALS, get_source_health_summary
+from services.source_health import classify_health, should_fetch, FETCH_INTERVALS, get_source_health_summary, _health_rank
+
+
+class TestHealthRank:
+    def test_known_statuses_rank_in_order(self):
+        assert _health_rank("healthy") == 0
+        assert _health_rank("degraded") == 1
+        assert _health_rank("failing") == 2
+        assert _health_rank("critical") == 3
+
+    def test_unknown_status_returns_zero_and_logs(self, capsys):
+        rank = _health_rank("unknown_status")
+        assert rank == 0
+        captured = capsys.readouterr()
+        assert "unknown_status" in captured.out
 
 
 class TestClassifyHealth:
@@ -146,6 +160,40 @@ class TestGetSourceHealthSummary:
             result = await get_source_health_summary(env=None)
 
         assert result["sources"][0]["status"] == "failing"
+
+    @pytest.mark.asyncio
+    async def test_url_and_country_id_included_in_response(self):
+        mock_raw = [
+            {
+                "_id": "abc",
+                "name": "Herald",
+                "url": "https://herald.co.zw/feed",
+                "country_id": "ZW",
+                "consecutive_failures": 0,
+                "source_quality_score": 0.9,
+                "last_successful_fetch": None,
+            },
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        source = result["sources"][0]
+        assert source["url"] == "https://herald.co.zw/feed"
+        assert source["country_id"] == "ZW"
+
+    @pytest.mark.asyncio
+    async def test_url_and_country_id_none_when_absent(self):
+        mock_raw = [
+            {"_id": "abc", "name": "Unknown", "consecutive_failures": 0, "source_quality_score": 0.5, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        source = result["sources"][0]
+        assert source["url"] is None
+        assert source["country_id"] is None
 
     @pytest.mark.asyncio
     async def test_sources_sorted_critical_first(self):

--- a/processing/tests/test_source_health.py
+++ b/processing/tests/test_source_health.py
@@ -1,12 +1,14 @@
 """
 Tests for source health service.
 
-Covers: health classification, adaptive scheduling, should_fetch logic.
+Covers: health classification, adaptive scheduling, should_fetch logic,
+and get_source_health_summary response shape.
 """
 
 import pytest
 from datetime import datetime, timezone, timedelta
-from services.source_health import classify_health, should_fetch, FETCH_INTERVALS
+from unittest.mock import AsyncMock, patch
+from services.source_health import classify_health, should_fetch, FETCH_INTERVALS, get_source_health_summary
 
 
 class TestClassifyHealth:
@@ -88,3 +90,73 @@ class TestFetchIntervals:
 
     def test_critical_no_interval(self):
         assert FETCH_INTERVALS["critical"] is None
+
+
+class TestGetSourceHealthSummary:
+    @pytest.mark.asyncio
+    async def test_returns_sources_and_summary_keys(self):
+        mock_raw = [
+            {"_id": "abc123", "name": "Herald", "consecutive_failures": 0, "source_quality_score": 0.9, "last_successful_fetch": None},
+            {"_id": "def456", "name": "Daily News", "consecutive_failures": 5, "source_quality_score": 0.4, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        assert "sources" in result
+        assert "summary" in result
+
+    @pytest.mark.asyncio
+    async def test_summary_counts_match_classified_status(self):
+        mock_raw = [
+            {"_id": "a", "name": "A", "consecutive_failures": 0, "source_quality_score": 0.8, "last_successful_fetch": None},
+            {"_id": "b", "name": "B", "consecutive_failures": 2, "source_quality_score": 0.6, "last_successful_fetch": None},
+            {"_id": "c", "name": "C", "consecutive_failures": 5, "source_quality_score": 0.5, "last_successful_fetch": None},
+            {"_id": "d", "name": "D", "consecutive_failures": 10, "source_quality_score": 0.2, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        assert result["summary"]["healthy"] == 1
+        assert result["summary"]["degraded"] == 1
+        assert result["summary"]["failing"] == 1
+        assert result["summary"]["critical"] == 1
+
+    @pytest.mark.asyncio
+    async def test_source_id_coerced_from_object_id(self):
+        mock_raw = [
+            {"_id": "507f1f77bcf86cd799439011", "name": "Herald", "consecutive_failures": 0, "source_quality_score": 0.9, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        assert result["sources"][0]["source_id"] == "507f1f77bcf86cd799439011"
+        assert isinstance(result["sources"][0]["source_id"], str)
+
+    @pytest.mark.asyncio
+    async def test_status_uses_recomputed_classify_health(self):
+        # consecutive_failures=5 → failing, regardless of any stored health_status field
+        mock_raw = [
+            {"_id": "x", "name": "X", "consecutive_failures": 5, "health_status": "healthy", "source_quality_score": 0.5, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        assert result["sources"][0]["status"] == "failing"
+
+    @pytest.mark.asyncio
+    async def test_sources_sorted_worst_first(self):
+        mock_raw = [
+            {"_id": "a", "name": "A", "consecutive_failures": 0, "source_quality_score": 0.9, "last_successful_fetch": None},
+            {"_id": "b", "name": "B", "consecutive_failures": 10, "source_quality_score": 0.2, "last_successful_fetch": None},
+            {"_id": "c", "name": "C", "consecutive_failures": 4, "source_quality_score": 0.5, "last_successful_fetch": None},
+        ]
+        with patch("services.source_health.MongoDBClient") as MockDB:
+            MockDB.return_value.find = AsyncMock(return_value=mock_raw)
+            result = await get_source_health_summary(env=None)
+
+        statuses = [s["status"] for s in result["sources"]]
+        assert statuses == ["healthy", "failing", "critical"]

--- a/processing/tests/test_trending.py
+++ b/processing/tests/test_trending.py
@@ -14,7 +14,7 @@ class TestISOHelpers:
     def test_now_iso_format(self):
         result = _now_iso()
         assert "T" in result
-        assert "+" in result or "Z" in result
+        assert result.endswith("Z"), f"_now_iso() should use Z suffix for consistent MongoDB range queries, got: {result}"
 
     def test_hours_ago_returns_past(self):
         now = _now_iso()

--- a/processing/tests/test_trending.py
+++ b/processing/tests/test_trending.py
@@ -1,10 +1,12 @@
 """
 Tests for trending topics service.
 
-Covers: ISO helpers, compute structure.
+Covers: ISO helpers, compute structure, cache path discrimination, field names.
 """
 
+import json
 import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 from services.trending import _now_iso, _hours_ago_iso
 
 
@@ -36,6 +38,12 @@ class TestTrendingStructure:
         assert isinstance(result["topics"], list)
 
     @pytest.mark.asyncio
+    async def test_get_trending_cache_miss_returns_cached_false(self):
+        from services.trending import get_trending
+        result = await get_trending(None)
+        assert result.get("cached") is False
+
+    @pytest.mark.asyncio
     async def test_refresh_trending_no_env(self):
         """refresh_trending should handle missing env gracefully."""
         from services.trending import refresh_trending
@@ -43,3 +51,66 @@ class TestTrendingStructure:
         result = await refresh_trending(None)
         assert isinstance(result, dict)
         assert "global" in result
+
+
+class TestCachePaths:
+    def _make_env(self, kv_data: dict | None):
+        env = MagicMock()
+        if kv_data is None:
+            env.CACHE_STORAGE.get = AsyncMock(return_value=None)
+        else:
+            env.CACHE_STORAGE.get = AsyncMock(return_value=json.dumps(kv_data))
+        return env
+
+    @pytest.mark.asyncio
+    async def test_global_cache_hit_uses_global_key(self):
+        from services.trending import get_trending
+        topics = [{"keyword": "politics", "count": 10, "velocity": 1.5}]
+        env = self._make_env({"global": topics, "countries": {}, "updated_at": "2026-01-01T00:00:00+00:00"})
+        with patch("services.trending.MongoDBClient"):
+            result = await get_trending(env, country_id=None)
+        assert result["topics"] == topics
+        assert result["cached"] is True
+        assert "updated_at" not in result
+
+    @pytest.mark.asyncio
+    async def test_country_cache_hit_strips_updated_at(self):
+        from services.trending import get_trending
+        topics = [{"keyword": "sport", "count": 5, "velocity": 0.8}]
+        env = self._make_env({"topics": topics, "updated_at": "2026-01-01T00:00:00+00:00"})
+        with patch("services.trending.MongoDBClient"):
+            result = await get_trending(env, country_id="ZW")
+        assert result["topics"] == topics
+        assert result["cached"] is True
+        assert "updated_at" not in result
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_computes_live(self):
+        from services.trending import get_trending
+        env = self._make_env(None)
+        with patch("services.trending.MongoDBClient") as MockDB:
+            MockDB.return_value.aggregate = AsyncMock(return_value=[])
+            result = await get_trending(env, country_id=None)
+        assert result["cached"] is False
+        assert result["topics"] == []
+
+    @pytest.mark.asyncio
+    async def test_field_names_are_count_and_velocity(self):
+        from services.trending import get_trending
+        env = self._make_env(None)
+        raw_agg = [{
+            "keyword": "harare",
+            "article_count": 3,
+            "weighted_score": 2.5,
+        }]
+        with patch("services.trending.MongoDBClient") as MockDB:
+            MockDB.return_value.aggregate = AsyncMock(return_value=raw_agg)
+            result = await get_trending(env)
+        assert len(result["topics"]) == 1
+        topic = result["topics"][0]
+        assert "count" in topic
+        assert "velocity" in topic
+        assert "article_count" not in topic
+        assert "score" not in topic
+        assert topic["count"] == 3
+        assert topic["velocity"] == 2.5

--- a/processing/tests/test_trending.py
+++ b/processing/tests/test_trending.py
@@ -95,6 +95,17 @@ class TestCachePaths:
         assert result["topics"] == []
 
     @pytest.mark.asyncio
+    async def test_country_cache_topics_key_absent_falls_through_to_live(self):
+        """Symmetric to global 'global key absent' case: stale country payload falls through."""
+        from services.trending import get_trending
+        # Payload has no "topics" key — should fall through to live compute
+        env = self._make_env({"stale_key": [], "updated_at": "2026-01-01T00:00:00Z"})
+        with patch("services.trending.MongoDBClient") as MockDB:
+            MockDB.return_value.aggregate = AsyncMock(return_value=[])
+            result = await get_trending(env, country_id="ZW")
+        assert result["cached"] is False
+
+    @pytest.mark.asyncio
     async def test_field_names_are_count_and_velocity(self):
         from services.trending import get_trending
         env = self._make_env(None)

--- a/processing/wrangler.jsonc
+++ b/processing/wrangler.jsonc
@@ -19,15 +19,15 @@
     "account_id": "125a2dfbc21f76a25c980609609e8218",
 
     /**
-     * Custom Domain & Routes
+     * Custom Domain
      * Production traffic routed through news-api.mukoko.com
      * DNS: CNAME news-api.mukoko.com -> mukoko-news-api.<account>.workers.dev
+     *
+     * Using custom_domains instead of routes to avoid Wrangler 4.x route
+     * registration conflicts (error 10020) on repeated deploys.
      */
-    "routes": [
-        {
-            "pattern": "news-api.mukoko.com/*",
-            "zone_name": "mukoko.com"
-        }
+    "custom_domains": [
+        { "pattern": "news-api.mukoko.com" }
     ],
 
     /**
@@ -204,11 +204,8 @@
                 "CORS_ORIGINS": "https://staging.news.mukoko.com,http://localhost:3000",
                 "LOG_LEVEL": "debug"
             },
-            "routes": [
-                {
-                    "pattern": "staging-news-api.mukoko.com/*",
-                    "zone_name": "mukoko.com"
-                }
+            "custom_domains": [
+                { "pattern": "staging-news-api.mukoko.com" }
             ],
             "workers_dev": true
         },

--- a/processing/wrangler.jsonc
+++ b/processing/wrangler.jsonc
@@ -21,7 +21,10 @@
     /**
      * Custom Domain
      * Production traffic routed through news-api.mukoko.com
-     * DNS: CNAME news-api.mukoko.com -> mukoko-news-api.<account>.workers.dev
+     *
+     * With custom_domains, Cloudflare manages DNS automatically (AAAA + proxied
+     * CNAME on Cloudflare's nameservers). Do NOT add a manual CNAME pointing to
+     * the .workers.dev subdomain — the platform handles DNS directly.
      *
      * Using custom_domains instead of routes to avoid Wrangler 4.x route
      * registration conflicts (error 10020) on repeated deploys.


### PR DESCRIPTION
## Summary
This PR improves source health monitoring, simplifies the trending API response format, and updates deployment configuration to use custom domains instead of routes.

## Key Changes

### Source Health Service (`processing/src/services/source_health.py`)
- Added `timedelta` import for date calculations
- Refactored `get_source_health_summary()` to:
  - Transform raw database results into a structured response with health status classification
  - Add a summary object tracking counts of healthy, degraded, failing, and critical sources
  - Include additional fields: `source_id`, `status`, `consecutive_failures`, `last_successful_fetch`, and `quality_score`
- Simplified `_compute_source_quality()` date range calculation:
  - Replaced complex MongoDB aggregation date subtraction with Python `timedelta` for better readability
  - Changed from millisecond-based calculation to ISO format string comparison

### Trending API (`processing/src/services/trending.py`)
- Removed unused `time` import
- Enhanced cache handling to properly parse both global and country-specific cache formats
- Added `"cached"` boolean flag to all responses (replaces `"updated_at"` field)
- Simplified trending topic response schema:
  - Renamed `article_count` → `count`
  - Renamed `engagement_score` → removed (not in output)
  - Renamed `score` → `velocity`

### Deployment Configuration
- **`processing/wrangler.jsonc`**: Migrated from `routes` to `custom_domains` configuration
  - Avoids Wrangler 4.x route registration conflicts (error 10020) on repeated deploys
  - Applied to both production and staging environments
  - Updated comments to clarify DNS setup
  
- **`backend/wrangler.jsonc`**: 
  - Added `CREATOR_ROLES` environment variable (mirrors `AUTHOR_ROLES`)
  
- **`backend/tsconfig.json`**: 
  - Added `middleware/**/*.ts` to TypeScript compilation includes

## Implementation Details
- Health status classification now happens at the API layer, providing better separation of concerns
- Cache responses now consistently indicate whether data is fresh or cached, improving client-side decision making
- The trending API response schema is more concise and semantically clearer with the renamed fields

https://claude.ai/code/session_015ALt7fETjxyPgfurj7on2g