### PR TITLE
feat: add fly-worker FastAPI backend

### DIFF
--- a/fly-worker/.env.example
+++ b/fly-worker/.env.example
@@ -1,0 +1,43 @@
+# Mukoko News API — Environment Variables
+# Copy to .env and fill in values for local development
+# For Fly.io, set via: fly secrets set KEY=VALUE
+# Shared secrets available from mukoko-platform/backend/.env
+
+# Supabase Postgres — direct connection (shared with mukoko-platform)
+DATABASE_URL=postgresql://postgres.PROJECT:PASSWORD@db.PROJECT.supabase.co:5432/postgres
+
+# Stytch — user auth (shared with mukoko-platform)
+STYTCH_PROJECT_ID=project-live-...
+STYTCH_SECRET=secret-live-...
+
+# Platform JWT — service-to-service auth (= Supabase JWT secret)
+PLATFORM_JWT_SECRET=your-supabase-jwt-secret
+
+# Platform API — mukoko-platform internal URL (Fly.io internal networking)
+PLATFORM_API_URL=http://mukoko-platform-api.internal:8080
+
+# CouchDB — article body storage (Fly.io internal)
+COUCHDB_URL=http://mukoko-couchdb.internal:5984
+COUCHDB_USERNAME=admin
+COUCHDB_PASSWORD=password
+COUCHDB_DATABASE=mukoko_articles
+
+# Apache Doris — analytics and search
+DORIS_HTTP_URL=http://localhost:8030
+DORIS_USERNAME=root
+DORIS_PASSWORD=
+DORIS_DATABASE=mukoko_analytics
+
+# AI Services
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Cloudflare Workers AI — BGE-M3 embeddings (1024-dim)
+CF_ACCOUNT_ID=your-cloudflare-account-id
+CF_AI_API_TOKEN=your-cf-ai-api-token
+
+# CORS
+CORS_ORIGINS=https://news.mukoko.com,http://localhost:3000
+
+# Worker
+LOG_LEVEL=info
+ENVIRONMENT=development

--- a/fly-worker/.gitignore
+++ b/fly-worker/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.pytest_cache/
+dist/
+*.egg
+.ruff_cache/

--- a/fly-worker/Dockerfile
+++ b/fly-worker/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Install dependencies (cached layer)
+COPY pyproject.toml uv.lock* ./
+RUN uv sync --frozen --no-dev 2>/dev/null || uv sync --no-dev
+
+# Copy application code
+COPY src/ src/
+COPY migrations/ migrations/
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"
+
+EXPOSE 8080
+
+CMD ["uv", "run", "uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/fly-worker/fly.toml
+++ b/fly-worker/fly.toml
@@ -1,0 +1,37 @@
+app = "mukoko-news-api"
+primary_region = "jnb"
+
+[build]
+
+[env]
+  # Non-secret env vars. Secrets set via: fly secrets set KEY=VALUE
+  CORS_ORIGINS = "https://news.mukoko.com,https://mukoko-news.vercel.app,http://localhost:3000"
+  LOG_LEVEL = "info"
+  ENVIRONMENT = "production"
+  # CouchDB and Doris URLs — internal Fly.io addresses (secrets set via fly secrets)
+  COUCHDB_URL = "http://couchdb.internal:5984"
+  COUCHDB_DATABASE = "mukoko_articles"
+  DORIS_HTTP_URL = "http://doris-fe.internal:8030"
+  DORIS_DATABASE = "mukoko_analytics"
+  PLATFORM_API_URL = "http://mukoko-platform-api.internal:8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[checks]
+  [checks.health]
+    type = "http"
+    port = 8080
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  memory = "2048mb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly-worker/migrations/001_schema.sql
+++ b/fly-worker/migrations/001_schema.sql
@@ -1,0 +1,627 @@
+-- Mukoko News — Supabase-aligned Postgres Schema
+-- Combined from 12 Supabase migrations (supabase_mukoko_news)
+-- Plus fly-worker operational extensions
+--
+-- Target: supabase_mukoko_news (gjdmtthumkopkwuttwnd)
+-- Source mirror: mukoko_platform_cloud (tdcpuzqyoodrdsxldgsh)
+
+-- ══════════════════════════════════════════════════
+-- 001: Extensions & Schemas
+-- ══════════════════════════════════════════════════
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE SCHEMA IF NOT EXISTS identity;
+CREATE SCHEMA IF NOT EXISTS news;
+CREATE SCHEMA IF NOT EXISTS engagement;
+CREATE SCHEMA IF NOT EXISTS system;
+CREATE SCHEMA IF NOT EXISTS sync;
+
+-- ══════════════════════════════════════════════════
+-- 002: Identity Schema
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS identity.person (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    stytch_user_id          TEXT UNIQUE,
+    name                    TEXT NOT NULL,
+    givenname               TEXT,
+    familyname              TEXT,
+    email                   TEXT UNIQUE,
+    telephone               TEXT UNIQUE,
+    image                   TEXT,
+    url                     TEXT,
+    phone_verified          BOOLEAN DEFAULT FALSE,
+    email_verified          BOOLEAN DEFAULT FALSE,
+    synced_from_platform    BOOLEAN DEFAULT FALSE,
+    platform_person_id      UUID,
+    last_synced_at          TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ DEFAULT now(),
+    updated_at              TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_identity_person_platform_id
+    ON identity.person (platform_person_id);
+
+-- ══════════════════════════════════════════════════
+-- 003: Engagement Interest Categories
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS engagement.interest_category (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    slug                    TEXT UNIQUE NOT NULL,
+    name                    TEXT NOT NULL,
+    description             TEXT,
+    parent_id               UUID REFERENCES engagement.interest_category (id),
+    icon_url                TEXT,
+    color_hex               TEXT,
+    sort_order              INT DEFAULT 0,
+    is_active               BOOLEAN DEFAULT TRUE,
+    platform_category_id    UUID,
+    last_synced_at          TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ DEFAULT now(),
+    updated_at              TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_interest_category_slug
+    ON engagement.interest_category (slug);
+CREATE INDEX IF NOT EXISTS idx_interest_category_parent
+    ON engagement.interest_category (parent_id);
+
+-- ══════════════════════════════════════════════════
+-- 004: News Organizations & Journalists
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS news.news_media_organization (
+    id                              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name                            TEXT NOT NULL,
+    alternatename                   TEXT,
+    description                     TEXT,
+    url                             TEXT,
+    logo                            JSONB,
+    ethicspolicy                    TEXT,
+    masthead                        TEXT,
+    missioncoverageprioritiespolicy TEXT,
+    correctionspolicy               TEXT,
+    diversitypolicy                 TEXT,
+    unnamedsourcespolicy            TEXT,
+    contactpoint                    JSONB,
+    address                         JSONB,
+    source_type                     TEXT CHECK (source_type IN (
+                                        'newspaper', 'magazine', 'broadcaster',
+                                        'digital_native', 'wire_service'
+                                    )),
+    is_verified                     BOOLEAN DEFAULT FALSE,
+    follower_count                  INT DEFAULT 0,
+    platform_org_id                 UUID,
+    last_synced_at                  TIMESTAMPTZ,
+    created_at                      TIMESTAMPTZ DEFAULT now(),
+    updated_at                      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS news.journalist (
+    person_id               UUID PRIMARY KEY REFERENCES identity.person (id),
+    alumniof                JSONB,
+    award                   TEXT[],
+    worksfor                UUID REFERENCES news.news_media_organization (id),
+    jobtitle                TEXT,
+    knowsabout              TEXT[],
+    article_count           INT DEFAULT 0,
+    follower_count          INT DEFAULT 0,
+    verified_journalist     BOOLEAN DEFAULT FALSE,
+    platform_person_id      UUID,
+    last_synced_at          TIMESTAMPTZ,
+    created_at              TIMESTAMPTZ DEFAULT now(),
+    updated_at              TIMESTAMPTZ DEFAULT now()
+);
+
+-- ══════════════════════════════════════════════════
+-- 005: News Article
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS news.news_article (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    articletype                 TEXT NOT NULL DEFAULT 'NewsArticle' CHECK (articletype IN (
+                                    'NewsArticle', 'AnalysisNewsArticle', 'BackgroundNewsArticle',
+                                    'OpinionNewsArticle', 'ReportageNewsArticle', 'ReviewNewsArticle',
+                                    'Article', 'BlogPosting', 'ScholarlyArticle'
+                                )),
+
+    headline                    TEXT NOT NULL,
+    image                       JSONB,
+    datepublished               TIMESTAMPTZ NOT NULL,
+    datemodified                TIMESTAMPTZ,
+    author                      JSONB NOT NULL,
+    primary_author_person_id    UUID REFERENCES identity.person (id),
+    publisher                   JSONB NOT NULL,
+    publisher_organization_id   UUID REFERENCES news.news_media_organization (id),
+    articlebody                 TEXT,
+    mongodb_article_id          TEXT,
+    couchdb_doc_id              TEXT,
+    articlesection              TEXT,
+    wordcount                   INT,
+    description                 TEXT,
+    abstract                    TEXT,
+    mainentityofpage            TEXT,
+    keywords                    TEXT[],
+    about                       JSONB,
+    mentions                    JSONB,
+    inlanguage                  TEXT DEFAULT 'en',
+    copyrightholder             JSONB,
+    copyrightyear               INT,
+    license                     TEXT,
+    dateline                    TEXT,
+    backstory                   TEXT,
+    slug                        TEXT UNIQUE,
+
+    view_count                  INT DEFAULT 0,
+    like_count                  INT DEFAULT 0,
+    comment_count               INT DEFAULT 0,
+    share_count                 INT DEFAULT 0,
+
+    status                      TEXT DEFAULT 'draft' CHECK (status IN (
+                                    'draft', 'processing', 'enriching', 'review',
+                                    'published', 'archived', 'retracted'
+                                )),
+    is_featured                 BOOLEAN DEFAULT FALSE,
+    is_breaking                 BOOLEAN DEFAULT FALSE,
+
+    source_url                  TEXT,
+    source_feed_id              TEXT,
+    source_fingerprint          TEXT UNIQUE,
+    ingestion_method            TEXT CHECK (ingestion_method IN (
+                                    'manual', 'rss_feed', 'api_push', 'scraper', 'partner_feed'
+                                )),
+    ingested_at                 TIMESTAMPTZ DEFAULT now(),
+
+    sentiment_score             FLOAT,
+    sentiment_label             TEXT CHECK (sentiment_label IN (
+                                    'very_negative', 'negative', 'neutral', 'positive', 'very_positive'
+                                )),
+    named_entities              JSONB,
+    topic_tags                  TEXT[],
+    reading_time_minutes        INT,
+    summary_auto                TEXT,
+    summary_approved            BOOLEAN DEFAULT FALSE,
+
+    primary_location_country    TEXT,
+    primary_location_region     TEXT,
+    geo_tags                    JSONB,
+
+    primary_interest_category_id    UUID REFERENCES engagement.interest_category (id),
+    interest_category_scores        JSONB,
+
+    factcheck_status            TEXT DEFAULT 'pending' CHECK (factcheck_status IN (
+                                    'pending', 'verified', 'disputed', 'false', 'satire', 'skipped'
+                                )),
+    factcheck_source            TEXT,
+    factcheck_notes             TEXT,
+    moderation_status           TEXT DEFAULT 'pending' CHECK (moderation_status IN (
+                                    'pending', 'approved', 'flagged', 'rejected'
+                                )),
+    moderation_notes            TEXT,
+    moderated_by                UUID REFERENCES identity.person (id),
+    moderated_at                TIMESTAMPTZ,
+
+    sync_status                 TEXT DEFAULT 'not_synced' CHECK (sync_status IN (
+                                    'not_synced', 'pending_sync', 'synced', 'sync_error'
+                                )),
+    platform_article_id         UUID,
+    last_synced_at              TIMESTAMPTZ,
+    sync_error_message          TEXT,
+
+    created_at                  TIMESTAMPTZ DEFAULT now(),
+    updated_at                  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_news_article_status          ON news.news_article (status);
+CREATE INDEX IF NOT EXISTS idx_news_article_sync_status     ON news.news_article (sync_status);
+CREATE INDEX IF NOT EXISTS idx_news_article_datepublished   ON news.news_article (datepublished DESC);
+CREATE INDEX IF NOT EXISTS idx_news_article_publisher       ON news.news_article (publisher_organization_id);
+CREATE INDEX IF NOT EXISTS idx_news_article_author          ON news.news_article (primary_author_person_id);
+CREATE INDEX IF NOT EXISTS idx_news_article_category        ON news.news_article (primary_interest_category_id);
+CREATE INDEX IF NOT EXISTS idx_news_article_source_fp       ON news.news_article (source_fingerprint);
+CREATE INDEX IF NOT EXISTS idx_news_article_ingested        ON news.news_article (ingested_at DESC);
+CREATE INDEX IF NOT EXISTS idx_news_article_moderation      ON news.news_article (moderation_status);
+CREATE INDEX IF NOT EXISTS idx_news_article_factcheck       ON news.news_article (factcheck_status);
+
+-- ══════════════════════════════════════════════════
+-- 006: News Engagement Tables
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS news.article_authorship (
+    article_id  UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    person_id   UUID NOT NULL REFERENCES identity.person (id),
+    authortype  TEXT DEFAULT 'author' CHECK (authortype IN (
+                    'author', 'contributor', 'editor', 'photographer'
+                )),
+    position    INT,
+    PRIMARY KEY (article_id, person_id)
+);
+
+CREATE TABLE IF NOT EXISTS news.article_interest_category (
+    article_id              UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    interest_category_id    UUID NOT NULL REFERENCES engagement.interest_category (id),
+    relevance_score         FLOAT DEFAULT 1.0,
+    is_primary              BOOLEAN DEFAULT FALSE,
+    assigned_by             TEXT DEFAULT 'auto' CHECK (assigned_by IN ('auto', 'manual', 'hybrid')),
+    created_at              TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (article_id, interest_category_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_article_category_category
+    ON news.article_interest_category (interest_category_id);
+
+CREATE TABLE IF NOT EXISTS news.like_action (
+    article_id  UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    person_id   UUID NOT NULL REFERENCES identity.person (id),
+    starttime   TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (article_id, person_id)
+);
+
+CREATE TABLE IF NOT EXISTS news.comment (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    article_id          UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    author              UUID NOT NULL REFERENCES identity.person (id),
+    text                TEXT NOT NULL,
+    datecreated         TIMESTAMPTZ DEFAULT now(),
+    parentitem          UUID REFERENCES news.comment (id),
+    moderationstatus    TEXT DEFAULT 'published' CHECK (moderationstatus IN (
+                            'published', 'flagged', 'removed'
+                        )),
+    created_at          TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_news_comment_article ON news.comment (article_id);
+CREATE INDEX IF NOT EXISTS idx_news_comment_parent  ON news.comment (parentitem);
+
+CREATE TABLE IF NOT EXISTS news.bookmark_action (
+    article_id  UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    person_id   UUID NOT NULL REFERENCES identity.person (id),
+    starttime   TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (article_id, person_id)
+);
+
+CREATE TABLE IF NOT EXISTS news.follow_journalist (
+    follower_person_id      UUID NOT NULL REFERENCES identity.person (id),
+    journalist_person_id    UUID NOT NULL REFERENCES identity.person (id),
+    starttime               TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (follower_person_id, journalist_person_id)
+);
+
+CREATE TABLE IF NOT EXISTS news.follow_organization (
+    follower_person_id  UUID NOT NULL REFERENCES identity.person (id),
+    organization_id     UUID NOT NULL REFERENCES news.news_media_organization (id),
+    starttime           TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (follower_person_id, organization_id)
+);
+
+-- ══════════════════════════════════════════════════
+-- 007: News Pipeline Tables
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS news.feed_source (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     UUID REFERENCES news.news_media_organization (id),
+    name                TEXT NOT NULL,
+    feed_url            TEXT NOT NULL UNIQUE,
+    feed_type           TEXT CHECK (feed_type IN ('rss', 'atom', 'json_feed', 'api', 'scraper')),
+    language            TEXT DEFAULT 'en',
+    country             TEXT DEFAULT 'ZW',
+    is_active           BOOLEAN DEFAULT TRUE,
+    fetch_interval_mins INT DEFAULT 30,
+    last_fetched_at     TIMESTAMPTZ,
+    last_fetch_status   TEXT CHECK (last_fetch_status IN ('success', 'error', 'timeout')),
+    last_fetch_error    TEXT,
+    article_count       INT DEFAULT 0,
+    created_at          TIMESTAMPTZ DEFAULT now(),
+    updated_at          TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS news.processing_job (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    article_id      UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    job_type        TEXT NOT NULL CHECK (job_type IN (
+                        'nlp_enrichment', 'geo_tagging', 'category_tagging',
+                        'sentiment_analysis', 'fact_check', 'summary_generation',
+                        'image_processing', 'duplicate_detection', 'sync_to_platform'
+                    )),
+    status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+                        'pending', 'running', 'completed', 'failed', 'skipped', 'retrying'
+                    )),
+    priority        INT DEFAULT 5,
+    attempts        INT DEFAULT 0,
+    max_attempts    INT DEFAULT 3,
+    payload         JSONB,
+    result          JSONB,
+    error_message   TEXT,
+    started_at      TIMESTAMPTZ,
+    completed_at    TIMESTAMPTZ,
+    scheduled_for   TIMESTAMPTZ DEFAULT now(),
+    created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_processing_job_article
+    ON news.processing_job (article_id);
+CREATE INDEX IF NOT EXISTS idx_processing_job_status_type
+    ON news.processing_job (status, job_type, priority);
+CREATE INDEX IF NOT EXISTS idx_processing_job_scheduled
+    ON news.processing_job (scheduled_for) WHERE status = 'pending';
+
+-- ══════════════════════════════════════════════════
+-- 008: Sync & System Tables
+-- ══════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS sync.sync_log (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    sync_direction  TEXT NOT NULL CHECK (sync_direction IN ('to_platform', 'from_platform')),
+    entity_type     TEXT NOT NULL,
+    local_id        UUID NOT NULL,
+    platform_id     UUID,
+    status          TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+                        'pending', 'in_progress', 'success', 'failed', 'conflict'
+                    )),
+    payload         JSONB,
+    response        JSONB,
+    error_message   TEXT,
+    attempts        INT DEFAULT 0,
+    synced_at       TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sync_log_entity ON sync.sync_log (entity_type, local_id);
+CREATE INDEX IF NOT EXISTS idx_sync_log_status ON sync.sync_log (status, sync_direction);
+
+CREATE TABLE IF NOT EXISTS system.activity_logs (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID REFERENCES identity.person (id),
+    action      TEXT NOT NULL,
+    entity_type TEXT,
+    entity_id   UUID,
+    metadata    JSONB,
+    ip_address  TEXT,
+    user_agent  TEXT,
+    created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_activity_logs_user
+    ON system.activity_logs (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_activity_logs_entity
+    ON system.activity_logs (entity_type, entity_id);
+
+CREATE TABLE IF NOT EXISTS system.feature_flags (
+    key         TEXT PRIMARY KEY,
+    value       BOOLEAN NOT NULL DEFAULT FALSE,
+    description TEXT,
+    updated_at  TIMESTAMPTZ DEFAULT now()
+);
+
+INSERT INTO system.feature_flags (key, value, description) VALUES
+    ('nlp_enrichment_enabled',  TRUE,  'Enable NLP enrichment pipeline'),
+    ('auto_category_tagging',   TRUE,  'Auto-tag articles with interest categories'),
+    ('fact_check_enabled',      FALSE, 'Enable automated fact-checking'),
+    ('auto_sync_to_platform',   FALSE, 'Auto-sync published articles to platform cloud'),
+    ('breaking_news_alerts',    TRUE,  'Enable breaking news push notifications'),
+    ('rss_ingestion_enabled',   TRUE,  'Enable RSS feed ingestion workers')
+ON CONFLICT (key) DO NOTHING;
+
+-- ══════════════════════════════════════════════════
+-- 009: Triggers
+-- ══════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION system.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_identity_person_updated_at
+        BEFORE UPDATE ON identity.person
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_news_media_org_updated_at
+        BEFORE UPDATE ON news.news_media_organization
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_news_journalist_updated_at
+        BEFORE UPDATE ON news.journalist
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_news_article_updated_at
+        BEFORE UPDATE ON news.news_article
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_feed_source_updated_at
+        BEFORE UPDATE ON news.feed_source
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE TRIGGER trg_interest_category_updated_at
+        BEFORE UPDATE ON engagement.interest_category
+        FOR EACH ROW EXECUTE FUNCTION system.set_updated_at();
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ══════════════════════════════════════════════════
+-- 010: claim_processing_job RPC
+-- ══════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION claim_processing_job(p_job_type TEXT)
+RETURNS SETOF news.processing_job AS $$
+    UPDATE news.processing_job
+    SET status = 'running', started_at = now(), attempts = attempts + 1
+    WHERE id = (
+        SELECT id FROM news.processing_job
+        WHERE job_type = p_job_type
+          AND status IN ('pending', 'retrying')
+          AND scheduled_for <= now()
+        ORDER BY priority ASC, scheduled_for ASC
+        FOR UPDATE SKIP LOCKED
+        LIMIT 1
+    )
+    RETURNING *;
+$$ LANGUAGE sql;
+
+-- ══════════════════════════════════════════════════
+-- WORKER EXTENSIONS
+-- Fly-worker operational columns not in canonical Supabase schema
+-- ══════════════════════════════════════════════════
+
+-- news.news_article: processing pipeline columns
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS article_body_processed TEXT;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS ai_processed BOOLEAN DEFAULT FALSE;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS ai_processed_at TIMESTAMPTZ;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS quality_score REAL DEFAULT 0.0;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS engagement_score REAL DEFAULT 0.0;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS trending_score REAL DEFAULT 0.0;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS embedding JSONB;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS bookmark_count INT DEFAULT 0;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS content_type TEXT DEFAULT 'article';
+
+CREATE INDEX IF NOT EXISTS idx_news_article_engagement ON news.news_article (engagement_score DESC);
+CREATE INDEX IF NOT EXISTS idx_news_article_trending ON news.news_article (trending_score DESC);
+CREATE INDEX IF NOT EXISTS idx_news_article_ai_processed ON news.news_article (ai_processed) WHERE ai_processed = FALSE;
+CREATE INDEX IF NOT EXISTS idx_news_article_updated ON news.news_article (updated_at);
+
+-- news.news_media_organization: slug for URL-friendly identification
+ALTER TABLE news.news_media_organization ADD COLUMN IF NOT EXISTS slug TEXT UNIQUE;
+
+-- news.feed_source: health tracking extensions
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS consecutive_failures INT DEFAULT 0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS total_fetch_count INT DEFAULT 0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS total_error_count INT DEFAULT 0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS last_successful_fetch_at TIMESTAMPTZ;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS health_status TEXT DEFAULT 'unknown';
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS quality_score REAL DEFAULT 0.0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS credibility_score REAL DEFAULT 1.0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS priority INT DEFAULT 3;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS article_section_slug TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_feed_source_active ON news.feed_source (is_active) WHERE is_active = TRUE;
+CREATE INDEX IF NOT EXISTS idx_feed_source_health ON news.feed_source (health_status);
+CREATE INDEX IF NOT EXISTS idx_feed_source_country ON news.feed_source (country);
+
+-- engagement.interest_category: display metadata
+ALTER TABLE engagement.interest_category ADD COLUMN IF NOT EXISTS emoji TEXT;
+ALTER TABLE engagement.interest_category ADD COLUMN IF NOT EXISTS classification_keywords JSONB DEFAULT '[]';
+
+-- identity.person: author/journalist extensions
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS normalized_name TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS slug TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS description TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS job_title TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS works_for TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS same_as JSONB DEFAULT '[]';
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS article_count INT DEFAULT 0;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS total_views INT DEFAULT 0;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS verification_status TEXT DEFAULT 'unverified';
+
+CREATE INDEX IF NOT EXISTS idx_persons_normalized ON identity.person (normalized_name);
+CREATE INDEX IF NOT EXISTS idx_persons_slug ON identity.person (slug);
+CREATE INDEX IF NOT EXISTS idx_persons_article_count ON identity.person (article_count DESC);
+
+-- news.article_authorship: extraction metadata
+ALTER TABLE news.article_authorship ADD COLUMN IF NOT EXISTS confidence REAL DEFAULT 1.0;
+ALTER TABLE news.article_authorship ADD COLUMN IF NOT EXISTS extraction_method TEXT DEFAULT 'rss';
+ALTER TABLE news.article_authorship ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT now();
+
+-- ══════════════════════════════════════════════════
+-- OPERATIONAL TABLES
+-- Fly-worker-specific tables not in canonical Supabase schema
+-- ══════════════════════════════════════════════════
+
+-- Countries (schema:Country / schema:Place)
+CREATE TABLE IF NOT EXISTS news.country (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    flag_emoji TEXT,
+    color TEXT,
+    region TEXT,
+    in_language TEXT DEFAULT 'en',
+    timezone TEXT,
+    enabled BOOLEAN DEFAULT TRUE,
+    priority INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Defined Terms / Keywords (schema:DefinedTerm)
+CREATE TABLE IF NOT EXISTS news.defined_term (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    term_code TEXT UNIQUE,
+    term_type TEXT DEFAULT 'keyword'
+        CHECK (term_type IN ('keyword', 'topic', 'entity', 'location')),
+    article_count INTEGER DEFAULT 0,
+    enabled BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_terms_article_count ON news.defined_term (article_count DESC);
+CREATE INDEX IF NOT EXISTS idx_terms_type ON news.defined_term (term_type);
+
+-- Article ↔ DefinedTerm junction
+CREATE TABLE IF NOT EXISTS news.article_keyword (
+    article_id UUID NOT NULL REFERENCES news.news_article (id) ON DELETE CASCADE,
+    term_id TEXT NOT NULL REFERENCES news.defined_term (id),
+    relevance_score REAL DEFAULT 1.0,
+    source TEXT DEFAULT 'auto'
+        CHECK (source IN ('auto', 'ai', 'manual')),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (article_id, term_id)
+);
+
+-- Trending Cache
+CREATE TABLE IF NOT EXISTS news.trending_cache (
+    id SERIAL PRIMARY KEY,
+    scope TEXT NOT NULL DEFAULT 'global',
+    scope_id TEXT,
+    term_id TEXT REFERENCES news.defined_term (id),
+    term_name TEXT NOT NULL,
+    article_count INTEGER DEFAULT 0,
+    score REAL DEFAULT 0.0,
+    computed_at TIMESTAMPTZ DEFAULT NOW(),
+    expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '1 hour'),
+    UNIQUE (scope, scope_id, term_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trending_expires ON news.trending_cache (expires_at);
+CREATE INDEX IF NOT EXISTS idx_trending_scope ON news.trending_cache (scope, scope_id);
+
+-- Collection Log (job execution tracking)
+CREATE TABLE IF NOT EXISTS system.collection_log (
+    id SERIAL PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('started', 'success', 'failed')),
+    articles_collected INTEGER DEFAULT 0,
+    articles_processed INTEGER DEFAULT 0,
+    errors INTEGER DEFAULT 0,
+    duration_ms INTEGER,
+    error_message TEXT,
+    metadata JSONB DEFAULT '{}',
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_collection_created ON system.collection_log (created_at DESC);

--- a/fly-worker/migrations/002_seed.sql
+++ b/fly-worker/migrations/002_seed.sql
@@ -1,0 +1,102 @@
+-- Mukoko News — Seed Data
+-- Countries, Interest Categories, Organizations, Feed Sources
+
+-- ══════════════════════════════════════════════════
+-- COUNTRIES
+-- ══════════════════════════════════════════════════
+
+INSERT INTO news.country (id, name, flag_emoji, color, region, in_language, timezone, enabled, priority) VALUES
+('ZW', 'Zimbabwe',     '🇿🇼', 'bg-green-600',  'southern', 'en', 'Africa/Harare',        TRUE, 10),
+('ZA', 'South Africa', '🇿🇦', 'bg-yellow-500', 'southern', 'en', 'Africa/Johannesburg',  TRUE, 9),
+('KE', 'Kenya',        '🇰🇪', 'bg-red-600',    'eastern',  'en', 'Africa/Nairobi',       TRUE, 8),
+('NG', 'Nigeria',      '🇳🇬', 'bg-green-500',  'western',  'en', 'Africa/Lagos',         TRUE, 7),
+('GH', 'Ghana',        '🇬🇭', 'bg-yellow-400', 'western',  'en', 'Africa/Accra',         TRUE, 6),
+('TZ', 'Tanzania',     '🇹🇿', 'bg-blue-500',   'eastern',  'sw', 'Africa/Dar_es_Salaam', TRUE, 5),
+('UG', 'Uganda',       '🇺🇬', 'bg-yellow-600', 'eastern',  'en', 'Africa/Kampala',       TRUE, 5),
+('RW', 'Rwanda',       '🇷🇼', 'bg-cyan-500',   'eastern',  'en', 'Africa/Kigali',        TRUE, 4),
+('ET', 'Ethiopia',     '🇪🇹', 'bg-green-400',  'eastern',  'am', 'Africa/Addis_Ababa',   TRUE, 4),
+('BW', 'Botswana',     '🇧🇼', 'bg-sky-400',    'southern', 'en', 'Africa/Gaborone',      TRUE, 4),
+('ZM', 'Zambia',       '🇿🇲', 'bg-orange-500', 'southern', 'en', 'Africa/Lusaka',        TRUE, 4),
+('MW', 'Malawi',       '🇲🇼', 'bg-red-500',    'southern', 'en', 'Africa/Blantyre',      TRUE, 3),
+('EG', 'Egypt',        '🇪🇬', 'bg-red-700',    'northern', 'ar', 'Africa/Cairo',         TRUE, 3),
+('MA', 'Morocco',      '🇲🇦', 'bg-red-600',    'northern', 'ar', 'Africa/Casablanca',    TRUE, 3),
+('NA', 'Namibia',      '🇳🇦', 'bg-blue-600',   'southern', 'en', 'Africa/Windhoek',      TRUE, 3),
+('MZ', 'Mozambique',   '🇲🇿', 'bg-yellow-500', 'southern', 'pt', 'Africa/Maputo',        TRUE, 3)
+ON CONFLICT (id) DO NOTHING;
+
+-- ══════════════════════════════════════════════════
+-- INTEREST CATEGORIES (replaces article_sections)
+-- ══════════════════════════════════════════════════
+
+INSERT INTO engagement.interest_category (slug, name, description, emoji, color_hex, classification_keywords, is_active, sort_order) VALUES
+('politics',      'Politics',      'Political news and government affairs',      '🏛️', '#EF4444', '["politics", "government", "election", "vote", "parliament", "minister", "president", "policy", "law", "legislation", "democracy", "party", "campaign", "political", "governance", "reform"]', TRUE, 1),
+('economy',       'Economy',       'Economic news, business, and finance',       '💰', '#10B981', '["economy", "business", "finance", "banking", "investment", "market", "economic", "financial", "money", "currency", "inflation", "gdp", "trade", "export", "import", "stock", "mining"]', TRUE, 2),
+('technology',    'Technology',    'Technology, innovation, and digital news',    '💻', '#3B82F6', '["technology", "tech", "digital", "innovation", "startup", "internet", "mobile", "app", "software", "ai", "blockchain", "fintech", "ict"]', TRUE, 3),
+('sports',        'Sports',        'Sports news and events',                     '⚽', '#F97316', '["sports", "football", "soccer", "cricket", "rugby", "tennis", "athletics", "olympics", "world cup", "premier league"]', TRUE, 4),
+('health',        'Health',        'Health, medical, and wellness news',         '🏥', '#22C55E', '["health", "medical", "hospital", "doctor", "medicine", "healthcare", "pandemic", "vaccine", "disease", "treatment", "wellness"]', TRUE, 5),
+('education',     'Education',     'Education news and academic affairs',        '📚', '#8B5CF6', '["education", "school", "university", "student", "teacher", "learning", "academic", "examination"]', TRUE, 6),
+('entertainment', 'Entertainment', 'Entertainment, arts, and culture',           '🎬', '#EC4899', '["entertainment", "music", "movie", "film", "celebrity", "artist", "culture", "arts", "theatre", "concert", "festival"]', TRUE, 7),
+('international', 'International', 'International and world news',               '🌍', '#06B6D4', '["international", "world", "global", "foreign", "africa", "sadc"]', TRUE, 8),
+('general',       'General',       'General news and updates',                   '📰', '#84CC16', '["news", "zimbabwe", "africa", "breaking", "latest", "update"]', TRUE, 9),
+('agriculture',   'Agriculture',   'Agricultural news and farming',              '🌾', '#F59E0B', '["agriculture", "farming", "crop", "livestock", "tobacco", "maize", "farmer", "harvest", "land", "rural"]', TRUE, 10),
+('crime',         'Crime',         'Crime and law enforcement news',             '🚔', '#DC2626', '["crime", "police", "arrest", "court", "justice", "theft", "murder", "robbery", "investigation", "criminal"]', TRUE, 11),
+('environment',   'Environment',   'Environmental news and conservation',        '🌿', '#16A34A', '["environment", "climate", "conservation", "pollution", "wildlife", "deforestation", "renewable", "sustainability"]', TRUE, 12)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ══════════════════════════════════════════════════
+-- NEWS MEDIA ORGANIZATIONS
+-- ══════════════════════════════════════════════════
+
+INSERT INTO news.news_media_organization (name, slug, url, source_type) VALUES
+-- Zimbabwe
+('Herald Zimbabwe',       'herald-zimbabwe',      'https://www.herald.co.zw',           'newspaper'),
+('NewsDay Zimbabwe',      'newsday-zimbabwe',      'https://www.newsday.co.zw',          'newspaper'),
+('Chronicle Zimbabwe',    'chronicle-zimbabwe',    'https://www.chronicle.co.zw',        'newspaper'),
+('ZBC News',              'zbc-news',              'https://www.zbc.co.zw',              'broadcaster'),
+('Business Weekly',       'business-weekly',       'https://businessweekly.co.zw',       'newspaper'),
+('Techzim',               'techzim',               'https://www.techzim.co.zw',          'digital_native'),
+('The Standard',          'the-standard',          'https://www.thestandard.co.zw',      'newspaper'),
+('ZimLive',               'zimlive',               'https://www.zimlive.com',            'digital_native'),
+('New Zimbabwe',          'new-zimbabwe',          'https://www.newzimbabwe.com',        'digital_native'),
+('The Independent',       'the-independent',       'https://www.theindependent.co.zw',   'newspaper'),
+('Sunday Mail',           'sunday-mail',           'https://www.sundaymail.co.zw',       'newspaper'),
+('263Chat',               '263chat',               'https://263chat.com',                'digital_native'),
+('Daily News',            'daily-news',            'https://www.dailynews.co.zw',        'newspaper'),
+('ZimEye',                'zimeye',                'https://zimeye.net',                 'digital_native'),
+('Pindula News',          'pindula-news',          'https://news.pindula.co.zw',         'digital_native'),
+('Zimbabwe Situation',    'zimbabwe-situation',    'https://zimbabwesituation.com',      'digital_native'),
+('Nehanda Radio',         'nehanda-radio',         'https://nehandaradio.com',           'digital_native'),
+('Open News Zimbabwe',    'open-news-zimbabwe',    'https://opennews.co.zw',             'digital_native'),
+('Financial Gazette',     'financial-gazette',     'https://fingaz.co.zw',               'newspaper'),
+('Manica Post',           'manica-post',           'https://manicapost.co.zw',           'newspaper'),
+('Southern Eye',          'southern-eye',          'https://southerneye.co.zw',          'newspaper')
+ON CONFLICT (slug) DO NOTHING;
+
+-- ══════════════════════════════════════════════════
+-- FEED SOURCES (linked to organizations)
+-- ══════════════════════════════════════════════════
+
+INSERT INTO news.feed_source (organization_id, name, feed_url, feed_type, country, language, article_section_slug, priority) VALUES
+-- Zimbabwe sources
+((SELECT id FROM news.news_media_organization WHERE slug = 'herald-zimbabwe'),      'Herald Zimbabwe RSS',       'https://www.herald.co.zw/feed/',       'rss', 'ZW', 'en', 'general', 5),
+((SELECT id FROM news.news_media_organization WHERE slug = 'newsday-zimbabwe'),     'NewsDay Zimbabwe RSS',      'https://www.newsday.co.zw/feed/',      'rss', 'ZW', 'en', 'general', 5),
+((SELECT id FROM news.news_media_organization WHERE slug = 'chronicle-zimbabwe'),   'Chronicle Zimbabwe RSS',    'https://www.chronicle.co.zw/feed/',    'rss', 'ZW', 'en', 'general', 5),
+((SELECT id FROM news.news_media_organization WHERE slug = 'zbc-news'),             'ZBC News RSS',              'https://www.zbc.co.zw/feed/',          'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'business-weekly'),      'Business Weekly RSS',       'https://businessweekly.co.zw/feed/',   'rss', 'ZW', 'en', 'economy', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'techzim'),              'Techzim RSS',               'https://www.techzim.co.zw/feed/',      'rss', 'ZW', 'en', 'technology', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'the-standard'),         'The Standard RSS',          'https://www.thestandard.co.zw/feed/',  'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'zimlive'),              'ZimLive RSS',               'https://www.zimlive.com/feed/',         'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'new-zimbabwe'),         'New Zimbabwe RSS',          'https://www.newzimbabwe.com/feed/',     'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'the-independent'),      'The Independent RSS',       'https://www.theindependent.co.zw/feed/', 'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'sunday-mail'),          'Sunday Mail RSS',           'https://www.sundaymail.co.zw/feed/',   'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = '263chat'),              '263Chat RSS',               'https://263chat.com/feed/',             'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'daily-news'),           'Daily News RSS',            'https://www.dailynews.co.zw/feed/',    'rss', 'ZW', 'en', 'general', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'zimeye'),               'ZimEye RSS',                'https://zimeye.net/feed/',              'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'pindula-news'),         'Pindula News RSS',          'https://news.pindula.co.zw/feed/',     'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'zimbabwe-situation'),   'Zimbabwe Situation RSS',    'https://zimbabwesituation.com/feed/',   'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'nehanda-radio'),        'Nehanda Radio RSS',         'https://nehandaradio.com/feed/',        'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'open-news-zimbabwe'),   'Open News Zimbabwe RSS',    'https://opennews.co.zw/feed/',          'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'financial-gazette'),    'Financial Gazette RSS',     'https://fingaz.co.zw/feed/',            'rss', 'ZW', 'en', 'economy', 4),
+((SELECT id FROM news.news_media_organization WHERE slug = 'manica-post'),          'Manica Post RSS',           'https://manicapost.co.zw/feed/',        'rss', 'ZW', 'en', 'general', 3),
+((SELECT id FROM news.news_media_organization WHERE slug = 'southern-eye'),         'Southern Eye RSS',          'https://southerneye.co.zw/feed/',       'rss', 'ZW', 'en', 'general', 3)
+ON CONFLICT (feed_url) DO NOTHING;

--- a/fly-worker/migrations/003_schema_fixes.sql
+++ b/fly-worker/migrations/003_schema_fixes.sql
@@ -1,0 +1,9 @@
+-- Phase 1: Fix schema mismatches
+-- Adds missing columns to feed_source that the application code expects
+
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS area_served TEXT;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS article_section_id UUID REFERENCES engagement.interest_category(id);
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS last_error_at TIMESTAMPTZ;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS total_fetch_count INTEGER DEFAULT 0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS total_error_count INTEGER DEFAULT 0;
+ALTER TABLE news.feed_source ADD COLUMN IF NOT EXISTS health_status TEXT DEFAULT 'unknown';

--- a/fly-worker/migrations/004_pgvector_embeddings.sql
+++ b/fly-worker/migrations/004_pgvector_embeddings.sql
@@ -1,0 +1,28 @@
+-- ══════════════════════════════════════════════════
+-- Migration 004: pgvector embeddings for semantic search
+-- Model: BAAI/bge-m3 via Cloudflare Workers AI (1024 dimensions)
+-- ══════════════════════════════════════════════════
+
+-- Enable pgvector extension (Supabase has this pre-installed)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Add vector column for BGE-M3 embeddings (1024 dimensions)
+ALTER TABLE news.news_article
+    ADD COLUMN IF NOT EXISTS embedding_vector vector(1024);
+
+-- HNSW index for fast approximate nearest neighbor search
+-- ef_construction=128: build quality (higher = better recall, slower build)
+-- m=16: connections per node (higher = better recall, more memory)
+CREATE INDEX IF NOT EXISTS idx_news_article_embedding_hnsw
+    ON news.news_article
+    USING hnsw (embedding_vector vector_cosine_ops)
+    WITH (m = 16, ef_construction = 128);
+
+-- Track when embedding was generated (separate from ai_processed)
+ALTER TABLE news.news_article
+    ADD COLUMN IF NOT EXISTS embedding_model TEXT;
+
+-- Partial index: find articles that need embedding
+CREATE INDEX IF NOT EXISTS idx_news_article_needs_embedding
+    ON news.news_article (ai_processed, datepublished DESC)
+    WHERE embedding_vector IS NULL AND ai_processed = TRUE;

--- a/fly-worker/migrations/005_auth_columns.sql
+++ b/fly-worker/migrations/005_auth_columns.sql
@@ -1,0 +1,163 @@
+-- Schema alignment with mukoko-platform (Schema.org camelCase)
+-- Applied 2026-03-30
+
+-- ═══════════════════════════════════════════
+-- identity.person — match platform exactly
+-- ═══════════════════════════════════════════
+
+-- Auth
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS auth_method TEXT DEFAULT 'email_otp';
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS last_seen_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_identity_person_stytch
+    ON identity.person (stytch_user_id) WHERE stytch_user_id IS NOT NULL;
+
+-- Name parts (Schema.org Person)
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS additionalname TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS honorificprefix TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS honorificsuffix TEXT;
+
+-- Demographics
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS birthdate DATE;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS deathdate DATE;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS gender TEXT;
+
+-- Location & contact
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS address JSONB;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nationality JSONB;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS contactpoint JSONB;
+
+-- Professional (Schema.org camelCase)
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS jobtitle TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS worksfor JSONB;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS affiliation JSONB;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS alumniof JSONB;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS knowslanguage TEXT[];
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- Session tracking (match platform)
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS stytch_session_id TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS last_login_method TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS last_login_platform TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS registered_devices JSONB DEFAULT '[]'::jsonb;
+
+-- Web3 identity
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nft_identity_token_id TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nft_identity_blockchain TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nft_identity_contract_address TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nft_identity_token_uri TEXT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS nft_identity_ipfs_hash TEXT;
+
+-- Sync
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS d1_person_id BIGINT;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS d1_synced_at TIMESTAMPTZ;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS sync_version INTEGER DEFAULT 1;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS phone_verified_at TIMESTAMPTZ;
+ALTER TABLE identity.person ADD COLUMN IF NOT EXISTS email_verified_at TIMESTAMPTZ;
+
+-- ═══════════════════════════════════════════
+-- news.news_article — Schema.org naming
+-- ═══════════════════════════════════════════
+
+ALTER TABLE news.news_article RENAME COLUMN status TO creativeworkstatus;
+ALTER TABLE news.news_article ADD COLUMN IF NOT EXISTS bookmark_count INTEGER DEFAULT 0;
+
+-- ═══════════════════════════════════════════
+-- engagement — match platform tables
+-- ═══════════════════════════════════════════
+
+ALTER TABLE engagement.interest_category RENAME COLUMN parent_id TO parent_category_id;
+
+CREATE TABLE IF NOT EXISTS engagement.interaction_counter (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "forType" TEXT NOT NULL,
+    "forId" UUID NOT NULL,
+    "interactionType" TEXT NOT NULL,
+    "userInteractionCount" INTEGER DEFAULT 0,
+    last_updated TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS engagement.user_action (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent UUID REFERENCES identity.person(id),
+    actiontype TEXT NOT NULL,
+    object_type TEXT NOT NULL,
+    object_id UUID NOT NULL,
+    starttime TIMESTAMPTZ DEFAULT now(),
+    endtime TIMESTAMPTZ,
+    result JSONB,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS engagement.follow_action (
+    follower_person_id UUID NOT NULL REFERENCES identity.person(id),
+    followed_type TEXT NOT NULL,
+    followed_id UUID NOT NULL,
+    starttime TIMESTAMPTZ DEFAULT now(),
+    PRIMARY KEY (follower_person_id, followed_type, followed_id)
+);
+
+CREATE TABLE IF NOT EXISTS engagement.recommendation (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    person_id UUID REFERENCES identity.person(id),
+    itemoffered_type TEXT NOT NULL,
+    itemoffered_id UUID NOT NULL,
+    score REAL,
+    reasoning TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS engagement.unverified_interaction (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    person_id UUID REFERENCES identity.person(id),
+    content_id TEXT NOT NULL,
+    content_type TEXT NOT NULL,
+    interaction_type TEXT NOT NULL,
+    duration_seconds INTEGER,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS engagement.interest_keyword (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    category_id UUID REFERENCES engagement.interest_category(id),
+    keyword TEXT NOT NULL,
+    weight REAL DEFAULT 1.0,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- ═══════════════════════════════════════════
+-- places schema — match platform
+-- ═══════════════════════════════════════════
+
+CREATE SCHEMA IF NOT EXISTS places;
+
+CREATE TABLE IF NOT EXISTS places.countries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    iso_code CHAR(2) NOT NULL UNIQUE,
+    continent TEXT,
+    currency_code CHAR(3),
+    phone_code TEXT,
+    flag_emoji TEXT,
+    active BOOLEAN DEFAULT true,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+INSERT INTO places.countries (name, iso_code, continent, currency_code, phone_code, flag_emoji) VALUES
+('Zimbabwe', 'ZW', 'Africa', 'ZWL', '+263', '🇿🇼'),
+('South Africa', 'ZA', 'Africa', 'ZAR', '+27', '🇿🇦'),
+('Kenya', 'KE', 'Africa', 'KES', '+254', '🇰🇪'),
+('Nigeria', 'NG', 'Africa', 'NGN', '+234', '🇳🇬'),
+('Ghana', 'GH', 'Africa', 'GHS', '+233', '🇬🇭'),
+('Tanzania', 'TZ', 'Africa', 'TZS', '+255', '🇹🇿'),
+('Uganda', 'UG', 'Africa', 'UGX', '+256', '🇺🇬'),
+('Rwanda', 'RW', 'Africa', 'RWF', '+250', '🇷🇼'),
+('Ethiopia', 'ET', 'Africa', 'ETB', '+251', '🇪🇹'),
+('Botswana', 'BW', 'Africa', 'BWP', '+267', '🇧🇼'),
+('Zambia', 'ZM', 'Africa', 'ZMW', '+260', '🇿🇲'),
+('Malawi', 'MW', 'Africa', 'MWK', '+265', '🇲🇼'),
+('Egypt', 'EG', 'Africa', 'EGP', '+20', '🇪🇬'),
+('Morocco', 'MA', 'Africa', 'MAD', '+212', '🇲🇦'),
+('Namibia', 'NA', 'Africa', 'NAD', '+264', '🇳🇦'),
+('Mozambique', 'MZ', 'Africa', 'MZN', '+258', '🇲🇿')
+ON CONFLICT (iso_code) DO NOTHING;

--- a/fly-worker/pyproject.toml
+++ b/fly-worker/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "mukoko-news-api"
+version = "2.0.0"
+description = "Mukoko News API backend — FastAPI on Fly.io with Supabase Postgres"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "asyncpg>=0.30",
+    "httpx>=0.28",
+    "feedparser>=6.0",
+    "beautifulsoup4>=4.12",
+    "lxml>=5.3",
+    "textstat>=0.7",
+    "anthropic>=0.40",
+    "apscheduler>=3.10",
+    "pydantic-settings>=2.6",
+    "stytch>=10.0",
+    "pyjwt[crypto]>=2.8",
+    "readability-lxml>=0.8",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pyright>=1.1",
+    "ruff>=0.8",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "standard"
+venvPath = "."
+venv = ".venv"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100

--- a/fly-worker/src/api/__init__.py
+++ b/fly-worker/src/api/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/fly-worker/src/api/admin.py
+++ b/fly-worker/src/api/admin.py
@@ -1,0 +1,229 @@
+"""Admin API endpoints — /api/admin/*.
+
+Protected by admin auth (JWT with admin or service_role).
+"""
+
+import json
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Body, Header
+
+from src.db import get_pool
+from src.api.auth import require_admin, AuthUser
+
+router = APIRouter(prefix="/api/admin", tags=["admin"])
+
+
+@router.get("/stats")
+async def admin_stats(_admin: AuthUser = Depends(require_admin)):
+    """Get admin dashboard statistics."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        total_articles = await conn.fetchval("SELECT COUNT(*) FROM news.news_article")
+        published = await conn.fetchval("SELECT COUNT(*) FROM news.news_article WHERE creativeworkstatus = 'published'")
+        sources = await conn.fetchval("SELECT COUNT(*) FROM news.feed_source")
+        enabled_sources = await conn.fetchval("SELECT COUNT(*) FROM news.feed_source WHERE is_active = TRUE")
+        categories = await conn.fetchval("SELECT COUNT(*) FROM engagement.interest_category WHERE is_active = TRUE")
+        today = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.news_article WHERE ingested_at >= CURRENT_DATE"
+        )
+
+    return {
+        "stats": {
+            "total_articles": total_articles or 0,
+            "published_articles": published or 0,
+            "total_sources": sources or 0,
+            "enabled_sources": enabled_sources or 0,
+            "categories": categories or 0,
+            "today_articles": today or 0,
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/sources")
+async def admin_sources(
+    _admin: AuthUser = Depends(require_admin),
+):
+    """Get all sources with health info for admin."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT fs.id::text AS feed_source_id,
+                      org.id::text AS id, org.name, org.url,
+                      fs.feed_url, fs.area_served, fs.article_section_id,
+                      fs.is_active, fs.priority, fs.health_status,
+                      fs.consecutive_failures, fs.last_fetch_error, fs.last_error_at,
+                      fs.last_fetched_at, fs.total_fetch_count, fs.total_error_count,
+                      COUNT(a.id) AS article_count,
+                      MAX(a.datepublished) AS latest_article_at
+               FROM news.feed_source fs
+               JOIN news.news_media_organization org ON fs.organization_id = org.id
+               LEFT JOIN news.news_article a ON a.publisher_organization_id = org.id
+               GROUP BY fs.id, org.id, org.name, org.url,
+                        fs.feed_url, fs.area_served, fs.article_section_id,
+                        fs.is_active, fs.priority, fs.health_status,
+                        fs.consecutive_failures, fs.last_fetch_error, fs.last_error_at,
+                        fs.last_fetched_at, fs.total_fetch_count, fs.total_error_count
+               ORDER BY fs.priority DESC, org.name"""
+        )
+
+    return {"sources": [dict(r) for r in rows]}
+
+
+@router.get("/sources/health")
+async def admin_sources_health(_admin: AuthUser = Depends(require_admin)):
+    """Get source health summary."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT health_status, COUNT(*) AS count
+               FROM news.feed_source
+               WHERE is_active = TRUE
+               GROUP BY health_status"""
+        )
+
+        failing = await conn.fetch(
+            """SELECT fs.id::text AS feed_source_id,
+                      org.id::text AS id, org.name,
+                      fs.health_status, fs.consecutive_failures,
+                      fs.last_fetch_error, fs.last_error_at
+               FROM news.feed_source fs
+               JOIN news.news_media_organization org ON fs.organization_id = org.id
+               WHERE fs.is_active = TRUE AND fs.consecutive_failures > 3
+               ORDER BY fs.consecutive_failures DESC"""
+        )
+
+    return {
+        "summary": {r["health_status"]: r["count"] for r in rows},
+        "alerts": [dict(r) for r in failing],
+    }
+
+
+@router.get("/sources/{source_id}")
+async def admin_source_detail(
+    source_id: str = Path(...),
+    _admin: AuthUser = Depends(require_admin),
+):
+    """Get detailed source info."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT fs.id::text AS feed_source_id,
+                      org.id::text AS id, org.name, org.url,
+                      fs.feed_url, fs.area_served, fs.article_section_id,
+                      fs.is_active, fs.priority, fs.health_status,
+                      fs.consecutive_failures, fs.last_fetch_error, fs.last_error_at,
+                      fs.last_fetched_at, fs.total_fetch_count, fs.total_error_count
+               FROM news.feed_source fs
+               JOIN news.news_media_organization org ON fs.organization_id = org.id
+               WHERE org.id::text = $1 OR fs.id::text = $1""",
+            source_id,
+        )
+        if not row:
+            raise HTTPException(status_code=404, detail="Source not found")
+
+        article_count = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.news_article WHERE publisher_organization_id::text = $1",
+            source_id,
+        )
+
+    source = dict(row)
+    source["article_count"] = article_count
+
+    return {"source": source}
+
+
+@router.put("/rss-source/{source_id}")
+async def update_rss_source(
+    source_id: str = Path(...),
+    body: dict = Body(...),
+    _admin: AuthUser = Depends(require_admin),
+):
+    """Update an RSS source configuration."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        existing = await conn.fetchrow(
+            "SELECT fs.id FROM news.feed_source fs WHERE fs.id::text = $1", source_id
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Source not found")
+
+        # Fields on feed_source
+        fs_updates = []
+        fs_params = []
+        idx = 1
+
+        for field in ["feed_url", "area_served", "article_section_id",
+                       "is_active", "priority"]:
+            if field in body:
+                fs_updates.append(f"{field} = ${idx}")
+                fs_params.append(body[field])
+                idx += 1
+
+        if fs_updates:
+            fs_updates.append("updated_at = NOW()")
+            fs_params.append(source_id)
+            await conn.execute(
+                f"UPDATE news.feed_source SET {', '.join(fs_updates)} WHERE id::text = ${idx}",
+                *fs_params,
+            )
+
+        # Fields on organization (via feed_source join)
+        org_updates = []
+        org_params = []
+        org_idx = 1
+
+        for field in ["name", "url", "description"]:
+            if field in body:
+                org_updates.append(f"{field} = ${org_idx}")
+                org_params.append(body[field])
+                org_idx += 1
+
+        if org_updates:
+            org_updates.append("updated_at = NOW()")
+            org_params.append(source_id)
+            await conn.execute(
+                f"""UPDATE news.news_media_organization SET {', '.join(org_updates)}
+                    WHERE id = (SELECT organization_id FROM news.feed_source WHERE id::text = ${org_idx})""",
+                *org_params,
+            )
+
+    return {"success": True, "message": "Source updated"}
+
+
+@router.get("/cron-logs")
+async def admin_cron_logs(
+    limit: int = Query(20, ge=1, le=100),
+    _admin: AuthUser = Depends(require_admin),
+):
+    """Get recent cron execution logs."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT * FROM system.collection_log
+               ORDER BY created_at DESC
+               LIMIT $1""",
+            limit,
+        )
+
+    return {"logs": [dict(r) for r in rows]}
+
+
+@router.post("/feed/collect")
+async def trigger_collection(_admin: AuthUser = Depends(require_admin)):
+    """Manually trigger RSS feed collection."""
+    from src.jobs.rss_collector import collect_feeds
+
+    try:
+        await collect_feeds()
+        return {"success": True, "message": "Feed collection triggered"}
+    except Exception as e:
+        print(f"[ADMIN] Feed collection error: {e}")
+        return {"success": False, "error": "Feed collection failed"}

--- a/fly-worker/src/api/analytics.py
+++ b/fly-worker/src/api/analytics.py
@@ -1,0 +1,440 @@
+"""Public analytics endpoints — /api/analytics/*.
+
+Mukoko is an open data platform. All non-PII analytics are public.
+Anyone can query article performance, source trends, and readership patterns.
+Business intelligence is for the people, not locked behind admin.
+
+Only PII-related data (individual user behavior) stays behind admin auth.
+"""
+
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Query
+
+from src.db import get_pool
+from src.services.doris import get_doris
+from src.services.analytics import get_analytics
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+# Simple in-memory cache: {key: (data, expires_at)}
+_cache: dict[str, tuple[dict, float]] = {}
+CACHE_TTL = 300  # 5 minutes
+
+
+def _cache_get(key: str) -> dict | None:
+    entry = _cache.get(key)
+    if entry and entry[1] > time.time():
+        return entry[0]
+    return None
+
+
+def _cache_set(key: str, data: dict) -> None:
+    _cache[key] = (data, time.time() + CACHE_TTL)
+
+
+def _period_to_interval(period: str) -> str:
+    """Convert period param to SQL interval string."""
+    mapping = {"24h": "1 day", "7d": "7 days", "30d": "30 days", "90d": "90 days"}
+    return mapping.get(period, "7 days")
+
+
+@router.get("/overview")
+async def analytics_overview(
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Platform-wide open stats. No auth required."""
+    cache_key = f"overview:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    async with pool.acquire() as conn:
+        total_articles = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.news_article WHERE creativeworkstatus = 'published'"
+        )
+        period_articles = await conn.fetchval(
+            f"SELECT COUNT(*) FROM news.news_article WHERE creativeworkstatus = 'published' AND datepublished >= NOW() - INTERVAL '{interval}'"
+        )
+        active_sources = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.feed_source WHERE is_active = TRUE"
+        )
+        countries = await conn.fetchval(
+            "SELECT COUNT(DISTINCT primary_location_country) FROM news.news_article WHERE creativeworkstatus = 'published'"
+        )
+        total_views = await conn.fetchval(
+            "SELECT COALESCE(SUM(view_count), 0) FROM news.news_article WHERE creativeworkstatus = 'published'"
+        )
+        total_likes = await conn.fetchval(
+            "SELECT COALESCE(SUM(like_count), 0) FROM news.news_article WHERE creativeworkstatus = 'published'"
+        )
+
+    result = {
+        "data": {
+            "total_articles": total_articles or 0,
+            "period_articles": period_articles or 0,
+            "active_sources": active_sources or 0,
+            "countries_covered": countries or 0,
+            "total_views": total_views or 0,
+            "total_likes": total_likes or 0,
+        },
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/overview")
+    return result
+
+
+@router.get("/articles/top")
+async def top_articles(
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+    country: str | None = Query(None),
+    category: str | None = Query(None),
+    limit: int = Query(10, ge=1, le=50),
+):
+    """Top articles by engagement. Open data — no auth."""
+    cache_key = f"top:{period}:{country}:{category}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    conditions = [
+        "a.creativeworkstatus = 'published'",
+        f"a.datepublished >= NOW() - INTERVAL '{interval}'",
+    ]
+    params: list = []
+    idx = 1
+
+    if country:
+        conditions.append(f"a.primary_location_country = ${idx}")
+        params.append(country)
+        idx += 1
+    if category and category != "all":
+        conditions.append(f"a.articlesection = ${idx}")
+        params.append(category)
+        idx += 1
+
+    where = " AND ".join(conditions)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT a.id::text, a.headline, a.slug,
+                       a.articlesection AS category,
+                       a.primary_location_country AS country,
+                       a.view_count, a.like_count, a.bookmark_count,
+                       a.share_count, a.engagement_score, a.quality_score,
+                       a.datepublished,
+                       org.name AS publisher_name
+                FROM news.news_article a
+                LEFT JOIN news.news_media_organization org
+                    ON a.publisher_organization_id = org.id
+                WHERE {where}
+                ORDER BY a.engagement_score DESC
+                LIMIT ${idx}""",
+            *params,
+            limit,
+        )
+
+    result = {
+        "data": [dict(r) for r in rows],
+        "period": period,
+        "filters": {"country": country, "category": category},
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/articles/top")
+    return result
+
+
+@router.get("/articles/{article_id}/performance")
+async def article_performance(
+    article_id: str,
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Single article engagement over time. Open data — no auth."""
+    cache_key = f"article_perf:{article_id}:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    # Try Doris first for time-series data
+    doris = get_doris()
+    time_series = []
+
+    try:
+        if await doris.ping():
+            safe_id = article_id.replace("'", "\\'")
+            rows = await doris.query(f"""
+                SELECT event_date, SUM(views) AS views, SUM(likes) AS likes,
+                       SUM(bookmarks) AS bookmarks, SUM(shares) AS shares
+                FROM mukoko_analytics.article_metrics
+                WHERE article_id = '{safe_id}'
+                GROUP BY event_date
+                ORDER BY event_date DESC
+                LIMIT 90
+            """)
+            time_series = rows
+    except Exception:
+        pass
+
+    # Always get current totals from Postgres
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT a.id::text, a.headline, a.view_count, a.like_count,
+                      a.bookmark_count, a.share_count, a.engagement_score,
+                      a.quality_score, a.datepublished,
+                      org.name AS publisher_name
+               FROM news.news_article a
+               LEFT JOIN news.news_media_organization org
+                   ON a.publisher_organization_id = org.id
+               WHERE a.id = $1::uuid""",
+            article_id,
+        )
+
+    if not row:
+        return {"error": "Article not found"}, 404
+
+    result = {
+        "data": {
+            "article": dict(row),
+            "time_series": time_series,
+        },
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/articles/performance")
+    return result
+
+
+@router.get("/sources")
+async def source_analytics(
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Source reliability and performance. Open data — no auth."""
+    cache_key = f"sources:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT org.id::text AS source_id, org.name,
+                       fs.health_status, fs.consecutive_failures,
+                       fs.total_fetch_count, fs.total_error_count,
+                       COUNT(a.id) AS period_articles,
+                       COALESCE(AVG(a.quality_score), 0) AS avg_quality,
+                       COALESCE(SUM(a.view_count), 0) AS total_views,
+                       COALESCE(SUM(a.like_count), 0) AS total_likes
+                FROM news.feed_source fs
+                JOIN news.news_media_organization org ON fs.organization_id = org.id
+                LEFT JOIN news.news_article a
+                    ON a.publisher_organization_id = org.id
+                    AND a.creativeworkstatus = 'published'
+                    AND a.datepublished >= NOW() - INTERVAL '{interval}'
+                WHERE fs.is_active = TRUE
+                GROUP BY org.id, org.name, fs.health_status,
+                         fs.consecutive_failures, fs.total_fetch_count, fs.total_error_count
+                ORDER BY total_views DESC"""
+        )
+
+    result = {
+        "data": [dict(r) for r in rows],
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/sources")
+    return result
+
+
+@router.get("/sources/{source_id}/performance")
+async def source_performance(
+    source_id: str,
+    period: str = Query("30d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Single source performance history. Open data — no auth."""
+    cache_key = f"source_perf:{source_id}:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    async with pool.acquire() as conn:
+        source = await conn.fetchrow(
+            """SELECT org.id::text, org.name, org.url,
+                      fs.health_status, fs.total_fetch_count, fs.total_error_count
+               FROM news.feed_source fs
+               JOIN news.news_media_organization org ON fs.organization_id = org.id
+               WHERE org.id::text = $1 OR fs.id::text = $1""",
+            source_id,
+        )
+        if not source:
+            return {"error": "Source not found"}, 404
+
+        daily_stats = await conn.fetch(
+            f"""SELECT DATE(a.datepublished) AS date,
+                       COUNT(*) AS articles,
+                       COALESCE(AVG(a.quality_score), 0) AS avg_quality,
+                       COALESCE(SUM(a.view_count), 0) AS views,
+                       COALESCE(SUM(a.like_count), 0) AS likes
+                FROM news.news_article a
+                WHERE a.publisher_organization_id::text = $1
+                  AND a.creativeworkstatus = 'published'
+                  AND a.datepublished >= NOW() - INTERVAL '{interval}'
+                GROUP BY DATE(a.datepublished)
+                ORDER BY date DESC""",
+            source_id,
+        )
+
+    result = {
+        "data": {
+            "source": dict(source),
+            "daily": [dict(r) for r in daily_stats],
+        },
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/sources/performance")
+    return result
+
+
+@router.get("/geo")
+async def geo_analytics(
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Geographic readership distribution. Open data — no auth."""
+    cache_key = f"geo:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT a.primary_location_country AS country,
+                       c.name AS country_name,
+                       c.flag_emoji,
+                       COUNT(a.id) AS article_count,
+                       COALESCE(SUM(a.view_count), 0) AS total_views,
+                       COALESCE(SUM(a.like_count), 0) AS total_likes,
+                       COALESCE(AVG(a.engagement_score), 0) AS avg_engagement
+                FROM news.news_article a
+                LEFT JOIN news.country c ON c.id = a.primary_location_country
+                WHERE a.creativeworkstatus = 'published'
+                  AND a.datepublished >= NOW() - INTERVAL '{interval}'
+                GROUP BY a.primary_location_country, c.name, c.flag_emoji
+                ORDER BY article_count DESC"""
+        )
+
+    result = {
+        "data": [dict(r) for r in rows],
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/geo")
+    return result
+
+
+@router.get("/categories")
+async def category_analytics(
+    period: str = Query("7d", regex="^(24h|7d|30d|90d)$"),
+):
+    """Category performance. Open data — no auth."""
+    cache_key = f"categories:{period}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+    interval = _period_to_interval(period)
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT ic.name AS category, ic.slug, ic.emoji,
+                       COUNT(a.id) AS article_count,
+                       COALESCE(SUM(a.view_count), 0) AS total_views,
+                       COALESCE(SUM(a.like_count), 0) AS total_likes,
+                       COALESCE(AVG(a.engagement_score), 0) AS avg_engagement,
+                       COALESCE(AVG(a.quality_score), 0) AS avg_quality
+                FROM news.news_article a
+                JOIN engagement.interest_category ic ON a.primary_interest_category_id = ic.id
+                WHERE a.creativeworkstatus = 'published'
+                  AND a.datepublished >= NOW() - INTERVAL '{interval}'
+                GROUP BY ic.name, ic.slug, ic.emoji
+                ORDER BY article_count DESC"""
+        )
+
+    result = {
+        "data": [dict(r) for r in rows],
+        "period": period,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/categories")
+    return result
+
+
+@router.get("/trending")
+async def trending_analytics(
+    period: str = Query("24h", regex="^(24h|7d|30d|90d)$"),
+    country: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+):
+    """Trending topics with scores. Open data — no auth."""
+    cache_key = f"trending:{period}:{country}:{limit}"
+    cached = _cache_get(cache_key)
+    if cached:
+        return cached
+
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        scope = "global"
+        params: list = [limit]
+        country_filter = ""
+
+        if country:
+            scope = country
+            country_filter = "AND scope = $2"
+            params.append(country)
+
+        rows = await conn.fetch(
+            f"""SELECT term_id AS id, term_name AS name, score,
+                       article_count, scope AS country
+                FROM news.trending_cache
+                WHERE scope = '{scope}'
+                  AND expires_at > NOW()
+                  {country_filter}
+                ORDER BY score DESC
+                LIMIT $1""",
+            *params,
+        )
+
+    result = {
+        "data": [dict(r) for r in rows],
+        "period": period,
+        "filters": {"country": country},
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _cache_set(cache_key, result)
+    get_analytics().track_open_data_access("/api/analytics/trending")
+    return result

--- a/fly-worker/src/api/articles.py
+++ b/fly-worker/src/api/articles.py
@@ -1,0 +1,202 @@
+"""Article endpoints — /api/article/:id, /api/article/:id/related."""
+
+import json
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+from src.api.feeds import _row_to_article, ARTICLE_SELECT, ARTICLE_FROM
+from src.services.couchdb import get_couchdb
+from src.services.analytics import get_analytics
+
+router = APIRouter(prefix="/api", tags=["articles"])
+
+
+@router.get("/article/{article_id}")
+async def get_article(
+    article_id: str = Path(...),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get a single article by ID or slug."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        # Try by UUID first, then slug
+        row = None
+        # UUID format check (simple heuristic)
+        if _is_uuid(article_id):
+            row = await conn.fetchrow(
+                f"""SELECT {ARTICLE_SELECT},
+                           a.articlebody AS article_body,
+                           a.article_body_processed,
+                           a.couchdb_doc_id
+                   {ARTICLE_FROM}
+                   WHERE a.id = $1::uuid""",
+                article_id,
+            )
+        if not row:
+            row = await conn.fetchrow(
+                f"""SELECT {ARTICLE_SELECT},
+                           a.articlebody AS article_body,
+                           a.article_body_processed,
+                           a.couchdb_doc_id
+                   {ARTICLE_FROM}
+                   WHERE a.slug = $1""",
+                article_id,
+            )
+
+        if not row:
+            raise HTTPException(status_code=404, detail="Article not found")
+
+        article = _row_to_article(row)
+
+        # Include full body — prefer CouchDB, fallback to Postgres
+        d = dict(row)
+        body = None
+        couchdb_id = d.get("couchdb_doc_id")
+        if couchdb_id:
+            try:
+                couch_doc = await get_couchdb().get_doc(couchdb_id)
+                if couch_doc:
+                    body = couch_doc.get("article_body_processed") or couch_doc.get("articlebody")
+            except Exception:
+                pass  # Fall through to Postgres
+        if not body:
+            body = d.get("article_body_processed") or d.get("article_body", "")
+        article["article_body"] = body
+
+        # Get keywords with full info
+        article_db_id = row["id"]
+        kw_rows = await conn.fetch(
+            """SELECT dt.id::text, dt.name, dt.term_code AS slug
+               FROM news.article_keyword ak
+               JOIN news.defined_term dt ON dt.id = ak.term_id
+               WHERE ak.article_id = $1::uuid
+               ORDER BY ak.relevance_score DESC
+               LIMIT 15""",
+            article_db_id,
+        )
+        if kw_rows:
+            article["keywords"] = [dict(r) for r in kw_rows]
+
+        # Increment view count (Postgres + Doris)
+        await conn.execute(
+            "UPDATE news.news_article SET view_count = view_count + 1, updated_at = NOW() WHERE id = $1::uuid",
+            article_db_id,
+        )
+        get_analytics().track_view(str(article_db_id))
+
+    return {"article": article}
+
+
+@router.get("/article/{article_id}/related")
+async def get_related_articles(
+    article_id: str = Path(...),
+    limit: int = Query(5, ge=1, le=20),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get articles related to the given article."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        # Get the source article
+        source = None
+        if _is_uuid(article_id):
+            source = await conn.fetchrow(
+                """SELECT id, primary_interest_category_id, primary_location_country,
+                          publisher_organization_id, keywords, headline
+                   FROM news.news_article WHERE id = $1::uuid""",
+                article_id,
+            )
+        if not source:
+            source = await conn.fetchrow(
+                """SELECT id, primary_interest_category_id, primary_location_country,
+                          publisher_organization_id, keywords, headline
+                   FROM news.news_article WHERE slug = $1""",
+                article_id,
+            )
+
+        if not source:
+            raise HTTPException(status_code=404, detail="Article not found")
+
+        source_id = source["id"]
+
+        # Strategy 1: Same keywords
+        kw_rows = await conn.fetch(
+            f"""SELECT DISTINCT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               JOIN news.article_keyword ak ON ak.article_id = a.id
+               WHERE ak.term_id IN (
+                   SELECT term_id FROM news.article_keyword WHERE article_id = $1
+               )
+               AND a.id != $1
+               AND a.creativeworkstatus = 'published'
+               ORDER BY a.datepublished DESC
+               LIMIT $2""",
+            source_id,
+            limit,
+        )
+
+        if len(kw_rows) < limit:
+            # Strategy 2: Same section and country
+            extra = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.primary_interest_category_id = $1
+                     AND a.primary_location_country = $2
+                     AND a.id != $3
+                     AND a.creativeworkstatus = 'published'
+                   ORDER BY a.datepublished DESC
+                   LIMIT $4""",
+                source["primary_interest_category_id"],
+                source["primary_location_country"],
+                source_id,
+                limit - len(kw_rows),
+            )
+            # Deduplicate
+            seen = {r["id"] for r in kw_rows}
+            for r in extra:
+                if r["id"] not in seen:
+                    kw_rows.append(r)
+                    seen.add(r["id"])
+
+    return {"related": [_row_to_article(r) for r in kw_rows[:limit]]}
+
+
+@router.get("/article/by-source-slug")
+async def get_article_by_source_slug(
+    source: str = Query(...),
+    slug: str = Query(...),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get article by source ID and slug combo."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            f"""SELECT {ARTICLE_SELECT},
+                       a.articlebody AS article_body,
+                       a.article_body_processed
+               {ARTICLE_FROM}
+               WHERE a.publisher_organization_id::text = $1 AND a.slug = $2 AND a.creativeworkstatus = 'published'
+               LIMIT 1""",
+            source,
+            slug,
+        )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    article = _row_to_article(row)
+    d = dict(row)
+    article["article_body"] = d.get("article_body_processed") or d.get("article_body", "")
+
+    return {"article": article}
+
+
+def _is_uuid(value: str) -> bool:
+    """Check if a string looks like a UUID."""
+    import re
+    return bool(re.match(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$', value))

--- a/fly-worker/src/api/auth.py
+++ b/fly-worker/src/api/auth.py
@@ -1,0 +1,112 @@
+"""API authentication — Stytch session tokens + Platform JWT.
+
+User auth: Stytch session tokens (validated via Stytch API)
+Service auth: PLATFORM_JWT (HS256, shared secret with mukoko-platform)
+Public reads: optional_auth (no token needed)
+"""
+
+from dataclasses import dataclass
+
+from fastapi import Header, HTTPException
+
+from src.config import settings
+from src.services.jwt import verify_jwt
+from src.services.stytch_client import get_stytch_client, is_stytch_configured
+
+
+@dataclass
+class AuthUser:
+    """Authenticated user context."""
+    user_id: str
+    email: str | None = None
+    role: str = "authenticated"
+    person_id: str | None = None
+
+
+async def require_auth(authorization: str = Header(default="")) -> AuthUser:
+    """Require a valid Stytch session or Platform JWT. Returns AuthUser or raises 401."""
+    if not settings.platform_jwt_secret and not is_stytch_configured():
+        if settings.environment == "production":
+            print("[AUTH] WARNING: No auth configured in production — rejecting request")
+            raise HTTPException(status_code=500, detail="Auth not configured")
+        return AuthUser(user_id="dev", role="admin")
+
+    token = _extract_bearer(authorization)
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    user = await _try_authenticate(token)
+    if user is not None:
+        return user
+
+    raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+
+async def require_admin(authorization: str = Header(default="")) -> AuthUser:
+    """Require admin role."""
+    user = await require_auth(authorization)
+    if user.role not in ("admin", "service_role"):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user
+
+
+async def require_service(authorization: str = Header(default="")) -> AuthUser:
+    """Require service-to-service JWT (from mukoko-platform)."""
+    user = await require_auth(authorization)
+    if user.role != "service_role":
+        raise HTTPException(status_code=403, detail="Service role required")
+    return user
+
+
+async def optional_auth(authorization: str = Header(default="")) -> AuthUser | None:
+    """Extract auth if present, but don't require it. Used for public reads."""
+    token = _extract_bearer(authorization)
+    if not token:
+        return None
+
+    return await _try_authenticate(token)
+
+
+async def _try_authenticate(token: str) -> AuthUser | None:
+    """Try to authenticate a token as Platform JWT or Stytch session."""
+    import asyncio
+
+    # Try Platform JWT first (service-to-service, fast local check)
+    if settings.platform_jwt_secret:
+        payload = verify_jwt(token)
+        if payload is not None:
+            return AuthUser(
+                user_id=payload.get("sub", ""),
+                email=payload.get("email"),
+                role=payload.get("role", "authenticated"),
+                person_id=payload.get("person_id"),
+            )
+
+    # Try Stytch session token (user auth, remote validation)
+    # Stytch SDK is synchronous — run in thread to avoid blocking event loop
+    if is_stytch_configured():
+        try:
+            client = get_stytch_client()
+            resp = await asyncio.to_thread(
+                client.sessions.authenticate, session_token=token
+            )
+            user = resp.user
+            return AuthUser(
+                user_id=user.user_id,
+                email=user.emails[0].email if user.emails else None,
+                role="authenticated",
+            )
+        except Exception as e:
+            print(f"[AUTH] Stytch session validation failed: {type(e).__name__}: {e}")
+
+    return None
+
+
+def _extract_bearer(auth_header: str) -> str | None:
+    """Extract bearer token from Authorization header."""
+    if not auth_header:
+        return None
+    parts = auth_header.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1]

--- a/fly-worker/src/api/auth_router.py
+++ b/fly-worker/src/api/auth_router.py
@@ -1,0 +1,243 @@
+"""Authentication router — Stytch Email OTP with session management.
+
+POST /api/auth/otp/email/send   — send OTP
+POST /api/auth/otp/email/verify — verify OTP, returns Stytch session token
+GET  /api/auth/me               — current user from session
+POST /api/auth/logout           — revoke Stytch session
+"""
+
+import asyncio
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from pydantic import BaseModel, EmailStr
+
+from src.api.auth import require_auth, AuthUser
+from src.config import settings
+from src.services.stytch_client import get_stytch_client, is_stytch_configured
+from src.db import get_pool
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+# ---------------------------------------------------------------------------
+# CSRF — Origin check (empty origin = curl/server-side, always allowed)
+# ---------------------------------------------------------------------------
+
+_PROD_ORIGINS = {
+    "https://news.mukoko.com",
+    "https://mukoko-news.vercel.app",
+}
+_DEV_ORIGINS = {"http://localhost:3000"}
+
+
+def _get_allowed_origins() -> set[str]:
+    origins = set(_PROD_ORIGINS)
+    if settings.environment != "production":
+        origins |= _DEV_ORIGINS
+    return origins
+
+
+def _check_origin(request: Request):
+    origin = request.headers.get("origin", "")
+    if origin and origin not in _get_allowed_origins():
+        raise HTTPException(status_code=403, detail="Invalid origin")
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter — Postgres-backed, distributed across instances
+# Max 3 OTP sends per email per 15 minutes
+# ---------------------------------------------------------------------------
+
+_OTP_RATE_LIMIT_MAX = 3
+_OTP_RATE_LIMIT_WINDOW_MINUTES = 15
+
+
+async def _check_otp_rate_limit(email: str):
+    """Check OTP rate limit using Postgres (works across Fly.io instances).
+
+    Fails closed: if the DB is unavailable, returns 503 rather than allowing the send.
+    """
+    try:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            count = await conn.fetchval(
+                """SELECT COUNT(*) FROM system.otp_rate_limit
+                   WHERE email = $1 AND attempted_at > NOW() - INTERVAL '15 minutes'""",
+                email,
+            )
+
+            if count >= _OTP_RATE_LIMIT_MAX:
+                raise HTTPException(
+                    status_code=429,
+                    detail="Too many verification code requests. Please wait before trying again.",
+                )
+
+            # Record this attempt
+            await conn.execute(
+                "INSERT INTO system.otp_rate_limit (email) VALUES ($1)",
+                email,
+            )
+
+            # Cleanup old entries
+            await conn.execute(
+                "DELETE FROM system.otp_rate_limit WHERE attempted_at < NOW() - INTERVAL '1 hour'"
+            )
+    except HTTPException:
+        raise  # Re-raise 429
+    except Exception as e:
+        # Fail closed — don't allow OTP sends if rate limiting is broken
+        print(f"[AUTH] Rate limit check failed (failing closed): {e}")
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class EmailOtpSendRequest(BaseModel):
+    email: EmailStr
+
+
+class EmailOtpVerifyRequest(BaseModel):
+    email: EmailStr
+    otp: str
+    full_name: str | None = None
+
+
+class AuthResponse(BaseModel):
+    session_token: str
+    is_new_user: bool
+    user: dict
+    person_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post("/otp/email/send")
+async def send_email_otp(body: EmailOtpSendRequest, request: Request):
+    """Send an email OTP via Stytch."""
+    _check_origin(request)
+
+    if not is_stytch_configured():
+        raise HTTPException(status_code=503, detail="Auth service not configured")
+
+    await _check_otp_rate_limit(body.email)
+
+    client = get_stytch_client()
+    try:
+        # Stytch SDK is synchronous — run in thread to avoid blocking event loop
+        await asyncio.to_thread(
+            client.otps.email.send,
+            email=body.email,
+            expiration_minutes=10,
+        )
+    except Exception as e:
+        print(f"[AUTH] OTP send failed: {e}")
+        raise HTTPException(status_code=500, detail="Failed to send verification code")
+
+    return {"message": "Verification code sent", "email": body.email}
+
+
+@router.post("/otp/email/verify", response_model=AuthResponse)
+async def verify_email_otp(body: EmailOtpVerifyRequest, request: Request):
+    """Verify email OTP — Stytch creates a session, we sync user to DB."""
+    _check_origin(request)
+
+    if not is_stytch_configured():
+        raise HTTPException(status_code=503, detail="Auth service not configured")
+
+    client = get_stytch_client()
+
+    # Verify OTP — Stytch creates a session automatically
+    try:
+        auth_response = await asyncio.to_thread(
+            client.otps.email.authenticate,
+            email=body.email,
+            code=body.otp,
+            session_duration_minutes=60 * 24 * 30,  # 30 days
+        )
+    except Exception as e:
+        print(f"[AUTH] OTP verify failed: {e}")
+        raise HTTPException(status_code=400, detail="Invalid or expired verification code")
+
+    stytch_user_id = auth_response.user_id
+    session_token = auth_response.session_token
+
+    # Sync user to our database
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id::text, name, email FROM identity.person WHERE stytch_user_id = $1",
+            stytch_user_id,
+        )
+
+        is_new_user = False
+        if not row:
+            row = await conn.fetchrow(
+                "SELECT id::text, name, email FROM identity.person WHERE email = $1",
+                body.email,
+            )
+            if row:
+                await conn.execute(
+                    "UPDATE identity.person SET stytch_user_id = $1, last_seen_at = NOW() WHERE id::text = $2",
+                    stytch_user_id, row["id"],
+                )
+            else:
+                row = await conn.fetchrow(
+                    """INSERT INTO identity.person (stytch_user_id, email, name, auth_method)
+                       VALUES ($1, $2, $3, 'email_otp')
+                       RETURNING id::text, name, email""",
+                    stytch_user_id, body.email, body.full_name,
+                )
+                is_new_user = True
+        else:
+            await conn.execute(
+                "UPDATE identity.person SET last_seen_at = NOW() WHERE stytch_user_id = $1",
+                stytch_user_id,
+            )
+
+    person_id = row["id"]
+
+    return AuthResponse(
+        session_token=session_token,
+        is_new_user=is_new_user,
+        user=dict(row),
+        person_id=person_id,
+    )
+
+
+@router.get("/me")
+async def get_me(user: AuthUser = Depends(require_auth)):
+    """Get current user profile from Stytch session."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT id::text, name, email, role FROM identity.person WHERE stytch_user_id = $1",
+            user.user_id,
+        )
+    if not row:
+        return {"user": {"id": user.user_id, "email": user.email, "role": user.role}}
+    return {"user": dict(row)}
+
+
+@router.post("/logout")
+async def logout(
+    request: Request,
+    user: AuthUser = Depends(require_auth),
+    authorization: str = Header(default=""),
+):
+    """Revoke Stytch session."""
+    _check_origin(request)
+
+    if is_stytch_configured() and authorization:
+        from src.api.auth import _extract_bearer
+        token = _extract_bearer(authorization)
+        try:
+            client = get_stytch_client()
+            await asyncio.to_thread(client.sessions.revoke, session_token=token)
+        except Exception as e:
+            print(f"[AUTH] Session revoke failed: {e}")
+    return {"message": "Logged out"}

--- a/fly-worker/src/api/authors.py
+++ b/fly-worker/src/api/authors.py
@@ -1,0 +1,140 @@
+"""Author endpoints — /api/authors, /api/author/:slug, /api/trending-authors, /api/featured-authors."""
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+from src.api.feeds import _row_to_article, ARTICLE_SELECT, ARTICLE_FROM
+
+router = APIRouter(prefix="/api", tags=["authors"])
+
+
+@router.get("/authors")
+async def get_authors(
+    limit: int = Query(20, ge=1, le=100),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get authors sorted by article count."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id, name, slug, description, job_title, works_for, image,
+                      article_count, total_views, verification_status
+               FROM identity.person
+               WHERE article_count > 0
+               ORDER BY article_count DESC
+               LIMIT $1""",
+            limit,
+        )
+
+    return {"authors": [dict(r) for r in rows]}
+
+
+@router.get("/author/{slug}")
+async def get_author(
+    slug: str = Path(...),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get author profile and their articles."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        author = await conn.fetchrow(
+            """SELECT id, name, slug, description, job_title, works_for, image,
+                      article_count, total_views, verification_status
+               FROM identity.person WHERE slug = $1 OR normalized_name = $1""",
+            slug,
+        )
+
+        if not author:
+            raise HTTPException(status_code=404, detail="Author not found")
+
+        articles = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               JOIN news.article_authorship aa ON aa.article_id = a.id
+               WHERE aa.person_id = $1
+                 AND a.creativeworkstatus = 'published'
+               ORDER BY a.datepublished DESC
+               LIMIT 20""",
+            author["id"],
+        )
+
+    return {
+        "author": dict(author),
+        "articles": [_row_to_article(r) for r in articles],
+    }
+
+
+@router.get("/search/authors")
+async def search_authors(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(20, ge=1, le=100),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Search authors by name."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id, name, slug, article_count
+               FROM identity.person
+               WHERE name ILIKE $1
+               ORDER BY article_count DESC
+               LIMIT $2""",
+            f"%{q}%",
+            limit,
+        )
+
+    return {"authors": [dict(r) for r in rows]}
+
+
+@router.get("/trending-authors")
+async def get_trending_authors(
+    limit: int = Query(5, ge=1, le=50),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get trending authors by recent article output (last 7 days)."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT p.id::text, p.name,
+                      COUNT(a.id) AS article_count
+               FROM identity.person p
+               JOIN news.article_authorship aa ON aa.person_id = p.id
+               JOIN news.news_article a ON a.id = aa.article_id
+               WHERE a.creativeworkstatus = 'published'
+                 AND a.datepublished >= NOW() - INTERVAL '7 days'
+               GROUP BY p.id, p.name
+               ORDER BY COUNT(a.id) DESC
+               LIMIT $1""",
+            limit,
+        )
+
+    return {
+        "trending_authors": [dict(r) for r in rows],
+        "timeframe": "7d",
+    }
+
+
+@router.get("/featured-authors")
+async def get_featured_authors(
+    limit: int = Query(5, ge=1, le=50),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get featured/top authors by total article count."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id::text, name, description AS bio, article_count
+               FROM identity.person
+               WHERE article_count > 0
+               ORDER BY article_count DESC
+               LIMIT $1""",
+            limit,
+        )
+
+    return {"authors": [dict(r) for r in rows]}

--- a/fly-worker/src/api/categories.py
+++ b/fly-worker/src/api/categories.py
@@ -1,0 +1,90 @@
+"""Category endpoints — /api/categories, /api/trending-categories."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+
+router = APIRouter(prefix="/api", tags=["categories"])
+
+
+@router.get("/categories")
+async def get_categories(
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get all enabled categories (interest categories) with article counts."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT ic.id, ic.name, ic.description, ic.emoji, ic.color_hex AS color,
+                      ic.sort_order,
+                      COUNT(a.id) AS article_count
+               FROM engagement.interest_category ic
+               LEFT JOIN news.news_article a ON a.primary_interest_category_id = ic.id AND a.creativeworkstatus = 'published'
+               WHERE ic.is_active = TRUE
+               GROUP BY ic.id, ic.name, ic.description, ic.emoji, ic.color_hex, ic.sort_order
+               ORDER BY ic.sort_order, ic.name"""
+        )
+
+    categories = [
+        {
+            "id": r["id"],
+            "name": r["name"],
+            "slug": r["id"],
+            "description": r.get("description"),
+            "emoji": r.get("emoji"),
+            "color": r.get("color"),
+            "article_count": r["article_count"],
+        }
+        for r in rows
+    ]
+
+    return {"categories": categories}
+
+
+@router.get("/trending-categories")
+async def get_trending_categories(
+    limit: int = Query(8, ge=1, le=50),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get trending categories ranked by recent article volume and growth."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT ic.id, ic.name, ic.id AS slug,
+                      COUNT(a.id) FILTER (WHERE a.datepublished >= NOW() - INTERVAL '7 days') AS article_count,
+                      COUNT(a.id) FILTER (WHERE a.datepublished >= NOW() - INTERVAL '7 days') AS recent_count,
+                      COUNT(a.id) FILTER (WHERE a.datepublished >= NOW() - INTERVAL '14 days'
+                                            AND a.datepublished < NOW() - INTERVAL '7 days') AS prev_count
+               FROM engagement.interest_category ic
+               LEFT JOIN news.news_article a ON a.primary_interest_category_id = ic.id AND a.creativeworkstatus = 'published'
+               WHERE ic.is_active = TRUE
+               GROUP BY ic.id, ic.name
+               HAVING COUNT(a.id) FILTER (WHERE a.datepublished >= NOW() - INTERVAL '7 days') > 0
+               ORDER BY COUNT(a.id) FILTER (WHERE a.datepublished >= NOW() - INTERVAL '7 days') DESC
+               LIMIT $1""",
+            limit,
+        )
+
+    trending = []
+    for r in rows:
+        recent = r["recent_count"] or 0
+        prev = r["prev_count"] or 0
+        growth_rate = ((recent - prev) / max(prev, 1)) * 100 if prev > 0 else (100.0 if recent > 0 else 0.0)
+        trending.append({
+            "id": r["id"],
+            "name": r["name"],
+            "slug": r["slug"],
+            "article_count": r["article_count"],
+            "growth_rate": round(growth_rate, 1),
+        })
+
+    return {
+        "success": True,
+        "trending": trending,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/fly-worker/src/api/deps.py
+++ b/fly-worker/src/api/deps.py
@@ -1,0 +1,11 @@
+"""Shared dependencies for API routes."""
+
+import asyncpg
+
+from src.db import get_pool
+
+
+async def get_conn() -> asyncpg.Connection:
+    """Acquire a connection from the pool. Used as a FastAPI dependency."""
+    pool = await get_pool()
+    return pool

--- a/fly-worker/src/api/engagement.py
+++ b/fly-worker/src/api/engagement.py
@@ -1,0 +1,115 @@
+"""User engagement endpoints — like, save, view, comments."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Body
+
+from src.db import get_pool
+from src.api.auth import require_auth, AuthUser
+from src.services.analytics import get_analytics
+
+router = APIRouter(prefix="/api", tags=["engagement"])
+
+
+@router.post("/articles/{article_id}/like")
+async def like_article(
+    article_id: str = Path(...),
+    _user: AuthUser = Depends(require_auth),
+):
+    """Toggle like on an article. Increments/decrements like_count."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        # Check article exists
+        exists = await conn.fetchval(
+            "SELECT 1 FROM news.news_article WHERE id = $1::uuid", article_id
+        )
+        if not exists:
+            raise HTTPException(status_code=404, detail="Article not found")
+
+        # For anonymous users, just increment (no toggle)
+        await conn.execute(
+            "UPDATE news.news_article SET like_count = like_count + 1, updated_at = NOW() WHERE id = $1::uuid",
+            article_id,
+        )
+        new_count = await conn.fetchval(
+            "SELECT like_count FROM news.news_article WHERE id = $1::uuid", article_id
+        )
+
+    get_analytics().track_like(article_id)
+    return {"success": True, "liked": True, "message": "Article liked", "likes": new_count}
+
+
+@router.post("/articles/{article_id}/save")
+async def save_article(
+    article_id: str = Path(...),
+    _user: AuthUser = Depends(require_auth),
+):
+    """Toggle save/bookmark on an article."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM news.news_article WHERE id = $1::uuid", article_id
+        )
+        if not exists:
+            raise HTTPException(status_code=404, detail="Article not found")
+
+        await conn.execute(
+            "UPDATE news.news_article SET bookmark_count = bookmark_count + 1, updated_at = NOW() WHERE id = $1::uuid",
+            article_id,
+        )
+        new_count = await conn.fetchval(
+            "SELECT bookmark_count FROM news.news_article WHERE id = $1::uuid", article_id
+        )
+
+    get_analytics().track_save(article_id)
+    return {"success": True, "saved": True, "message": "Article saved", "saves": new_count}
+
+
+@router.post("/articles/{article_id}/view")
+async def track_view(
+    article_id: str = Path(...),
+    body: dict = Body(default={}),
+    _user: AuthUser = Depends(require_auth),
+):
+    """Track article view with optional reading metrics."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        result = await conn.execute(
+            "UPDATE news.news_article SET view_count = view_count + 1, updated_at = NOW() WHERE id = $1::uuid",
+            article_id,
+        )
+        views = await conn.fetchval(
+            "SELECT view_count FROM news.news_article WHERE id = $1::uuid", article_id
+        )
+
+    get_analytics().track_view(article_id)
+    return {"success": True, "views": views or 0}
+
+
+@router.get("/articles/{article_id}/engagement")
+async def get_engagement(
+    article_id: str = Path(...),
+    _user: AuthUser = Depends(require_auth),
+):
+    """Get engagement counts for an article."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """SELECT like_count, bookmark_count, share_count, view_count
+               FROM news.news_article WHERE id = $1::uuid""",
+            article_id,
+        )
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    return {
+        "likes": row["like_count"] or 0,
+        "saves": row["bookmark_count"] or 0,
+        "shares": row["share_count"] or 0,
+        "views": row["view_count"] or 0,
+    }

--- a/fly-worker/src/api/feeds.py
+++ b/fly-worker/src/api/feeds.py
@@ -1,0 +1,413 @@
+"""Feed endpoints — /api/feeds, /api/feeds/sectioned, /api/news-bytes.
+
+These are the most critical endpoints: they power the homepage and all feed views.
+"""
+
+import json
+import re
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+
+router = APIRouter(prefix="/api", tags=["feeds"])
+
+# Common SELECT columns for article queries with aliases for backward compatibility
+ARTICLE_SELECT = """
+    a.id::text,
+    a.headline,
+    a.description,
+    a.slug,
+    a.mainentityofpage AS main_entity_of_page,
+    a.image->>'url' AS image,
+    a.author->>'name' AS author_name,
+    a.publisher_organization_id::text AS publisher_id,
+    a.publisher->>'name' AS publisher_name,
+    a.articlesection AS article_section_id,
+    a.primary_location_country AS about_country_id,
+    a.datepublished AS date_published,
+    a.datemodified AS date_modified,
+    a.wordcount AS word_count,
+    a.reading_time_minutes,
+    a.inlanguage AS in_language,
+    a.keywords,
+    a.view_count, a.like_count, a.bookmark_count,
+    a.comment_count, a.share_count,
+    a.quality_score, a.engagement_score,
+    a.content_type,
+    CASE WHEN a.is_breaking THEN 'breaking'
+         WHEN a.is_featured THEN 'urgent'
+         ELSE 'standard' END AS urgency,
+    a.creativeworkstatus,
+    ic.name AS section_name,
+    ic.emoji AS section_emoji,
+    ic.color_hex AS section_color
+"""
+
+ARTICLE_FROM = """
+    FROM news.news_article a
+    LEFT JOIN engagement.interest_category ic ON a.primary_interest_category_id = ic.id
+"""
+
+
+@router.get("/feeds")
+async def get_feeds(
+    limit: int = Query(24, ge=1, le=100),
+    page: int = Query(1, ge=1),
+    category: str | None = Query(None),
+    countries: str | None = Query(None),
+    sort: str = Query("latest"),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get articles feed with filtering and pagination."""
+    pool = await get_pool()
+    offset = (page - 1) * limit
+
+    async with pool.acquire() as conn:
+        # Build query
+        conditions = ["a.creativeworkstatus = 'published'"]
+        params: list = []
+        idx = 1
+
+        if category and category != "all":
+            conditions.append(f"a.articlesection = ${idx}")
+            params.append(category)
+            idx += 1
+
+        if countries:
+            country_list = [c.strip() for c in countries.split(",") if c.strip()]
+            if country_list:
+                placeholders = ", ".join(f"${idx + i}" for i in range(len(country_list)))
+                conditions.append(f"a.primary_location_country IN ({placeholders})")
+                params.extend(country_list)
+                idx += len(country_list)
+
+        where = " AND ".join(conditions)
+
+        # Sort order
+        order_by = {
+            "latest": "a.datepublished DESC",
+            "trending": "a.trending_score DESC, a.datepublished DESC",
+            "popular": "a.engagement_score DESC, a.datepublished DESC",
+        }.get(sort, "a.datepublished DESC")
+
+        # Count total
+        total = await conn.fetchval(
+            f"SELECT COUNT(*) FROM news.news_article a WHERE {where}", *params
+        )
+
+        # Fetch articles
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+                {ARTICLE_FROM}
+                WHERE {where}
+                ORDER BY {order_by}
+                LIMIT ${idx} OFFSET ${idx + 1}""",
+            *params,
+            limit,
+            offset,
+        )
+
+    articles = [_row_to_article(row) for row in rows]
+
+    return {
+        "articles": articles,
+        "pagination": {
+            "page": page,
+            "limit": limit,
+            "total": total or 0,
+        },
+    }
+
+
+@router.get("/feeds/sectioned")
+async def get_sectioned_feed(
+    countries: str | None = Query(None),
+    categories: str | None = Query(None),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Sectioned feed: top stories, your news, by category, latest."""
+    pool = await get_pool()
+
+    country_list = (
+        [c.strip() for c in countries.split(",") if c.strip()] if countries else []
+    )
+    category_list = (
+        [c.strip() for c in categories.split(",") if c.strip()] if categories else []
+    )
+
+    async with pool.acquire() as conn:
+        # Top stories: highest engagement in last 48h
+        if country_list:
+            top_rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.creativeworkstatus = 'published'
+                     AND a.datepublished >= NOW() - INTERVAL '48 hours'
+                     AND a.primary_location_country = ANY($1::text[])
+                   ORDER BY a.engagement_score DESC, a.datepublished DESC
+                   LIMIT 20""",
+                country_list,
+            )
+        else:
+            top_rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.creativeworkstatus = 'published'
+                     AND a.datepublished >= NOW() - INTERVAL '48 hours'
+                   ORDER BY a.engagement_score DESC, a.datepublished DESC
+                   LIMIT 20"""
+            )
+
+        top_stories = _cluster_articles([_row_to_article(r) for r in top_rows])
+
+        # Latest articles
+        if country_list:
+            latest_rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.creativeworkstatus = 'published'
+                     AND a.primary_location_country = ANY($1::text[])
+                   ORDER BY a.datepublished DESC
+                   LIMIT 24""",
+                country_list,
+            )
+        else:
+            latest_rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.creativeworkstatus = 'published'
+                   ORDER BY a.datepublished DESC
+                   LIMIT 24"""
+            )
+        latest = [_row_to_article(r) for r in latest_rows]
+
+        # By category
+        by_category = []
+        sections = await conn.fetch(
+            "SELECT id, name FROM engagement.interest_category WHERE is_active = TRUE ORDER BY sort_order"
+        )
+        for section in sections:
+            section_id = section["id"]
+            if category_list and section_id not in category_list:
+                continue
+
+            if country_list:
+                cat_rows = await conn.fetch(
+                    f"""SELECT {ARTICLE_SELECT}
+                       {ARTICLE_FROM}
+                       WHERE a.creativeworkstatus = 'published'
+                         AND a.primary_interest_category_id = $1
+                         AND a.primary_location_country = ANY($2::text[])
+                       ORDER BY a.datepublished DESC
+                       LIMIT 6""",
+                    section_id,
+                    country_list,
+                )
+            else:
+                cat_rows = await conn.fetch(
+                    f"""SELECT {ARTICLE_SELECT}
+                       {ARTICLE_FROM}
+                       WHERE a.creativeworkstatus = 'published'
+                         AND a.primary_interest_category_id = $1
+                       ORDER BY a.datepublished DESC
+                       LIMIT 6""",
+                    section_id,
+                )
+
+            if cat_rows:
+                by_category.append({
+                    "id": section_id,
+                    "name": section["name"],
+                    "articles": [_row_to_article(r) for r in cat_rows],
+                })
+
+    return {
+        "topStories": top_stories,
+        "yourNews": latest[:12] if country_list else [],
+        "byCategory": by_category,
+        "latest": latest,
+        "countries": country_list,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/news-bytes")
+async def get_news_bytes(
+    limit: int = Query(20, ge=1, le=50),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """NewsBytes: short-form articles for TikTok-style feed."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               WHERE a.creativeworkstatus = 'published'
+                 AND a.content_type = 'news-byte'
+               ORDER BY a.datepublished DESC
+               LIMIT $1""",
+            limit,
+        )
+
+        # Fallback: short articles if no explicit news-bytes
+        if not rows:
+            rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT}
+                   {ARTICLE_FROM}
+                   WHERE a.creativeworkstatus = 'published'
+                     AND a.wordcount <= 200
+                     AND a.image IS NOT NULL
+                   ORDER BY a.datepublished DESC
+                   LIMIT $1""",
+                limit,
+            )
+
+    return {"articles": [_row_to_article(r) for r in rows]}
+
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+
+def _row_to_article(row) -> dict:
+    """Convert a database row to the Article response dict."""
+    d = dict(row)
+
+    # keywords is now TEXT[] from asyncpg — comes as a Python list directly
+    keywords = d.get("keywords")
+    if isinstance(keywords, str):
+        try:
+            keywords = json.loads(keywords)
+        except (json.JSONDecodeError, TypeError):
+            keywords = []
+    elif keywords is None:
+        keywords = []
+
+    # Format keywords as objects for frontend
+    if keywords and isinstance(keywords, list):
+        if keywords and isinstance(keywords[0], str):
+            keywords = [
+                {"id": _slugify(k), "name": k, "slug": _slugify(k)}
+                for k in keywords
+            ]
+
+    # Build response
+    article = {
+        "id": str(d["id"]),
+        "headline": d.get("headline", ""),
+        "description": d.get("description", ""),
+        "slug": d.get("slug", ""),
+        "main_entity_of_page": d.get("main_entity_of_page", ""),
+        "image": d.get("image"),
+        "author_name": d.get("author_name"),
+        "publisher_id": d.get("publisher_id"),
+        "publisher_name": d.get("publisher_name"),
+        "article_section_id": d.get("article_section_id"),
+        "about_country_id": d.get("about_country_id"),
+        "date_published": _isoformat(d.get("date_published")),
+        "date_modified": _isoformat(d.get("date_modified")),
+        "word_count": d.get("word_count", 0),
+        "reading_time_minutes": d.get("reading_time_minutes", 0),
+        "in_language": d.get("in_language", "en"),
+        "keywords": keywords,
+        "view_count": d.get("view_count", 0),
+        "like_count": d.get("like_count", 0),
+        "bookmark_count": d.get("bookmark_count", 0),
+        "comment_count": d.get("comment_count", 0),
+        "quality_score": d.get("quality_score", 0),
+        "engagement_score": d.get("engagement_score", 0),
+        "content_type": d.get("content_type", "article"),
+        "urgency": d.get("urgency", "standard"),
+        "creativeworkstatus": d.get("creativeworkstatus", "published"),
+    }
+
+    # Include section info if available
+    if d.get("section_name"):
+        article["section_name"] = d["section_name"]
+        article["section_emoji"] = d.get("section_emoji")
+        article["section_color"] = d.get("section_color")
+
+    return article
+
+
+def _isoformat(dt) -> str | None:
+    """Safely convert datetime to ISO string."""
+    if dt is None:
+        return None
+    if isinstance(dt, datetime):
+        return dt.isoformat()
+    return str(dt)
+
+
+def _slugify(text: str) -> str:
+    """Generate URL-safe slug."""
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    return slug[:100].strip("-")
+
+
+def _cluster_articles(articles: list[dict], threshold: float = 0.4) -> list[dict]:
+    """Simple title-based clustering using Jaccard similarity."""
+    if not articles:
+        return []
+
+    clusters: list[dict] = []
+    used = set()
+
+    for i, article in enumerate(articles):
+        if i in used:
+            continue
+
+        cluster = {
+            "id": article["id"],
+            "primaryArticle": article,
+            "relatedArticles": [],
+            "articleCount": 1,
+        }
+
+        words_i = _title_words(article.get("headline", ""))
+
+        for j in range(i + 1, len(articles)):
+            if j in used:
+                continue
+            words_j = _title_words(articles[j].get("headline", ""))
+            if _jaccard(words_i, words_j) >= threshold:
+                cluster["relatedArticles"].append(articles[j])
+                cluster["articleCount"] += 1
+                used.add(j)
+
+        used.add(i)
+        clusters.append(cluster)
+
+    return clusters[:10]
+
+
+_STOP_WORDS = {
+    "the", "a", "an", "and", "or", "but", "in", "on", "at", "to", "for",
+    "of", "with", "by", "from", "is", "are", "was", "were", "has", "have",
+    "had", "be", "been", "being", "will", "would", "could", "should", "may",
+    "might", "shall", "can", "do", "does", "did", "not", "no", "its", "it",
+    "this", "that", "these", "those", "as", "if", "than", "then", "so",
+    "up", "out", "about", "into", "over", "after", "before",
+}
+
+
+def _title_words(title: str) -> set[str]:
+    """Normalize title to a set of meaningful words."""
+    words = re.sub(r"[^\w\s]", "", title.lower()).split()
+    return {w for w in words if w not in _STOP_WORDS and len(w) > 2}
+
+
+def _jaccard(a: set, b: set) -> float:
+    """Jaccard similarity between two sets."""
+    if not a or not b:
+        return 0.0
+    intersection = len(a & b)
+    union = len(a | b)
+    return intersection / union if union > 0 else 0.0

--- a/fly-worker/src/api/platform_sync.py
+++ b/fly-worker/src/api/platform_sync.py
@@ -1,0 +1,77 @@
+"""Platform sync — push/pull data with mukoko-platform.
+
+Uses Fly.io internal networking (.internal) when both apps are deployed.
+Falls back to public URL via PLATFORM_API_URL config.
+"""
+
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Body
+
+from src.api.auth import require_service, AuthUser
+from src.config import settings
+from src.services.jwt import create_jwt
+
+router = APIRouter(prefix="/api/platform", tags=["platform-sync"])
+
+# Only send service JWTs to trusted hosts
+_ALLOWED_PLATFORM_HOSTS = {
+    "mukoko-platform-api.internal",  # Fly.io internal
+    "api.mukoko.com",
+    "localhost",
+}
+
+
+def _validate_platform_url():
+    """Ensure PLATFORM_API_URL points to a trusted host."""
+    parsed = urlparse(settings.platform_api_url)
+    hostname = parsed.hostname or ""
+    if hostname not in _ALLOWED_PLATFORM_HOSTS:
+        raise RuntimeError(
+            f"PLATFORM_API_URL hostname '{hostname}' not in allowlist. "
+            f"Refusing to send service JWT to untrusted host."
+        )
+
+
+def _get_platform_headers() -> dict:
+    """Build auth headers for mukoko-platform API calls."""
+    _validate_platform_url()
+    token = create_jwt("mukoko-news-service", role="service_role")
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+@router.post("/push/articles")
+async def push_articles(
+    articles: list[dict] = Body(...),
+    _user: AuthUser = Depends(require_service),
+):
+    """Push processed articles to mukoko-platform."""
+    url = f"{settings.platform_api_url}/api/content/articles/bulk"
+    headers = _get_platform_headers()
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        try:
+            resp = await client.post(url, json={"articles": articles}, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=502, detail=f"Platform sync failed: {e}")
+
+
+@router.get("/pull/identity/{person_id}")
+async def pull_identity(
+    person_id: str,
+    _user: AuthUser = Depends(require_service),
+):
+    """Pull identity data from mukoko-platform."""
+    url = f"{settings.platform_api_url}/identity/person/{person_id}"
+    headers = _get_platform_headers()
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        try:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=502, detail=f"Platform pull failed: {e}")

--- a/fly-worker/src/api/search.py
+++ b/fly-worker/src/api/search.py
@@ -1,0 +1,282 @@
+"""Search endpoints — /api/search, /api/keywords.
+
+Search is a three-tier funnel:
+1. Semantic search via BGE-M3 embeddings (pgvector cosine similarity)
+2. Doris inverted index (full-text narrowing)
+3. Postgres ILIKE (fallback when both are unavailable)
+
+Each tier falls through to the next if unavailable or returns no results.
+"""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+from src.api.feeds import _row_to_article, ARTICLE_SELECT, ARTICLE_FROM
+from src.services.doris import get_doris
+from src.services.analytics import get_analytics
+from src.services.embeddings import embed_text
+
+router = APIRouter(prefix="/api", tags=["search"])
+
+
+@router.get("/search")
+async def search_articles(
+    q: str = Query(..., min_length=1),
+    limit: int = Query(10, ge=1, le=50),
+    category: str | None = Query(None),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Search articles. Funnel: Semantic (BGE-M3) → Doris → Postgres ILIKE."""
+    pool = await get_pool()
+    articles = []
+    search_method = "keyword"
+    total = 0
+
+    # Tier 1: Semantic search via BGE-M3 embeddings
+    semantic_results = await _semantic_search(pool, q, limit, category)
+    if semantic_results is not None:
+        search_method = "semantic"
+        articles, total = semantic_results
+    else:
+        # Tier 2: Doris inverted index
+        doris_ids = await _doris_search(q, limit, category)
+        if doris_ids is not None:
+            search_method = "doris_funnel"
+            articles, total = await _hydrate_from_postgres(pool, doris_ids, len(doris_ids))
+        else:
+            # Tier 3: Postgres ILIKE fallback
+            articles, total = await _postgres_search(pool, q, limit, category)
+
+    # Track search in analytics
+    get_analytics().track_search(q, total, category=category or "")
+
+    return {
+        "results": articles,
+        "articles": articles,
+        "query": q,
+        "count": total,
+        "category": category or "all",
+        "searchMethod": search_method,
+        "pagination": {
+            "page": 1,
+            "limit": limit,
+            "total": total,
+        },
+    }
+
+
+async def _semantic_search(
+    pool, query: str, limit: int, category: str | None
+) -> tuple[list[dict], int] | None:
+    """Tier 1: Semantic search using BGE-M3 embeddings and pgvector cosine similarity.
+
+    Returns (articles, total) or None if embeddings are unavailable.
+    """
+    # Generate query embedding
+    query_embedding = await embed_text(query)
+    if query_embedding is None:
+        return None
+
+    embedding_str = "[" + ",".join(str(v) for v in query_embedding) + "]"
+
+    try:
+        async with pool.acquire() as conn:
+            # Build optional category filter
+            category_clause = ""
+            params: list = [embedding_str, limit]
+            if category and category != "all":
+                category_clause = "AND a.articlesection = $3"
+                params.append(category)
+
+            rows = await conn.fetch(
+                f"""SELECT {ARTICLE_SELECT},
+                           1 - (a.embedding_vector <=> $1::vector) AS similarity
+                    {ARTICLE_FROM}
+                    WHERE a.creativeworkstatus = 'published'
+                      AND a.embedding_vector IS NOT NULL
+                      {category_clause}
+                    ORDER BY a.embedding_vector <=> $1::vector
+                    LIMIT $2""",
+                *params,
+            )
+
+            if not rows:
+                return None  # Fall through to Doris
+
+            # Count total matches (approximate — articles with embeddings)
+            total = len(rows)
+
+        return [_row_to_article(r) for r in rows], total
+
+    except Exception as e:
+        # pgvector not available or query failed — fall through
+        print(f"[SEARCH] Semantic search error: {e}")
+        return None
+
+
+async def _doris_search(query: str, limit: int, category: str | None) -> list[str] | None:
+    """Query Doris inverted index. Returns article IDs or None if unavailable."""
+    doris = get_doris()
+    try:
+        if not await doris.ping():
+            return None
+
+        # Escape single quotes for SQL safety
+        safe_q = query.replace("'", "\\'")
+
+        # Build WHERE clause
+        conditions = [f"MATCH_ANY(headline, '{safe_q}') OR MATCH_ANY(description, '{safe_q}') OR MATCH_ANY(keywords, '{safe_q}')"]
+        if category and category != "all":
+            safe_cat = category.replace("'", "\\'")
+            conditions.append(f"category = '{safe_cat}'")
+
+        where = " AND ".join(f"({c})" for c in conditions)
+
+        sql = f"""
+            SELECT article_id
+            FROM mukoko_analytics.article_search
+            WHERE {where}
+            ORDER BY engagement_score DESC, datepublished DESC
+            LIMIT {int(limit)}
+        """
+
+        rows = await doris.query(sql)
+        if rows:
+            return [r["article_id"] for r in rows]
+        return []
+
+    except Exception as e:
+        print(f"[SEARCH] Doris search error: {e}")
+        return None
+
+
+async def _hydrate_from_postgres(pool, article_ids: list[str], limit: int) -> tuple[list[dict], int]:
+    """Fetch full article metadata from Postgres for the given IDs, preserving order."""
+    if not article_ids:
+        return [], 0
+
+    async with pool.acquire() as conn:
+        # Build placeholders: $1, $2, $3...
+        placeholders = ", ".join(f"${i+1}::uuid" for i in range(len(article_ids)))
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+                {ARTICLE_FROM}
+                WHERE a.id IN ({placeholders})
+                AND a.creativeworkstatus = 'published'""",
+            *article_ids,
+        )
+
+    # Preserve Doris ranking order
+    row_map = {str(r["id"]): r for r in rows}
+    ordered = [row_map[aid] for aid in article_ids if aid in row_map]
+
+    return [_row_to_article(r) for r in ordered], len(ordered)
+
+
+async def _postgres_search(pool, query: str, limit: int, category: str | None) -> tuple[list[dict], int]:
+    """Fallback: Postgres ILIKE search."""
+    search_term = f"%{query}%"
+
+    async with pool.acquire() as conn:
+        conditions = [
+            "a.creativeworkstatus = 'published'",
+            "(a.headline ILIKE $1 OR a.description ILIKE $1)",
+        ]
+        params: list = [search_term]
+        idx = 2
+
+        if category and category != "all":
+            conditions.append(f"a.articlesection = ${idx}")
+            params.append(category)
+            idx += 1
+
+        where = " AND ".join(conditions)
+
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+                {ARTICLE_FROM}
+                WHERE {where}
+                ORDER BY a.datepublished DESC
+                LIMIT ${idx}""",
+            *params,
+            limit,
+        )
+
+        total = await conn.fetchval(
+            f"SELECT COUNT(*) FROM news.news_article a WHERE {where}",
+            *params,
+        )
+
+    return [_row_to_article(r) for r in rows], total or 0
+
+
+@router.get("/search/by-keyword/{keyword}")
+async def search_by_keyword(
+    keyword: str,
+    limit: int = Query(24, ge=1, le=100),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get articles tagged with a specific keyword/term."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               JOIN news.article_keyword ak ON ak.article_id = a.id
+               WHERE ak.term_id = $1
+                 AND a.creativeworkstatus = 'published'
+               ORDER BY a.datepublished DESC
+               LIMIT $2""",
+            keyword,
+            limit,
+        )
+
+    return {"articles": [_row_to_article(r) for r in rows], "keyword": keyword}
+
+
+@router.get("/keywords")
+async def get_keywords(
+    limit: int = Query(32, ge=1, le=100),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get trending keywords/topics for tag cloud."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        # Try trending cache first
+        rows = await conn.fetch(
+            """SELECT term_id AS id, term_name AS name, term_id AS slug,
+                      'keyword' AS type, article_count
+               FROM news.trending_cache
+               WHERE scope = 'global'
+                 AND expires_at > NOW()
+               ORDER BY score DESC
+               LIMIT $1""",
+            limit,
+        )
+
+        if not rows:
+            # Fallback: direct keyword count
+            rows = await conn.fetch(
+                """SELECT dt.id, dt.name, dt.term_code AS slug,
+                          dt.term_type AS type, dt.article_count
+                   FROM news.defined_term dt
+                   WHERE dt.enabled = TRUE
+                     AND dt.article_count > 0
+                   ORDER BY dt.article_count DESC
+                   LIMIT $1""",
+                limit,
+            )
+
+        total = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.defined_term WHERE enabled = TRUE AND article_count > 0"
+        )
+
+    return {
+        "keywords": [dict(r) for r in rows],
+        "total": total or 0,
+    }

--- a/fly-worker/src/api/sources.py
+++ b/fly-worker/src/api/sources.py
@@ -1,0 +1,134 @@
+"""Source endpoints — /api/sources, /api/countries."""
+
+from fastapi import APIRouter, Depends, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+
+router = APIRouter(prefix="/api", tags=["sources"])
+
+
+@router.get("/sources")
+async def get_sources(
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get all enabled news sources with article counts."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT org.id::text, org.name, org.url,
+                      fs.feed_url AS rss_feed_url, fs.area_served,
+                      fs.article_section_id, fs.health_status, fs.priority,
+                      fs.last_fetched_at, fs.total_fetch_count, fs.total_error_count,
+                      fs.last_fetch_error,
+                      COUNT(a.id) AS article_count,
+                      MAX(a.datepublished) AS latest_article_at
+               FROM news.feed_source fs
+               JOIN news.news_media_organization org ON fs.organization_id = org.id
+               LEFT JOIN news.news_article a ON a.publisher_organization_id = org.id AND a.creativeworkstatus = 'published'
+               WHERE fs.is_active = TRUE
+               GROUP BY org.id, org.name, org.url,
+                        fs.feed_url, fs.area_served, fs.article_section_id,
+                        fs.health_status, fs.priority, fs.last_fetched_at,
+                        fs.total_fetch_count, fs.total_error_count, fs.last_fetch_error
+               ORDER BY fs.priority DESC, org.name"""
+        )
+
+    sources = []
+    for r in rows:
+        sources.append({
+            "id": r["id"],
+            "name": r["name"],
+            "url": r.get("url"),
+            "rss_feed_url": r.get("rss_feed_url"),
+            "area_served": r.get("area_served"),
+            "article_section_id": r.get("article_section_id"),
+            "health_status": r.get("health_status", "unknown"),
+            "priority": r.get("priority", 0),
+            "last_fetched_at": r["last_fetched_at"].isoformat() if r.get("last_fetched_at") else None,
+            "total_fetch_count": r.get("total_fetch_count", 0),
+            "total_error_count": r.get("total_error_count", 0),
+            "last_error": r.get("last_fetch_error"),
+            "article_count": r["article_count"],
+            "latest_article_at": r["latest_article_at"].isoformat() if r.get("latest_article_at") else None,
+        })
+
+    return {"sources": sources, "total": len(sources)}
+
+
+@router.get("/countries")
+async def get_countries(
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get all enabled countries."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id, name, flag_emoji, color, region, in_language, timezone, priority
+               FROM news.country
+               WHERE enabled = TRUE
+               ORDER BY priority DESC, name"""
+        )
+
+    countries = [
+        {
+            "id": r["id"],
+            "code": r["id"],
+            "name": r["name"],
+            "flag_emoji": r.get("flag_emoji"),
+            "color": r.get("color"),
+            "region": r.get("region"),
+            "in_language": r.get("in_language"),
+            "timezone": r.get("timezone"),
+        }
+        for r in rows
+    ]
+
+    return {"countries": countries}
+
+
+@router.get("/countries/{country_id}")
+async def get_country(
+    country_id: str,
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get a single country."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT * FROM news.country WHERE id = $1", country_id
+        )
+
+    if not row:
+        return {"error": "Country not found"}, 404
+
+    return {
+        "country": {
+            "id": row["id"],
+            "code": row["id"],
+            "name": row["name"],
+            "flag_emoji": row.get("flag_emoji"),
+        }
+    }
+
+
+@router.get("/countries/stats/articles")
+async def get_country_article_stats(
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get article counts per country."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT primary_location_country AS country_id, COUNT(*) AS article_count
+               FROM news.news_article
+               WHERE creativeworkstatus = 'published'
+               GROUP BY primary_location_country
+               ORDER BY article_count DESC"""
+        )
+
+    return {"stats": [dict(r) for r in rows]}

--- a/fly-worker/src/api/stats.py
+++ b/fly-worker/src/api/stats.py
@@ -1,0 +1,80 @@
+"""Stats and health endpoints — /api/health, /api/stats."""
+
+import time
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+
+router = APIRouter(prefix="/api", tags=["stats"])
+
+
+@router.get("/health")
+async def health_check():
+    """Public health check — no auth required."""
+    pool = await get_pool()
+    db_ok = False
+    try:
+        async with pool.acquire() as conn:
+            await conn.fetchval("SELECT 1")
+            db_ok = True
+    except Exception:
+        pass
+
+    # CouchDB status
+    from src.services.couchdb import get_couchdb
+    couch_ok = False
+    try:
+        couch_ok = await get_couchdb().ping()
+    except Exception:
+        pass
+
+    # Doris status
+    from src.services.doris import get_doris
+    doris_ok = False
+    try:
+        doris_ok = await get_doris().ping()
+    except Exception:
+        pass
+
+    return {
+        "status": "healthy" if db_ok else "degraded",
+        "database": "connected" if db_ok else "disconnected",
+        "couchdb": "connected" if couch_ok else "disconnected",
+        "doris": "connected" if doris_ok else "disconnected",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/stats")
+async def get_stats(
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get database statistics for dashboard."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        total_articles = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.news_article WHERE creativeworkstatus = 'published'"
+        )
+        active_sources = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.feed_source WHERE is_active = TRUE"
+        )
+        categories = await conn.fetchval(
+            "SELECT COUNT(*) FROM engagement.interest_category WHERE is_active = TRUE"
+        )
+        today_articles = await conn.fetchval(
+            "SELECT COUNT(*) FROM news.news_article WHERE creativeworkstatus = 'published' AND datepublished >= CURRENT_DATE"
+        )
+
+    return {
+        "database": {
+            "total_articles": total_articles or 0,
+            "active_sources": active_sources or 0,
+            "categories": categories or 0,
+            "today_articles": today_articles or 0,
+        },
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }

--- a/fly-worker/src/api/stories.py
+++ b/fly-worker/src/api/stories.py
@@ -1,0 +1,89 @@
+"""Story clustering and trending endpoints."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Path, Query
+
+from src.db import get_pool
+from src.api.auth import optional_auth, AuthUser
+from src.api.feeds import _row_to_article, _cluster_articles, ARTICLE_SELECT, ARTICLE_FROM
+
+router = APIRouter(prefix="/api", tags=["stories"])
+
+
+@router.get("/stories/trending")
+async def get_trending_stories(
+    limit: int = Query(10, ge=1, le=50),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get trending story clusters from the last 48h."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               WHERE a.creativeworkstatus = 'published'
+                 AND a.datepublished >= NOW() - INTERVAL '48 hours'
+               ORDER BY a.engagement_score DESC, a.datepublished DESC
+               LIMIT $1""",
+            limit * 3,  # Fetch extra for clustering
+        )
+
+    articles = [_row_to_article(r) for r in rows]
+    clusters = _cluster_articles(articles)
+
+    stories = []
+    for cluster in clusters[:limit]:
+        stories.append({
+            "id": cluster["id"],
+            "headline": cluster["primaryArticle"]["headline"],
+            "article_count": cluster["articleCount"],
+            "latest_article": cluster["primaryArticle"],
+        })
+
+    return {"stories": stories}
+
+
+@router.get("/stories/cluster/{article_id}")
+async def get_story_cluster(
+    article_id: str = Path(...),
+    _user: AuthUser | None = Depends(optional_auth),
+):
+    """Get all articles in the same story cluster as the given article."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        # Get the source article
+        source = await conn.fetchrow(
+            "SELECT id, headline, primary_interest_category_id FROM news.news_article WHERE id = $1::uuid",
+            article_id,
+        )
+        if not source:
+            return {"cluster": None}
+
+        # Find similar articles by shared keywords
+        rows = await conn.fetch(
+            f"""SELECT {ARTICLE_SELECT}
+               {ARTICLE_FROM}
+               WHERE a.creativeworkstatus = 'published'
+                 AND a.primary_interest_category_id = $1
+                 AND a.datepublished >= NOW() - INTERVAL '72 hours'
+               ORDER BY a.datepublished DESC
+               LIMIT 30""",
+            source["primary_interest_category_id"],
+        )
+
+    articles = [_row_to_article(r) for r in rows]
+    clusters = _cluster_articles(articles)
+
+    # Find the cluster containing our article
+    target_id = str(article_id)
+    for cluster in clusters:
+        if cluster["primaryArticle"]["id"] == target_id:
+            return {"cluster": cluster}
+        for related in cluster["relatedArticles"]:
+            if related["id"] == target_id:
+                return {"cluster": cluster}
+
+    return {"cluster": None}

--- a/fly-worker/src/api/user.py
+++ b/fly-worker/src/api/user.py
@@ -1,0 +1,23 @@
+"""User endpoints — /api/user/*.
+
+These endpoints require user authentication (OIDC JWT from id.mukoko.com).
+Until OIDC validation is implemented, they return empty results gracefully.
+"""
+
+from fastapi import APIRouter, Depends
+
+from src.api.auth import require_auth, AuthUser
+
+router = APIRouter(prefix="/api/user", tags=["user"])
+
+
+@router.get("/bookmarks")
+async def get_bookmarks(
+    _user: AuthUser = Depends(require_auth),
+):
+    """Get user's saved/bookmarked articles.
+
+    TODO: Implement per-user bookmarks once OIDC JWT validation is added.
+    Currently returns empty list since there's no user identity context.
+    """
+    return {"articles": [], "total": 0}

--- a/fly-worker/src/config.py
+++ b/fly-worker/src/config.py
@@ -1,0 +1,52 @@
+"""Application configuration loaded from environment variables."""
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Fly.io worker settings. All secrets set via `fly secrets set`."""
+
+    # Database — Supabase direct connection
+    database_url: str = "postgresql://localhost:5432/mukoko_news"
+
+    # AI services
+    anthropic_api_key: str = ""
+
+    # Cloudflare Workers AI — BGE-M3 embeddings
+    cf_account_id: str = ""
+    cf_ai_api_token: str = ""
+
+    # CouchDB — article body document store
+    couchdb_url: str = ""
+    couchdb_username: str = ""
+    couchdb_password: str = ""
+    couchdb_database: str = "mukoko_articles"
+
+    # Apache Doris — analytics and search
+    doris_http_url: str = ""
+    doris_username: str = ""
+    doris_password: str = ""
+    doris_database: str = "mukoko_analytics"
+
+    # Authentication — Stytch OTP + Platform JWT
+    stytch_project_id: str = ""
+    stytch_secret: str = ""
+    platform_jwt_secret: str = ""
+    platform_api_url: str = "http://mukoko-platform-api.internal:8080"
+
+    # CORS
+    cors_origins: str = "https://news.mukoko.com,https://mukoko-news.vercel.app,http://localhost:3000"
+
+    # Worker config
+    log_level: str = "info"
+    environment: str = "production"
+
+    # RSS collection
+    rss_fetch_timeout: int = 15
+    rss_batch_size: int = 10
+    rss_max_articles_per_source: int = 20
+
+    model_config = {"env_prefix": "", "case_sensitive": False}
+
+
+settings = Settings()

--- a/fly-worker/src/db.py
+++ b/fly-worker/src/db.py
@@ -1,0 +1,68 @@
+"""Async Postgres connection pool using asyncpg.
+
+Fly.io managed Postgres provides DATABASE_URL automatically.
+Uses asyncpg directly for performance — no ORM overhead.
+"""
+
+import asyncpg
+from pathlib import Path
+
+from src.config import settings
+
+_pool: asyncpg.Pool | None = None
+
+
+async def get_pool() -> asyncpg.Pool:
+    """Get or create the connection pool."""
+    global _pool
+    if _pool is None:
+        _pool = await asyncpg.create_pool(
+            settings.database_url,
+            min_size=2,
+            max_size=10,
+            command_timeout=30,
+            server_settings={
+                "search_path": "public,news,engagement,identity,system,sync",
+            },
+        )
+    return _pool
+
+
+async def close_pool() -> None:
+    """Close the connection pool."""
+    global _pool
+    if _pool is not None:
+        await _pool.close()
+        _pool = None
+
+
+async def run_migrations() -> None:
+    """Run SQL migration files from migrations/ directory."""
+    pool = await get_pool()
+    migrations_dir = Path(__file__).parent.parent / "migrations"
+
+    async with pool.acquire() as conn:
+        # Create migrations tracking table
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS _migrations (
+                filename TEXT PRIMARY KEY,
+                applied_at TIMESTAMPTZ DEFAULT NOW()
+            )
+        """)
+
+        # Get already-applied migrations
+        applied = {
+            row["filename"]
+            for row in await conn.fetch("SELECT filename FROM _migrations")
+        }
+
+        # Apply new migrations in order
+        for sql_file in sorted(migrations_dir.glob("*.sql")):
+            if sql_file.name not in applied:
+                print(f"[DB] Applying migration: {sql_file.name}")
+                sql = sql_file.read_text()
+                await conn.execute(sql)
+                await conn.execute(
+                    "INSERT INTO _migrations (filename) VALUES ($1)", sql_file.name
+                )
+                print(f"[DB] Applied: {sql_file.name}")

--- a/fly-worker/src/jobs/ai_processor.py
+++ b/fly-worker/src/jobs/ai_processor.py
@@ -1,0 +1,217 @@
+"""AI article processing job.
+
+Runs inline after RSS collection. Extracts keywords, scores quality,
+generates content hash, and links keywords to articles.
+"""
+
+from src.db import get_pool
+from src.services.content_cleaner import extract_text, count_words
+from src.services.keyword_extractor import extract_keywords
+from src.services.quality_scorer import score_article
+from src.services.couchdb import get_couchdb
+from src.services.embeddings import embed_text, build_article_text
+from src.services.article_scraper import scrape_article
+
+
+async def process_articles_batch(article_ids: list[str]) -> None:
+    """Process a batch of newly inserted articles with AI.
+
+    Called inline by rss_collector after inserting new articles.
+    Article IDs are UUID strings.
+    """
+    if not article_ids:
+        return
+
+    pool = await get_pool()
+    processed = 0
+    errors = 0
+
+    for article_id in article_ids:
+        try:
+            await _process_single(pool, article_id)
+            processed += 1
+        except Exception as e:
+            print(f"[AI] Error processing article {article_id}: {e}")
+            errors += 1
+
+    print(f"[AI] Processed {processed}/{len(article_ids)} articles ({errors} errors)")
+
+
+async def process_unprocessed() -> None:
+    """Fallback: find and process any articles that were missed.
+
+    Called on schedule as a catch-up mechanism.
+    """
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id::text FROM news.news_article
+               WHERE ai_processed = FALSE
+               ORDER BY ingested_at ASC
+               LIMIT 50"""
+        )
+
+    if rows:
+        ids = [row["id"] for row in rows]
+        print(f"[AI] Found {len(ids)} unprocessed articles")
+        await process_articles_batch(ids)
+
+
+async def _process_single(pool, article_id: str) -> None:
+    """Process a single article: keywords, quality, update record."""
+    async with pool.acquire() as conn:
+        article = await conn.fetchrow(
+            """SELECT id::text, headline, description, articlebody,
+                      article_body_processed, articlesection,
+                      author, image, publisher_organization_id, couchdb_doc_id,
+                      mainentityofpage
+               FROM news.news_article WHERE id = $1::uuid""",
+            article_id,
+        )
+
+    if not article:
+        return
+
+    article_dict = dict(article)
+
+    # Try reading body from CouchDB first
+    couchdb_id = article_dict.get("couchdb_doc_id")
+    if couchdb_id:
+        try:
+            doc = await get_couchdb().get_doc(couchdb_id)
+            if doc:
+                article_dict["articlebody"] = doc.get("articlebody") or article_dict.get("articlebody", "")
+        except Exception:
+            pass  # Fall through to Postgres body
+
+    # Scrape full article from source URL if RSS content is thin
+    rss_body = article_dict.get("articlebody", "") or ""
+    rss_word_count = count_words(extract_text(rss_body))
+    source_url = article_dict.get("mainentityofpage", "")
+
+    if rss_word_count < 200 and source_url:
+        scraped = await scrape_article(source_url)
+        if scraped and scraped["word_count"] > rss_word_count:
+            article_dict["articlebody"] = scraped["body_html"]
+            # Update description if RSS had none and scraper found one
+            if not article_dict.get("description") and scraped.get("excerpt"):
+                article_dict["description"] = scraped["excerpt"]
+            # Store full body in CouchDB for future reads
+            if couchdb_id:
+                try:
+                    await get_couchdb().put_doc(couchdb_id, {
+                        "articlebody": scraped["body_html"],
+                        "scraped_from": source_url,
+                        "scraped_word_count": scraped["word_count"],
+                    })
+                except Exception:
+                    pass
+            print(f"[AI] Scraped full article: {rss_word_count} → {scraped['word_count']} words")
+
+    # 1. Extract plain text if not already done
+    plain_text = extract_text(article_dict.get("articlebody", "") or "")
+    word_count = count_words(plain_text)
+
+    # 2. Score quality
+    quality_result = score_article(article_dict)
+    quality_score = quality_result["quality_score"]
+
+    # 3. Extract keywords
+    async with pool.acquire() as conn:
+        # Load known terms
+        known_terms = await conn.fetch(
+            "SELECT id, name, term_code FROM news.defined_term WHERE enabled = TRUE"
+        )
+        known_terms = [dict(t) for t in known_terms]
+
+        # Load section classification keywords
+        section_keywords = []
+        section_slug = article_dict.get("articlesection")
+        if section_slug:
+            section = await conn.fetchrow(
+                "SELECT classification_keywords FROM engagement.interest_category WHERE slug = $1",
+                section_slug,
+            )
+            if section and section["classification_keywords"]:
+                kw_data = section["classification_keywords"]
+                if isinstance(kw_data, str):
+                    import json
+                    section_keywords = json.loads(kw_data)
+                else:
+                    section_keywords = kw_data
+
+    keywords = await extract_keywords(article_dict, known_terms, section_keywords)
+
+    # 4. Generate BGE-M3 embedding via Cloudflare Workers AI
+    embed_text_str = build_article_text(article_dict)
+    embedding = await embed_text(embed_text_str)
+
+    # 5. Write results
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # Update article — keywords is TEXT[], pass as Python list directly
+            keyword_names = [k["name"] for k in keywords]
+
+            if embedding:
+                # Store embedding as pgvector
+                embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
+                await conn.execute(
+                    """UPDATE news.news_article SET
+                       ai_processed = TRUE,
+                       ai_processed_at = NOW(),
+                       quality_score = $2,
+                       wordcount = $3,
+                       keywords = $4,
+                       embedding_vector = $5::vector,
+                       embedding_model = 'bge-m3',
+                       updated_at = NOW(),
+                       sync_status = 'pending_sync'
+                       WHERE id = $1::uuid""",
+                    article_id,
+                    quality_score,
+                    word_count,
+                    keyword_names,
+                    embedding_str,
+                )
+            else:
+                await conn.execute(
+                    """UPDATE news.news_article SET
+                       ai_processed = TRUE,
+                       ai_processed_at = NOW(),
+                       quality_score = $2,
+                       wordcount = $3,
+                       keywords = $4,
+                       updated_at = NOW(),
+                       sync_status = 'pending_sync'
+                       WHERE id = $1::uuid""",
+                    article_id,
+                    quality_score,
+                    word_count,
+                    keyword_names,
+                )
+
+            # Upsert keywords and create links
+            for kw in keywords:
+                # Ensure the term exists
+                await conn.execute(
+                    """INSERT INTO news.defined_term (id, name, term_code, article_count)
+                       VALUES ($1, $2, $3, 1)
+                       ON CONFLICT (id) DO UPDATE SET
+                           article_count = news.defined_term.article_count + 1,
+                           updated_at = NOW()""",
+                    kw["term_id"],
+                    kw["name"],
+                    kw["term_id"],
+                )
+
+                # Link article to keyword
+                await conn.execute(
+                    """INSERT INTO news.article_keyword (article_id, term_id, relevance_score, source)
+                       VALUES ($1::uuid, $2, $3, $4)
+                       ON CONFLICT (article_id, term_id) DO NOTHING""",
+                    article_id,
+                    kw["term_id"],
+                    kw["relevance_score"],
+                    kw["source"],
+                )

--- a/fly-worker/src/jobs/cleanup.py
+++ b/fly-worker/src/jobs/cleanup.py
@@ -1,0 +1,81 @@
+"""Stale data cleanup job.
+
+Removes archived articles older than 90 days, orphaned keyword links,
+and expired trending cache entries.
+Runs daily at 3:00 UTC.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.db import get_pool
+
+
+async def cleanup_stale_data() -> None:
+    """Clean up stale data from the database."""
+    pool = await get_pool()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=90)
+    stats = {"archived": 0, "orphaned_links": 0, "expired_cache": 0, "old_logs": 0}
+
+    async with pool.acquire() as conn:
+        # 1. Delete archived articles older than 90 days
+        result = await conn.execute(
+            """DELETE FROM news.news_article
+               WHERE creativeworkstatus = 'archived'
+                 AND datepublished < $1""",
+            cutoff,
+        )
+        stats["archived"] = _parse_count(result)
+
+        # 2. Clean orphaned article_keywords (article deleted)
+        result = await conn.execute(
+            """DELETE FROM news.article_keyword
+               WHERE article_id NOT IN (SELECT id FROM news.news_article)"""
+        )
+        stats["orphaned_links"] = _parse_count(result)
+
+        # 3. Clean orphaned article_authorships
+        await conn.execute(
+            """DELETE FROM news.article_authorship
+               WHERE article_id NOT IN (SELECT id FROM news.news_article)"""
+        )
+
+        # 4. Remove expired trending cache (backup for TTL)
+        result = await conn.execute(
+            "DELETE FROM news.trending_cache WHERE expires_at < NOW()"
+        )
+        stats["expired_cache"] = _parse_count(result)
+
+        # 5. Clean old collection logs (keep 30 days)
+        log_cutoff = datetime.now(timezone.utc) - timedelta(days=30)
+        result = await conn.execute(
+            "DELETE FROM system.collection_log WHERE created_at < $1", log_cutoff
+        )
+        stats["old_logs"] = _parse_count(result)
+
+        # 6. Clean old sync logs (keep 30 days)
+        await conn.execute(
+            "DELETE FROM sync.sync_log WHERE created_at < $1", log_cutoff
+        )
+
+        # 7. Recalculate keyword article counts
+        await conn.execute(
+            """UPDATE news.defined_term SET
+               article_count = (
+                   SELECT COUNT(*) FROM news.article_keyword
+                   WHERE news.article_keyword.term_id = news.defined_term.id
+               )"""
+        )
+
+    total = sum(stats.values())
+    if total > 0:
+        print(f"[CLEANUP] Removed: {stats}")
+    else:
+        print("[CLEANUP] Nothing to clean")
+
+
+def _parse_count(result: str) -> int:
+    """Parse row count from asyncpg command result like 'DELETE 5'."""
+    try:
+        return int(result.split()[-1])
+    except (ValueError, IndexError):
+        return 0

--- a/fly-worker/src/jobs/couchdb_migration.py
+++ b/fly-worker/src/jobs/couchdb_migration.py
@@ -1,0 +1,73 @@
+"""One-time migration: copy article bodies from Postgres to CouchDB.
+
+Finds articles where couchdb_doc_id IS NULL, copies body to CouchDB,
+then updates the couchdb_doc_id column. Rate-limited to avoid overload.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+
+from src.db import get_pool
+from src.services.couchdb import get_couchdb
+
+
+async def migrate_articles_to_couchdb(batch_size: int = 50) -> None:
+    """Migrate existing article bodies to CouchDB in batches."""
+    pool = await get_pool()
+    couchdb = get_couchdb()
+
+    if not await couchdb.ping():
+        print("[MIGRATION] CouchDB not reachable, aborting")
+        return
+
+    total_migrated = 0
+
+    while True:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """SELECT id::text, headline, articlebody, article_body_processed,
+                          publisher_organization_id::text AS source_id, ingested_at
+                   FROM news.news_article
+                   WHERE couchdb_doc_id IS NULL AND articlebody IS NOT NULL
+                   ORDER BY ingested_at ASC
+                   LIMIT $1""",
+                batch_size,
+            )
+
+        if not rows:
+            break
+
+        docs = []
+        for row in rows:
+            docs.append({
+                "_id": row["id"],
+                "type": "article",
+                "headline": row["headline"] or "",
+                "articlebody": row["articlebody"] or "",
+                "article_body_processed": row["article_body_processed"] or "",
+                "ingested_at": row["ingested_at"].isoformat() if row["ingested_at"] else "",
+                "source_id": row["source_id"] or "",
+            })
+
+        results = await couchdb.bulk_docs(docs)
+
+        # Update Postgres with CouchDB doc IDs
+        success_ids = [
+            r["id"] for r in results
+            if r.get("ok") or r.get("rev")
+        ]
+        if success_ids:
+            async with pool.acquire() as conn:
+                for article_id in success_ids:
+                    await conn.execute(
+                        "UPDATE news.news_article SET couchdb_doc_id = $1 WHERE id = $1::uuid",
+                        article_id,
+                    )
+
+        total_migrated += len(success_ids)
+        print(f"[MIGRATION] Migrated {len(success_ids)}/{len(rows)} articles (total: {total_migrated})")
+
+        # Rate limit: 1 second between batches
+        await asyncio.sleep(1)
+
+    print(f"[MIGRATION] Complete: {total_migrated} articles migrated to CouchDB")

--- a/fly-worker/src/jobs/embedding_backfill.py
+++ b/fly-worker/src/jobs/embedding_backfill.py
@@ -1,0 +1,60 @@
+"""Embedding backfill job.
+
+Generates BGE-M3 embeddings for articles that were processed before
+the embedding pipeline was added. Runs periodically until all articles
+have embeddings.
+"""
+
+from src.db import get_pool
+from src.services.embeddings import embed_text, build_article_text
+
+
+async def backfill_embeddings() -> None:
+    """Generate embeddings for articles that don't have them yet.
+
+    Processes in batches of 20 to avoid overwhelming the CF Workers AI API.
+    """
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            """SELECT id::text, headline, description, articlebody,
+                      article_body_processed
+               FROM news.news_article
+               WHERE ai_processed = TRUE
+                 AND embedding_vector IS NULL
+               ORDER BY datepublished DESC
+               LIMIT 20"""
+        )
+
+    if not rows:
+        return
+
+    print(f"[EMBEDDINGS] Backfilling {len(rows)} articles...")
+    success = 0
+
+    for row in rows:
+        article = dict(row)
+        text = build_article_text(article)
+        if not text:
+            continue
+
+        embedding = await embed_text(text)
+        if embedding is None:
+            continue
+
+        embedding_str = "[" + ",".join(str(v) for v in embedding) + "]"
+
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """UPDATE news.news_article SET
+                       embedding_vector = $2::vector,
+                       embedding_model = 'bge-m3'
+                   WHERE id = $1::uuid""",
+                article["id"],
+                embedding_str,
+            )
+
+        success += 1
+
+    print(f"[EMBEDDINGS] Backfilled {success}/{len(rows)} articles")

--- a/fly-worker/src/jobs/engagement.py
+++ b/fly-worker/src/jobs/engagement.py
@@ -1,0 +1,98 @@
+"""Engagement score recalculation job.
+
+Polls for recently updated articles and recalculates engagement scores.
+Replaces the Atlas trigger that fired on view/like/bookmark updates.
+"""
+
+import math
+from datetime import datetime, timedelta, timezone
+
+from src.db import get_pool
+from src.services.doris import get_doris
+
+
+async def recalc_engagement_scores() -> None:
+    """Recalculate engagement scores for recently updated articles."""
+    pool = await get_pool()
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=6)
+
+    async with pool.acquire() as conn:
+        articles = await conn.fetch(
+            """SELECT a.id, a.view_count, a.like_count, a.bookmark_count,
+                      a.share_count, a.datepublished, a.engagement_score
+               FROM news.news_article a
+               WHERE a.updated_at >= $1
+                 AND a.creativeworkstatus = 'published'
+                 AND (a.view_count > 0 OR a.like_count > 0 OR a.bookmark_count > 0)""",
+            cutoff,
+        )
+
+    if not articles:
+        return
+
+    updated = 0
+    async with pool.acquire() as conn:
+        for article in articles:
+            new_score = _compute_score(dict(article))
+            old_score = article["engagement_score"] or 0.0
+
+            # Only update if score changed meaningfully
+            if abs(new_score - old_score) > 0.01:
+                await conn.execute(
+                    """UPDATE news.news_article SET
+                       engagement_score = $2,
+                       sync_status = 'pending_sync'
+                       WHERE id = $1""",
+                    article["id"],
+                    new_score,
+                )
+                updated += 1
+
+    if updated:
+        print(f"[ENGAGEMENT] Updated {updated}/{len(articles)} scores")
+
+        # Sync updated scores to Doris search index
+        try:
+            doris = get_doris()
+            if await doris.ping():
+                for article in articles:
+                    new_score = _compute_score(dict(article))
+                    safe_id = str(article["id"]).replace("'", "\\'")
+                    await doris.query(
+                        f"UPDATE mukoko_analytics.article_search SET engagement_score = {new_score} WHERE article_id = '{safe_id}'"
+                    )
+        except Exception as e:
+            print(f"[ENGAGEMENT] Doris sync error: {e}")
+
+
+def _compute_score(article: dict) -> float:
+    """Compute engagement score with time decay.
+
+    Formula: raw_engagement * time_decay
+    - raw = views*1 + likes*3 + bookmarks*5 + shares*2
+    - decay = 1 / (1 + hours_since_published / 48)
+    """
+    views = article.get("view_count", 0) or 0
+    likes = article.get("like_count", 0) or 0
+    bookmarks = article.get("bookmark_count", 0) or 0
+    shares = article.get("share_count", 0) or 0
+
+    raw = views * 1 + likes * 3 + bookmarks * 5 + shares * 2
+
+    # Time decay
+    published = article.get("datepublished")
+    if published:
+        if isinstance(published, str):
+            published = datetime.fromisoformat(published)
+        hours = (datetime.now(timezone.utc) - published).total_seconds() / 3600
+        decay = 1.0 / (1.0 + hours / 48.0)
+    else:
+        decay = 0.5
+
+    score = raw * decay
+
+    # Log scale for very popular articles
+    if score > 100:
+        score = 100 + math.log10(score - 99) * 50
+
+    return round(score, 2)

--- a/fly-worker/src/jobs/health_checker.py
+++ b/fly-worker/src/jobs/health_checker.py
@@ -1,0 +1,97 @@
+"""Source health check job.
+
+Evaluates all enabled feed sources and classifies their health status.
+Runs every 6 hours.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from src.db import get_pool
+
+
+async def check_source_health() -> None:
+    """Evaluate and update health status for all enabled feed sources."""
+    pool = await get_pool()
+
+    async with pool.acquire() as conn:
+        sources = await conn.fetch(
+            """SELECT id, organization_id, consecutive_failures, total_fetch_count,
+                      total_error_count, last_successful_fetch_at,
+                      last_fetched_at, health_status
+               FROM news.feed_source
+               WHERE is_active = TRUE"""
+        )
+
+    if not sources:
+        return
+
+    updated = 0
+    seven_days_ago = datetime.now(timezone.utc) - timedelta(days=7)
+
+    async with pool.acquire() as conn:
+        for source in sources:
+            s = dict(source)
+
+            # Determine health status
+            failures = s.get("consecutive_failures", 0) or 0
+            if failures == 0:
+                new_status = "healthy"
+            elif failures <= 3:
+                new_status = "degraded"
+            elif failures <= 7:
+                new_status = "failing"
+            else:
+                new_status = "critical"
+
+            # Check staleness — no successful fetch in 48h
+            last_success = s.get("last_successful_fetch_at")
+            if last_success:
+                hours_since = (datetime.now(timezone.utc) - last_success).total_seconds() / 3600
+                if hours_since > 48 and new_status == "healthy":
+                    new_status = "degraded"
+
+            # Calculate quality score from recent articles
+            quality_score = await _calc_source_quality(conn, s["organization_id"], seven_days_ago)
+
+            # Only update if something changed
+            if new_status != s.get("health_status") or True:
+                await conn.execute(
+                    """UPDATE news.feed_source SET
+                       health_status = $2,
+                       quality_score = $3,
+                       updated_at = NOW()
+                       WHERE id = $1""",
+                    s["id"],
+                    new_status,
+                    quality_score,
+                )
+                updated += 1
+
+    print(f"[HEALTH] Updated {updated}/{len(sources)} source health statuses")
+
+
+async def _calc_source_quality(conn, organization_id, since: datetime) -> float:
+    """Calculate source quality score from recent articles."""
+    stats = await conn.fetchrow(
+        """SELECT
+             COUNT(*) AS article_count,
+             AVG(quality_score) AS avg_quality,
+             AVG(engagement_score) AS avg_engagement
+           FROM news.news_article
+           WHERE publisher_organization_id = $1
+             AND datepublished >= $2
+             AND creativeworkstatus = 'published'""",
+        organization_id,
+        since,
+    )
+
+    if not stats or stats["article_count"] == 0:
+        return 0.0
+
+    # 60% quality + 30% engagement + 10% volume
+    quality = (stats["avg_quality"] or 0) / 100.0  # Normalize to 0-1
+    engagement = min(1.0, (stats["avg_engagement"] or 0) / 50.0)  # Cap at 1.0
+    volume = min(1.0, stats["article_count"] / 50.0)  # 50 articles/week = 1.0
+
+    score = quality * 0.6 + engagement * 0.3 + volume * 0.1
+    return round(score * 100, 2)

--- a/fly-worker/src/jobs/rss_collector.py
+++ b/fly-worker/src/jobs/rss_collector.py
@@ -1,0 +1,298 @@
+"""RSS feed collection job.
+
+Fetches RSS feeds from all enabled feed sources, parses articles,
+deduplicates, inserts new articles, then runs AI processing inline.
+"""
+
+import json
+import time
+from datetime import datetime, timezone
+
+import httpx
+
+from src.config import settings
+from src.db import get_pool
+from src.services.rss_parser import parse_feed
+from src.services.content_cleaner import clean_html, extract_text, count_words, estimate_reading_time
+from src.jobs.ai_processor import process_articles_batch
+from src.services.couchdb import get_couchdb
+from src.services.doris import get_doris
+
+
+async def collect_feeds() -> None:
+    """Main RSS collection job. Runs every 15 minutes."""
+    start = time.time()
+    pool = await get_pool()
+    stats = {"sources": 0, "fetched": 0, "inserted": 0, "errors": 0, "skipped": 0}
+
+    try:
+        # Load enabled sources sorted by priority (JOIN feed_source + organization)
+        async with pool.acquire() as conn:
+            sources = await conn.fetch("""
+                SELECT fs.id, fs.organization_id, org.name AS org_name,
+                       fs.feed_url, fs.country, fs.article_section_slug,
+                       fs.language, fs.health_status, fs.consecutive_failures,
+                       fs.last_fetched_at
+                FROM news.feed_source fs
+                JOIN news.news_media_organization org ON fs.organization_id = org.id
+                WHERE fs.is_active = TRUE
+                ORDER BY fs.priority DESC, fs.consecutive_failures ASC
+            """)
+
+        stats["sources"] = len(sources)
+        print(f"[RSS] Starting collection for {len(sources)} sources")
+
+        # Process in batches
+        batch_size = settings.rss_batch_size
+        new_article_ids = []
+
+        for i in range(0, len(sources), batch_size):
+            batch = sources[i : i + batch_size]
+            batch_ids = await _process_batch(batch, pool, stats)
+            new_article_ids.extend(batch_ids)
+
+        # Inline AI processing for new articles
+        if new_article_ids:
+            print(f"[RSS] Processing {len(new_article_ids)} new articles with AI...")
+            await process_articles_batch(new_article_ids)
+
+        duration = int((time.time() - start) * 1000)
+        print(
+            f"[RSS] Complete: {stats['inserted']} new, "
+            f"{stats['skipped']} dupes, {stats['errors']} errors "
+            f"({duration}ms)"
+        )
+
+        # Log the run
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """INSERT INTO system.collection_log
+                   (job_type, status, articles_collected, articles_processed,
+                    errors, duration_ms, metadata, started_at, completed_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)""",
+                "rss_collection",
+                "success",
+                stats["fetched"],
+                stats["inserted"],
+                stats["errors"],
+                duration,
+                json.dumps(stats),
+                datetime.fromtimestamp(start, tz=timezone.utc),
+                datetime.now(timezone.utc),
+            )
+
+    except Exception as e:
+        print(f"[RSS] Collection failed: {e}")
+        duration = int((time.time() - start) * 1000)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """INSERT INTO system.collection_log
+                   (job_type, status, errors, duration_ms, error_message,
+                    started_at, completed_at)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7)""",
+                "rss_collection",
+                "failed",
+                stats["errors"],
+                duration,
+                str(e),
+                datetime.fromtimestamp(start, tz=timezone.utc),
+                datetime.now(timezone.utc),
+            )
+
+
+async def _process_batch(
+    sources: list, pool, stats: dict
+) -> list[str]:
+    """Fetch and process a batch of RSS sources. Returns new article IDs (UUID strings)."""
+    new_ids = []
+
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=settings.rss_fetch_timeout,
+    ) as client:
+        for source in sources:
+            source_dict = dict(source)
+            try:
+                # Skip sources with too many failures
+                if source_dict.get("consecutive_failures", 0) >= 8:
+                    continue
+
+                # Fetch the feed
+                url = source_dict["feed_url"]
+                response = await client.get(url)
+                if response.status_code != 200:
+                    await _record_failure(pool, source_dict, f"HTTP {response.status_code}")
+                    stats["errors"] += 1
+                    continue
+
+                # Parse
+                feed_data = parse_feed(response.text, source_dict)
+                articles = feed_data["articles"]
+                stats["fetched"] += len(articles)
+
+                # Insert new articles
+                ids = await _insert_articles(pool, articles, stats)
+                new_ids.extend(ids)
+
+                # Record success
+                await _record_success(pool, source_dict, len(articles))
+
+            except httpx.TimeoutException:
+                await _record_failure(pool, source_dict, "Timeout")
+                stats["errors"] += 1
+            except Exception as e:
+                await _record_failure(pool, source_dict, str(e)[:500])
+                stats["errors"] += 1
+
+    return new_ids
+
+
+async def _insert_articles(pool, articles: list[dict], stats: dict) -> list[str]:
+    """Insert new articles, skipping duplicates. Returns list of new article ID strings."""
+    new_ids = []
+
+    async with pool.acquire() as conn:
+        for article in articles:
+            # Check for duplicate by source_feed_id or mainentityofpage
+            existing = await conn.fetchval(
+                """SELECT id FROM news.news_article
+                   WHERE source_feed_id = $1 OR mainentityofpage = $2
+                   LIMIT 1""",
+                article["source_feed_id"],
+                article["mainentityofpage"],
+            )
+
+            if existing:
+                stats["skipped"] += 1
+                continue
+
+            # Clean content
+            raw_body = article.get("article_body", "")
+            cleaned_body = clean_html(raw_body) if raw_body else ""
+            plain_text = extract_text(raw_body) if raw_body else ""
+            word_count = count_words(plain_text)
+            reading_time = estimate_reading_time(word_count)
+
+            # Ensure unique slug
+            slug = article["slug"]
+            slug_exists = await conn.fetchval(
+                "SELECT 1 FROM news.news_article WHERE slug = $1", slug
+            )
+            if slug_exists:
+                slug = f"{slug}-{article['source_fingerprint'][:8]}"
+
+            # Look up interest_category UUID from slug
+            category_slug = article.get("articlesection", "general")
+            category_id = await conn.fetchval(
+                "SELECT id FROM engagement.interest_category WHERE slug = $1",
+                category_slug,
+            )
+
+            # Insert
+            article_id = await conn.fetchval(
+                """INSERT INTO news.news_article
+                   (headline, description, articlebody, article_body_processed,
+                    slug, mainentityofpage, source_feed_id, image,
+                    author, publisher_organization_id, publisher,
+                    articlesection, primary_interest_category_id, primary_location_country,
+                    datepublished, source_fingerprint, inlanguage,
+                    wordcount, reading_time_minutes, creativeworkstatus, ingestion_method)
+                   VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10,$11::jsonb,$12,$13,$14,$15,$16,$17,$18,$19,'published','rss_feed')
+                   RETURNING id::text""",
+                article["headline"],
+                article.get("description", ""),
+                raw_body,
+                cleaned_body,
+                slug,
+                article["mainentityofpage"],
+                article["source_feed_id"],
+                article.get("image"),
+                article.get("author"),
+                article["publisher_organization_id"],
+                article.get("publisher"),
+                category_slug,
+                category_id,
+                article.get("primary_location_country", "ZW"),
+                article["datepublished"],
+                article["source_fingerprint"],
+                article.get("inlanguage", "en"),
+                word_count,
+                reading_time,
+            )
+
+            if article_id:
+                new_ids.append(article_id)
+                stats["inserted"] += 1
+
+                # Store body in CouchDB (non-blocking — failure doesn't break ingestion)
+                try:
+                    couchdb = get_couchdb()
+                    if couchdb:
+                        doc = {
+                            "_id": article_id,
+                            "type": "article",
+                            "headline": article["headline"],
+                            "articlebody": raw_body,
+                            "article_body_processed": cleaned_body,
+                            "ingested_at": datetime.now(timezone.utc).isoformat(),
+                            "source_id": str(article.get("publisher_organization_id", "")),
+                        }
+                        rev = await couchdb.put_doc(article_id, doc)
+                        if rev:
+                            await conn.execute(
+                                "UPDATE news.news_article SET couchdb_doc_id = $2 WHERE id = $1::uuid",
+                                article_id,
+                                article_id,
+                            )
+                except Exception as e:
+                    print(f"[RSS] CouchDB write failed for {article_id}: {e}")
+
+                # Index in Doris for search (non-blocking)
+                try:
+                    doris = get_doris()
+                    await doris.stream_load("article_search", [{
+                        "article_id": article_id,
+                        "headline": article["headline"] or "",
+                        "description": article.get("description", "") or "",
+                        "keywords": "",  # filled after AI processing
+                        "category": category_slug,
+                        "country": article.get("primary_location_country", "ZW"),
+                        "source_id": str(article.get("publisher_organization_id", "")),
+                        "datepublished": article["datepublished"].isoformat() if article.get("datepublished") else "",
+                        "engagement_score": 0.0,
+                    }])
+                except Exception as e:
+                    print(f"[RSS] Doris index failed for {article_id}: {e}")
+
+    return new_ids
+
+
+async def _record_success(pool, source: dict, articles_count: int) -> None:
+    """Update feed source on successful fetch."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """UPDATE news.feed_source SET
+               last_fetched_at = NOW(),
+               last_successful_fetch_at = NOW(),
+               consecutive_failures = 0,
+               total_fetch_count = total_fetch_count + 1,
+               updated_at = NOW()
+               WHERE id = $1""",
+            source["id"],
+        )
+
+
+async def _record_failure(pool, source: dict, error: str) -> None:
+    """Update feed source on failed fetch."""
+    async with pool.acquire() as conn:
+        await conn.execute(
+            """UPDATE news.feed_source SET
+               last_fetched_at = NOW(),
+               consecutive_failures = consecutive_failures + 1,
+               total_error_count = total_error_count + 1,
+               last_fetch_error = $2,
+               updated_at = NOW()
+               WHERE id = $1""",
+            source["id"],
+            error,
+        )

--- a/fly-worker/src/jobs/trending.py
+++ b/fly-worker/src/jobs/trending.py
@@ -1,0 +1,132 @@
+"""Trending topics refresh job.
+
+Aggregates article keywords from the last 24 hours, scores them by
+frequency and engagement, writes to trending_cache.
+"""
+
+import math
+from datetime import datetime, timedelta, timezone
+
+from src.db import get_pool
+
+
+async def refresh_trending() -> None:
+    """Refresh trending topics cache. Runs every 30 minutes."""
+    pool = await get_pool()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+
+    async with pool.acquire() as conn:
+        # Aggregate keywords from recent articles
+        rows = await conn.fetch(
+            """SELECT
+                 ak.term_id,
+                 dt.name AS term_name,
+                 COUNT(DISTINCT ak.article_id) AS article_count,
+                 COALESCE(SUM(a.view_count), 0) AS total_views,
+                 COALESCE(SUM(a.like_count), 0) AS total_likes,
+                 COALESCE(SUM(a.bookmark_count), 0) AS total_bookmarks
+               FROM news.article_keyword ak
+               JOIN news.news_article a ON a.id = ak.article_id
+               JOIN news.defined_term dt ON dt.id = ak.term_id
+               WHERE a.datepublished >= $1
+                 AND a.creativeworkstatus = 'published'
+               GROUP BY ak.term_id, dt.name
+               HAVING COUNT(DISTINCT ak.article_id) >= 2
+               ORDER BY COUNT(DISTINCT ak.article_id) DESC
+               LIMIT 50""",
+            cutoff,
+        )
+
+    if not rows:
+        print("[TRENDING] No trending data found")
+        return
+
+    # Score and rank
+    scored = []
+    for row in rows:
+        engagement = (
+            row["total_views"]
+            + row["total_likes"] * 3
+            + row["total_bookmarks"] * 2
+            + 1
+        )
+        score = row["article_count"] * (1 + math.log10(engagement))
+        scored.append({
+            "term_id": row["term_id"],
+            "term_name": row["term_name"],
+            "article_count": row["article_count"],
+            "score": round(score, 2),
+        })
+
+    scored.sort(key=lambda x: x["score"], reverse=True)
+
+    # Write global trending (top 20)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            # Clear old global entries
+            await conn.execute(
+                "DELETE FROM news.trending_cache WHERE scope = 'global'"
+            )
+
+            for item in scored[:20]:
+                await conn.execute(
+                    """INSERT INTO news.trending_cache
+                       (scope, term_id, term_name, article_count, score, computed_at, expires_at)
+                       VALUES ('global', $1, $2, $3, $4, NOW(), NOW() + INTERVAL '1 hour')""",
+                    item["term_id"],
+                    item["term_name"],
+                    item["article_count"],
+                    item["score"],
+                )
+
+        # Per-country trending
+        countries = await conn.fetch(
+            "SELECT DISTINCT id FROM news.country WHERE enabled = TRUE"
+        )
+
+        for country in countries:
+            country_id = country["id"]
+            country_rows = await conn.fetch(
+                """SELECT
+                     ak.term_id,
+                     dt.name AS term_name,
+                     COUNT(DISTINCT ak.article_id) AS article_count,
+                     COALESCE(SUM(a.view_count), 0) AS total_views,
+                     COALESCE(SUM(a.like_count), 0) AS total_likes
+                   FROM news.article_keyword ak
+                   JOIN news.news_article a ON a.id = ak.article_id
+                   JOIN news.defined_term dt ON dt.id = ak.term_id
+                   WHERE a.datepublished >= $1
+                     AND a.primary_location_country = $2
+                     AND a.creativeworkstatus = 'published'
+                   GROUP BY ak.term_id, dt.name
+                   HAVING COUNT(DISTINCT ak.article_id) >= 2
+                   ORDER BY COUNT(DISTINCT ak.article_id) DESC
+                   LIMIT 20""",
+                cutoff,
+                country_id,
+            )
+
+            if country_rows:
+                async with conn.transaction():
+                    await conn.execute(
+                        "DELETE FROM news.trending_cache WHERE scope = 'country' AND scope_id = $1",
+                        country_id,
+                    )
+                    for row in country_rows:
+                        engagement = row["total_views"] + row["total_likes"] * 3 + 1
+                        score = row["article_count"] * (1 + math.log10(engagement))
+                        await conn.execute(
+                            """INSERT INTO news.trending_cache
+                               (scope, scope_id, term_id, term_name, article_count, score,
+                                computed_at, expires_at)
+                               VALUES ('country', $1, $2, $3, $4, $5, NOW(),
+                                       NOW() + INTERVAL '1 hour')""",
+                            country_id,
+                            row["term_id"],
+                            row["term_name"],
+                            row["article_count"],
+                            round(score, 2),
+                        )
+
+    print(f"[TRENDING] Refreshed {len(scored)} global + {len(countries)} country scopes")

--- a/fly-worker/src/main.py
+++ b/fly-worker/src/main.py
@@ -1,0 +1,160 @@
+"""Mukoko News Fly.io Backend — FastAPI application entry point.
+
+Serves the full API for news.mukoko.com frontend.
+Also runs background jobs: RSS collection, AI processing, engagement scoring.
+"""
+
+import time
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from src.config import settings
+from src.db import get_pool, close_pool, run_migrations
+from src.scheduler import create_scheduler
+from src.services.couchdb import init_couchdb, close_couchdb
+from src.services.doris import init_doris, close_doris
+from src.services.analytics import flush_analytics
+from src.services.embeddings import close_client as close_embeddings
+
+_start_time = time.time()
+_scheduler = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Startup: run migrations, start scheduler. Shutdown: stop scheduler, close DB."""
+    global _scheduler
+
+    # Database
+    print("[MAIN] Connecting to Postgres...")
+    await get_pool()
+    print("[MAIN] Running migrations...")
+    await run_migrations()
+
+    # CouchDB (article body storage)
+    print("[MAIN] Initializing CouchDB...")
+    await init_couchdb()
+
+    # Doris (analytics)
+    print("[MAIN] Initializing Doris...")
+    await init_doris()
+
+    # Scheduler (background jobs)
+    print("[MAIN] Starting scheduler...")
+    _scheduler = create_scheduler()
+    _scheduler.start()
+    print("[MAIN] Backend ready.")
+
+    yield
+
+    # Shutdown
+    print("[MAIN] Shutting down...")
+    if _scheduler:
+        _scheduler.shutdown(wait=False)
+    await flush_analytics()
+    await close_embeddings()
+    await close_doris()
+    await close_couchdb()
+    await close_pool()
+    print("[MAIN] Shutdown complete.")
+
+
+app = FastAPI(
+    title="Mukoko News API",
+    description="Pan-African news aggregation API — mukoko.com",
+    version="2.0.0",
+    lifespan=lifespan,
+)
+
+# CORS
+origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization", "Cookie"],
+    expose_headers=["Set-Cookie"],
+)
+
+# ── Register API routers ────────────────────────────────────
+from src.api.feeds import router as feeds_router
+from src.api.articles import router as articles_router
+from src.api.categories import router as categories_router
+from src.api.sources import router as sources_router
+from src.api.search import router as search_router
+from src.api.stats import router as stats_router
+from src.api.engagement import router as engagement_router
+from src.api.stories import router as stories_router
+from src.api.authors import router as authors_router
+from src.api.admin import router as admin_router
+from src.api.analytics import router as analytics_router
+from src.api.user import router as user_router
+from src.api.auth_router import router as auth_router
+from src.api.platform_sync import router as platform_sync_router
+
+app.include_router(feeds_router)
+app.include_router(articles_router)
+app.include_router(categories_router)
+app.include_router(sources_router)
+app.include_router(search_router)
+app.include_router(stats_router)
+app.include_router(engagement_router)
+app.include_router(stories_router)
+app.include_router(authors_router)
+app.include_router(admin_router)
+app.include_router(analytics_router)  # Public — no auth required
+app.include_router(user_router)
+app.include_router(auth_router)
+app.include_router(platform_sync_router)
+
+
+# ── Root health endpoint (for Fly.io health checks) ─────────
+@app.get("/health")
+async def health():
+    """Health check for Fly.io."""
+    pool = await get_pool()
+    db_ok = False
+    try:
+        async with pool.acquire() as conn:
+            await conn.fetchval("SELECT 1")
+            db_ok = True
+    except Exception:
+        pass
+
+    # CouchDB status
+    from src.services.couchdb import get_couchdb
+    couch_ok = False
+    try:
+        couch_ok = await get_couchdb().ping()
+    except Exception:
+        pass
+
+    # Doris status
+    from src.services.doris import get_doris as _get_doris
+    doris_ok = False
+    try:
+        doris_ok = await _get_doris().ping()
+    except Exception:
+        pass
+
+    jobs = {}
+    if _scheduler:
+        for job in _scheduler.get_jobs():
+            next_run = job.next_run_time
+            jobs[job.id] = {
+                "name": job.name,
+                "next_run": next_run.isoformat() if next_run else None,
+            }
+
+    # Degraded if DB is down; CouchDB/Doris being down is acceptable
+    return {
+        "status": "healthy" if db_ok else "degraded",
+        "uptime_seconds": int(time.time() - _start_time),
+        "database": "connected" if db_ok else "disconnected",
+        "couchdb": "connected" if couch_ok else "disconnected",
+        "doris": "connected" if doris_ok else "disconnected",
+        "jobs": jobs,
+    }

--- a/fly-worker/src/scheduler.py
+++ b/fly-worker/src/scheduler.py
@@ -1,0 +1,92 @@
+"""APScheduler job configuration.
+
+All scheduled jobs for the Fly.io backend:
+- RSS feed collection (every 15 min) — includes inline AI processing
+- Engagement score recalculation (every 5 min)
+- Trending topics refresh (every 30 min)
+- Source health check (every 6 hours)
+- Stale data cleanup (daily at 3:00 UTC)
+"""
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+
+def create_scheduler() -> AsyncIOScheduler:
+    """Create and configure the job scheduler."""
+    scheduler = AsyncIOScheduler(timezone="UTC")
+
+    # Import jobs lazily to avoid circular imports
+    from src.jobs.rss_collector import collect_feeds
+    from src.jobs.engagement import recalc_engagement_scores
+    from src.jobs.trending import refresh_trending
+    from src.jobs.health_checker import check_source_health
+    from src.jobs.cleanup import cleanup_stale_data
+    from src.services.analytics import flush_analytics
+    from src.jobs.embedding_backfill import backfill_embeddings
+
+    # RSS collection + inline AI processing: every 15 minutes
+    scheduler.add_job(
+        collect_feeds,
+        IntervalTrigger(minutes=15),
+        id="rss_collector",
+        name="RSS Feed Collection",
+        max_instances=1,
+    )
+
+    # Engagement score recalculation: every 5 minutes
+    scheduler.add_job(
+        recalc_engagement_scores,
+        IntervalTrigger(minutes=5),
+        id="engagement",
+        name="Engagement Score Recalc",
+        max_instances=1,
+    )
+
+    # Trending topics: every 30 minutes
+    scheduler.add_job(
+        refresh_trending,
+        IntervalTrigger(minutes=30),
+        id="trending",
+        name="Trending Topics Refresh",
+        max_instances=1,
+    )
+
+    # Source health: every 6 hours
+    scheduler.add_job(
+        check_source_health,
+        CronTrigger(hour="*/6"),
+        id="health_checker",
+        name="Source Health Check",
+        max_instances=1,
+    )
+
+    # Analytics buffer flush: every 30 seconds
+    scheduler.add_job(
+        flush_analytics,
+        IntervalTrigger(seconds=30),
+        id="analytics_flush",
+        name="Analytics Buffer Flush",
+        max_instances=1,
+    )
+
+    # Cleanup: daily at 3:00 UTC
+    scheduler.add_job(
+        cleanup_stale_data,
+        CronTrigger(hour=3, minute=0),
+        id="cleanup",
+        name="Stale Data Cleanup",
+        max_instances=1,
+    )
+
+    # Embedding backfill: every 10 minutes (catches articles without embeddings)
+    scheduler.add_job(
+        backfill_embeddings,
+        IntervalTrigger(minutes=10),
+        id="embedding_backfill",
+        name="Embedding Backfill (BGE-M3)",
+        max_instances=1,
+    )
+
+    return scheduler

--- a/fly-worker/src/services/ai_client.py
+++ b/fly-worker/src/services/ai_client.py
@@ -1,0 +1,82 @@
+"""Anthropic Claude client for AI processing.
+
+Native anthropic SDK — no Cloudflare AI Gateway needed on Fly.io.
+"""
+
+import json
+
+import anthropic
+
+from src.config import settings
+
+_client: anthropic.AsyncAnthropic | None = None
+
+
+def get_client() -> anthropic.AsyncAnthropic:
+    """Get or create the Anthropic client singleton."""
+    global _client
+    if _client is None:
+        _client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+    return _client
+
+
+async def complete(
+    prompt: str,
+    *,
+    system: str | None = None,
+    model: str = "claude-sonnet-4-5-20250929",
+    max_tokens: int = 1024,
+) -> str:
+    """Send a prompt to Claude and return the text response."""
+    client = get_client()
+    try:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+            system=system or anthropic.NOT_GIVEN,
+        )
+        return response.content[0].text
+    except Exception as e:
+        print(f"[AI_CLIENT] Anthropic call failed: {e}")
+        return ""
+
+
+async def extract_json(
+    prompt: str,
+    *,
+    system: str | None = None,
+    model: str = "claude-sonnet-4-5-20250929",
+    max_tokens: int = 1024,
+) -> dict | list | None:
+    """Send a prompt to Claude and parse the JSON response."""
+    text = await complete(prompt, system=system, model=model, max_tokens=max_tokens)
+    if not text:
+        return None
+
+    # Try to extract JSON from the response
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Try to find JSON in markdown code blocks
+    import re
+    json_match = re.search(r"```(?:json)?\s*([\s\S]*?)```", text)
+    if json_match:
+        try:
+            return json.loads(json_match.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    # Try to find any JSON object or array
+    for pattern in [r"\{[\s\S]*\}", r"\[[\s\S]*\]"]:
+        match = re.search(pattern, text)
+        if match:
+            try:
+                return json.loads(match.group())
+            except json.JSONDecodeError:
+                continue
+
+    print(f"[AI_CLIENT] Failed to parse JSON from response: {text[:200]}")
+    return None

--- a/fly-worker/src/services/analytics.py
+++ b/fly-worker/src/services/analytics.py
@@ -1,0 +1,134 @@
+"""Analytics event buffer for Doris.
+
+Buffers engagement events in memory and periodically flushes to Doris
+via Stream Load. If Doris is unavailable, events are silently discarded
+(analytics is non-critical — Postgres counters remain the source of truth).
+"""
+
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+
+from src.services.doris import get_doris
+
+
+class AnalyticsBuffer:
+    """In-memory event buffer that flushes to Doris."""
+
+    MAX_EVENTS = 10_000
+
+    def __init__(self) -> None:
+        self._events: dict[str, list[dict]] = defaultdict(list)
+        self._total = 0
+
+    def track_view(self, article_id: str, country: str = "") -> None:
+        self._add("article_metrics", {
+            "article_id": article_id,
+            "event_date": _today(),
+            "event_hour": _hour(),
+            "country": country or "XX",
+            "views": 1, "likes": 0, "bookmarks": 0, "shares": 0,
+        })
+
+    def track_like(self, article_id: str, country: str = "") -> None:
+        self._add("article_metrics", {
+            "article_id": article_id,
+            "event_date": _today(),
+            "event_hour": _hour(),
+            "country": country or "XX",
+            "views": 0, "likes": 1, "bookmarks": 0, "shares": 0,
+        })
+
+    def track_save(self, article_id: str, country: str = "") -> None:
+        self._add("article_metrics", {
+            "article_id": article_id,
+            "event_date": _today(),
+            "event_hour": _hour(),
+            "country": country or "XX",
+            "views": 0, "likes": 0, "bookmarks": 1, "shares": 0,
+        })
+
+    def track_share(self, article_id: str, country: str = "") -> None:
+        self._add("article_metrics", {
+            "article_id": article_id,
+            "event_date": _today(),
+            "event_hour": _hour(),
+            "country": country or "XX",
+            "views": 0, "likes": 0, "bookmarks": 0, "shares": 1,
+        })
+
+    def track_search(self, query: str, result_count: int, country: str = "", category: str = "") -> None:
+        self._add("search_analytics", {
+            "query_text": query[:500],
+            "search_date": _today(),
+            "search_hour": _hour(),
+            "result_count": result_count,
+            "country": country or "XX",
+            "category": category or "",
+        })
+
+    def track_open_data_access(self, endpoint: str, country: str = "") -> None:
+        self._add("open_data_access_log", {
+            "endpoint": endpoint[:200],
+            "access_date": _today(),
+            "access_hour": _hour(),
+            "request_count": 1,
+            "country": country or "XX",
+        })
+
+    def _add(self, table: str, event: dict) -> None:
+        if self._total >= self.MAX_EVENTS:
+            return  # Silently drop if buffer full
+        self._events[table].append(event)
+        self._total += 1
+
+    async def flush(self) -> None:
+        """Flush all buffered events to Doris."""
+        if self._total == 0:
+            return
+
+        doris = get_doris()
+        flushed = 0
+
+        for table, events in self._events.items():
+            if events:
+                ok = await doris.stream_load(table, events)
+                if ok:
+                    flushed += len(events)
+                else:
+                    print(f"[ANALYTICS] Failed to flush {len(events)} events to {table}")
+
+        if flushed:
+            print(f"[ANALYTICS] Flushed {flushed}/{self._total} events to Doris")
+
+        self._events.clear()
+        self._total = 0
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _hour() -> int:
+    return datetime.now(timezone.utc).hour
+
+
+# Singleton
+_buffer: AnalyticsBuffer | None = None
+
+
+def get_analytics() -> AnalyticsBuffer:
+    """Get the singleton analytics buffer."""
+    global _buffer
+    if _buffer is None:
+        _buffer = AnalyticsBuffer()
+    return _buffer
+
+
+async def flush_analytics() -> None:
+    """Flush the analytics buffer — called by scheduler."""
+    buf = get_analytics()
+    try:
+        await buf.flush()
+    except Exception as e:
+        print(f"[ANALYTICS] Flush error: {e}")

--- a/fly-worker/src/services/article_scraper.py
+++ b/fly-worker/src/services/article_scraper.py
@@ -1,0 +1,126 @@
+"""Full article scraper — fetches and extracts article body from source URLs.
+
+RSS feeds typically only provide a headline + truncated description (10-20%
+of the article). This service fetches the original article page and extracts
+the full body using Mozilla's Readability algorithm (same as Firefox Reader View).
+
+The richer content improves:
+- Keyword extraction (more text for AI)
+- Quality scoring (textstat needs full text)
+- BGE-M3 embeddings (more context = better vectors)
+- Content pushed to mukoko-platform
+"""
+
+import httpx
+from readability import Document
+from bs4 import BeautifulSoup
+
+# User-agent that identifies us as a news aggregator (not a generic bot)
+USER_AGENT = "MukokoNews/2.0 (+https://news.mukoko.com; news aggregator)"
+
+# Max response size to prevent memory issues (5MB)
+MAX_CONTENT_SIZE = 5 * 1024 * 1024
+
+# Timeout for fetching article pages
+FETCH_TIMEOUT = 15
+
+
+async def scrape_article(url: str) -> dict | None:
+    """Fetch and extract full article content from a URL.
+
+    Returns dict with extracted content, or None if scraping fails.
+    Falls back gracefully — RSS content is always the fallback.
+    """
+    if not url or not url.startswith("http"):
+        return None
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=FETCH_TIMEOUT,
+            headers={"User-Agent": USER_AGENT},
+        ) as client:
+            resp = await client.get(url)
+
+            if resp.status_code != 200:
+                print(f"[SCRAPER] HTTP {resp.status_code} for {url[:80]}")
+                return None
+
+            # Check content size
+            content_length = len(resp.content)
+            if content_length > MAX_CONTENT_SIZE:
+                print(f"[SCRAPER] Too large ({content_length} bytes): {url[:80]}")
+                return None
+
+            # Check content type is HTML
+            content_type = resp.headers.get("content-type", "")
+            if "html" not in content_type.lower():
+                return None
+
+            html = resp.text
+
+    except httpx.TimeoutException:
+        print(f"[SCRAPER] Timeout: {url[:80]}")
+        return None
+    except Exception as e:
+        print(f"[SCRAPER] Fetch error: {type(e).__name__}: {url[:80]}")
+        return None
+
+    return extract_article(html, url)
+
+
+def extract_article(html: str, url: str = "") -> dict | None:
+    """Extract article content from HTML using Mozilla Readability.
+
+    Returns:
+        {
+            "title": str,
+            "body_html": str,       # Cleaned HTML
+            "body_text": str,       # Plain text
+            "word_count": int,
+            "excerpt": str | None,  # Short description if found
+        }
+    """
+    try:
+        doc = Document(html, url=url)
+        title = doc.short_title()
+        body_html = doc.summary()
+
+        if not body_html:
+            return None
+
+        # Extract plain text from the readability output
+        soup = BeautifulSoup(body_html, "lxml")
+
+        # Remove any remaining unwanted elements
+        for tag in soup.find_all(["script", "style", "iframe", "nav", "footer"]):
+            tag.decompose()
+
+        body_text = soup.get_text(separator="\n")
+        # Normalize whitespace
+        body_text = "\n".join(
+            line.strip() for line in body_text.split("\n") if line.strip()
+        )
+
+        word_count = len(body_text.split())
+
+        # Skip if we got very little content (probably a paywall or error page)
+        if word_count < 50:
+            return None
+
+        # Try to get meta description as excerpt
+        full_soup = BeautifulSoup(html, "lxml")
+        meta_desc = full_soup.find("meta", attrs={"name": "description"})
+        excerpt = meta_desc.get("content") if meta_desc else None
+
+        return {
+            "title": title or "",
+            "body_html": body_html,
+            "body_text": body_text,
+            "word_count": word_count,
+            "excerpt": excerpt,
+        }
+
+    except Exception as e:
+        print(f"[SCRAPER] Extract error: {type(e).__name__}: {url[:80]}")
+        return None

--- a/fly-worker/src/services/content_cleaner.py
+++ b/fly-worker/src/services/content_cleaner.py
@@ -1,0 +1,83 @@
+"""HTML content cleaner for article bodies.
+
+Strips unsafe HTML, normalizes whitespace, extracts readable text.
+"""
+
+import re
+
+from bs4 import BeautifulSoup
+
+# Tags to keep in cleaned content
+ALLOWED_TAGS = {
+    "p", "br", "b", "strong", "i", "em", "u",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "ul", "ol", "li", "blockquote", "a",
+}
+
+# Tags to remove entirely (including content)
+STRIP_TAGS = {
+    "script", "style", "iframe", "form", "input",
+    "nav", "footer", "header", "aside", "noscript",
+    "svg", "canvas", "video", "audio", "object", "embed",
+}
+
+
+def clean_html(html: str) -> str:
+    """Clean HTML content, keeping only safe readable elements."""
+    if not html:
+        return ""
+
+    soup = BeautifulSoup(html, "lxml")
+
+    # Remove unwanted tags entirely
+    for tag in soup.find_all(STRIP_TAGS):
+        tag.decompose()
+
+    # Remove all attributes except href on <a> tags
+    for tag in soup.find_all(True):
+        if tag.name == "a":
+            href = tag.get("href", "")
+            tag.attrs = {"href": href} if href else {}
+        else:
+            tag.attrs = {}
+
+    # Get cleaned HTML
+    cleaned = str(soup)
+
+    # Normalize whitespace
+    cleaned = re.sub(r"\n\s*\n", "\n\n", cleaned)
+    cleaned = re.sub(r"[ \t]+", " ", cleaned)
+
+    return cleaned.strip()
+
+
+def extract_text(html: str) -> str:
+    """Extract plain text from HTML, preserving paragraph breaks."""
+    if not html:
+        return ""
+
+    soup = BeautifulSoup(html, "lxml")
+
+    # Remove unwanted tags
+    for tag in soup.find_all(STRIP_TAGS):
+        tag.decompose()
+
+    text = soup.get_text(separator="\n")
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+
+    return text.strip()
+
+
+def count_words(text: str) -> int:
+    """Count words in text."""
+    if not text:
+        return 0
+    return len(text.split())
+
+
+def estimate_reading_time(word_count: int, wpm: int = 200) -> int:
+    """Estimate reading time in minutes."""
+    if word_count <= 0:
+        return 0
+    return max(1, round(word_count / wpm))

--- a/fly-worker/src/services/couchdb.py
+++ b/fly-worker/src/services/couchdb.py
@@ -1,0 +1,158 @@
+"""CouchDB async client for article document storage.
+
+Article bodies go to CouchDB. Metadata stays in Supabase Postgres.
+Uses httpx (already a dependency) — no extra packages needed.
+"""
+
+import httpx
+
+from src.config import settings
+
+
+class CouchDBClient:
+    """Lightweight async CouchDB client over HTTP/JSON."""
+
+    def __init__(self) -> None:
+        self._base_url = settings.couchdb_url.rstrip("/")
+        self._db = settings.couchdb_database
+        self._auth = (
+            (settings.couchdb_username, settings.couchdb_password)
+            if settings.couchdb_username
+            else None
+        )
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url,
+                auth=self._auth,
+                timeout=10.0,
+                headers={"Content-Type": "application/json"},
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def ping(self) -> bool:
+        """Check if CouchDB is reachable."""
+        try:
+            client = await self._get_client()
+            resp = await client.get("/")
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    async def ensure_db(self) -> None:
+        """Create the database if it doesn't exist."""
+        client = await self._get_client()
+        resp = await client.put(f"/{self._db}")
+        if resp.status_code not in (201, 412):  # 412 = already exists
+            print(f"[COUCHDB] ensure_db: {resp.status_code} {resp.text[:200]}")
+
+    async def create_indexes(self) -> None:
+        """Create useful indexes for querying."""
+        client = await self._get_client()
+        for field in ["type", "article_id", "source_id"]:
+            await client.post(
+                f"/{self._db}/_index",
+                json={
+                    "index": {"fields": [field]},
+                    "name": f"idx_{field}",
+                    "type": "json",
+                },
+            )
+
+    async def get_doc(self, doc_id: str) -> dict | None:
+        """Get a document by ID. Returns None if not found."""
+        try:
+            client = await self._get_client()
+            resp = await client.get(f"/{self._db}/{doc_id}")
+            if resp.status_code == 200:
+                return resp.json()
+            return None
+        except Exception as e:
+            print(f"[COUCHDB] get_doc error: {e}")
+            return None
+
+    async def put_doc(self, doc_id: str, doc: dict) -> str | None:
+        """Create or update a document. Returns the revision ID."""
+        try:
+            client = await self._get_client()
+            resp = await client.put(f"/{self._db}/{doc_id}", json=doc)
+            if resp.status_code in (201, 202):
+                return resp.json().get("rev")
+            print(f"[COUCHDB] put_doc error: {resp.status_code} {resp.text[:200]}")
+            return None
+        except Exception as e:
+            print(f"[COUCHDB] put_doc error: {e}")
+            return None
+
+    async def bulk_docs(self, docs: list[dict]) -> list[dict]:
+        """Insert/update multiple documents at once."""
+        try:
+            client = await self._get_client()
+            resp = await client.post(
+                f"/{self._db}/_bulk_docs",
+                json={"docs": docs},
+            )
+            if resp.status_code in (201, 202):
+                return resp.json()
+            print(f"[COUCHDB] bulk_docs error: {resp.status_code}")
+            return []
+        except Exception as e:
+            print(f"[COUCHDB] bulk_docs error: {e}")
+            return []
+
+    async def find(self, selector: dict, limit: int = 25) -> list[dict]:
+        """Query documents using Mango selector."""
+        try:
+            client = await self._get_client()
+            resp = await client.post(
+                f"/{self._db}/_find",
+                json={"selector": selector, "limit": limit},
+            )
+            if resp.status_code == 200:
+                return resp.json().get("docs", [])
+            return []
+        except Exception as e:
+            print(f"[COUCHDB] find error: {e}")
+            return []
+
+
+# Singleton instance
+_couchdb: CouchDBClient | None = None
+
+
+def get_couchdb() -> CouchDBClient:
+    """Get the singleton CouchDB client."""
+    global _couchdb
+    if _couchdb is None:
+        _couchdb = CouchDBClient()
+    return _couchdb
+
+
+async def init_couchdb() -> None:
+    """Initialize CouchDB: ensure database and indexes exist."""
+    if not settings.couchdb_url:
+        print("[COUCHDB] No COUCHDB_URL configured, skipping init")
+        return
+
+    client = get_couchdb()
+    if await client.ping():
+        await client.ensure_db()
+        await client.create_indexes()
+        print("[COUCHDB] Initialized successfully")
+    else:
+        print("[COUCHDB] Not reachable, will operate in Postgres-only mode")
+
+
+async def close_couchdb() -> None:
+    """Close the CouchDB client."""
+    global _couchdb
+    if _couchdb:
+        await _couchdb.close()
+        _couchdb = None

--- a/fly-worker/src/services/doris.py
+++ b/fly-worker/src/services/doris.py
@@ -1,0 +1,271 @@
+"""Apache Doris async client for analytics workloads.
+
+Uses HTTP API (Stream Load for writes, MySQL-compatible query for reads).
+Doris handles engagement counters, search indexing, and analytics aggregation.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import httpx
+
+from src.config import settings
+
+
+class DorisClient:
+    """Lightweight async Doris client over HTTP."""
+
+    def __init__(self) -> None:
+        self._http_url = settings.doris_http_url.rstrip("/")
+        self._db = settings.doris_database
+        self._auth = (settings.doris_username, settings.doris_password)
+        self._client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                auth=self._auth,
+                timeout=15.0,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def ping(self) -> bool:
+        """Check if Doris FE is reachable."""
+        try:
+            client = await self._get_client()
+            resp = await client.get(f"{self._http_url}/api/bootstrap")
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    async def query(self, sql: str) -> list[dict]:
+        """Execute a SQL query and return rows as dicts."""
+        try:
+            client = await self._get_client()
+            resp = await client.post(
+                f"{self._http_url}/api/query/{self._db}",
+                json={"stmt": sql},
+                headers={"Content-Type": "application/json"},
+            )
+            if resp.status_code != 200:
+                print(f"[DORIS] Query error: {resp.status_code} {resp.text[:200]}")
+                return []
+
+            data = resp.json()
+            if data.get("status") != "OK" and data.get("msg"):
+                print(f"[DORIS] Query error: {data['msg']}")
+                return []
+
+            # Parse Doris HTTP API response format
+            columns = data.get("data", {}).get("meta", [])
+            rows_data = data.get("data", {}).get("data", [])
+            col_names = [c.get("name", f"col_{i}") for i, c in enumerate(columns)]
+
+            return [dict(zip(col_names, row)) for row in rows_data]
+
+        except Exception as e:
+            print(f"[DORIS] Query error: {e}")
+            return []
+
+    async def stream_load(self, table: str, rows: list[dict]) -> bool:
+        """Load data into Doris via Stream Load (HTTP PUT with JSON)."""
+        if not rows:
+            return True
+
+        try:
+            client = await self._get_client()
+            # Stream Load expects JSON array
+            payload = json.dumps(rows)
+            resp = await client.put(
+                f"{self._http_url}/api/{self._db}/{table}/_stream_load",
+                content=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "format": "json",
+                    "strip_outer_array": "true",
+                },
+            )
+
+            if resp.status_code == 200:
+                result = resp.json()
+                status = result.get("Status", "")
+                if status in ("Success", "Publish Timeout"):
+                    return True
+                print(f"[DORIS] Stream Load {table}: {status} - {result.get('Message', '')[:200]}")
+            else:
+                print(f"[DORIS] Stream Load {table}: HTTP {resp.status_code}")
+
+            return False
+        except Exception as e:
+            print(f"[DORIS] Stream Load {table} error: {e}")
+            return False
+
+    async def initialize_tables(self) -> None:
+        """Create analytics tables if they don't exist."""
+        tables_sql = [
+            # Article engagement metrics — aggregate model (sums by key)
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.article_metrics (
+                article_id VARCHAR(36),
+                event_date DATE,
+                event_hour TINYINT,
+                country VARCHAR(4),
+                views BIGINT SUM DEFAULT "0",
+                likes BIGINT SUM DEFAULT "0",
+                bookmarks BIGINT SUM DEFAULT "0",
+                shares BIGINT SUM DEFAULT "0"
+            )
+            AGGREGATE KEY(article_id, event_date, event_hour, country)
+            DISTRIBUTED BY HASH(article_id) BUCKETS 8
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Article search index — duplicate model with inverted indexes
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.article_search (
+                article_id VARCHAR(36),
+                headline VARCHAR(500),
+                description TEXT,
+                keywords TEXT,
+                category VARCHAR(100),
+                country VARCHAR(4),
+                source_id VARCHAR(36),
+                datepublished DATETIME,
+                engagement_score DOUBLE DEFAULT "0",
+                INDEX idx_headline (headline) USING INVERTED PROPERTIES("parser" = "unicode"),
+                INDEX idx_description (description) USING INVERTED PROPERTIES("parser" = "unicode"),
+                INDEX idx_keywords (keywords) USING INVERTED PROPERTIES("parser" = "unicode")
+            )
+            DUPLICATE KEY(article_id)
+            DISTRIBUTED BY HASH(article_id) BUCKETS 8
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Source health history
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.source_health_history (
+                source_id VARCHAR(36),
+                check_date DATE,
+                health_status VARCHAR(20),
+                consecutive_failures INT,
+                articles_fetched INT,
+                quality_score DOUBLE
+            )
+            DUPLICATE KEY(source_id, check_date)
+            DISTRIBUTED BY HASH(source_id) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Search analytics — what people search for
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.search_analytics (
+                query_text VARCHAR(500),
+                search_date DATE,
+                search_hour TINYINT,
+                result_count INT,
+                country VARCHAR(4),
+                category VARCHAR(100)
+            )
+            DUPLICATE KEY(query_text, search_date, search_hour)
+            DISTRIBUTED BY HASH(query_text) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Category trending — aggregated topic scores
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.category_trending (
+                term_id VARCHAR(100),
+                term_name VARCHAR(200),
+                category VARCHAR(100),
+                country VARCHAR(4),
+                trend_date DATE,
+                article_count BIGINT SUM DEFAULT "0",
+                engagement_sum DOUBLE SUM DEFAULT "0"
+            )
+            AGGREGATE KEY(term_id, term_name, category, country, trend_date)
+            DISTRIBUTED BY HASH(term_id) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Publisher analytics — open data
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.publisher_analytics (
+                source_id VARCHAR(36),
+                source_name VARCHAR(200),
+                stat_date DATE,
+                articles_published BIGINT SUM DEFAULT "0",
+                total_views BIGINT SUM DEFAULT "0",
+                total_likes BIGINT SUM DEFAULT "0",
+                total_shares BIGINT SUM DEFAULT "0",
+                avg_quality DOUBLE REPLACE DEFAULT "0"
+            )
+            AGGREGATE KEY(source_id, source_name, stat_date)
+            DISTRIBUTED BY HASH(source_id) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+
+            # Open data access log — who queries the open analytics
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.open_data_access_log (
+                endpoint VARCHAR(200),
+                access_date DATE,
+                access_hour TINYINT,
+                request_count BIGINT SUM DEFAULT "0",
+                country VARCHAR(4)
+            )
+            AGGREGATE KEY(endpoint, access_date, access_hour, country)
+            DISTRIBUTED BY HASH(endpoint) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+
+            # User analytics — anonymized aggregate (PII stays in Postgres)
+            f"""CREATE TABLE IF NOT EXISTS {self._db}.user_analytics (
+                user_hash VARCHAR(64),
+                event_type VARCHAR(50),
+                event_date DATE,
+                event_hour TINYINT,
+                country VARCHAR(4),
+                event_count BIGINT SUM DEFAULT "0"
+            )
+            AGGREGATE KEY(user_hash, event_type, event_date, event_hour, country)
+            DISTRIBUTED BY HASH(user_hash) BUCKETS 4
+            PROPERTIES ("replication_num" = "1")""",
+        ]
+
+        client = await self._get_client()
+        for sql in tables_sql:
+            try:
+                resp = await client.post(
+                    f"{self._http_url}/api/query/{self._db}",
+                    json={"stmt": sql},
+                    headers={"Content-Type": "application/json"},
+                )
+                if resp.status_code != 200:
+                    print(f"[DORIS] Table creation issue: {resp.text[:200]}")
+            except Exception as e:
+                print(f"[DORIS] Table creation error: {e}")
+
+
+# Singleton
+_doris: DorisClient | None = None
+
+
+def get_doris() -> DorisClient:
+    """Get the singleton Doris client."""
+    global _doris
+    if _doris is None:
+        _doris = DorisClient()
+    return _doris
+
+
+async def init_doris() -> None:
+    """Initialize Doris: create tables if they don't exist."""
+    if not settings.doris_http_url:
+        print("[DORIS] No DORIS_HTTP_URL configured, skipping init")
+        return
+
+    client = get_doris()
+    if await client.ping():
+        await client.initialize_tables()
+        print("[DORIS] Initialized successfully")
+    else:
+        print("[DORIS] Not reachable, will operate in Postgres-only mode")
+
+
+async def close_doris() -> None:
+    """Close the Doris client."""
+    global _doris
+    if _doris:
+        await _doris.close()
+        _doris = None

--- a/fly-worker/src/services/embeddings.py
+++ b/fly-worker/src/services/embeddings.py
@@ -1,0 +1,152 @@
+"""BGE-M3 embedding service via Cloudflare Workers AI.
+
+Generates dense embeddings (1024 dimensions) using @cf/baai/bge-m3 for:
+- Article indexing during AI processing
+- Semantic search queries
+- Related article discovery
+
+BGE-M3 was chosen over Voyage AI for:
+- Open-source (MIT license, no vendor lock-in)
+- Multilingual support (100+ languages — critical for Pan-African content)
+- State-of-the-art retrieval performance on MTEB
+- 8192 token context window
+- Available on Cloudflare Workers AI (low-latency, no GPU management)
+"""
+
+import httpx
+
+from src.config import settings
+
+# BGE-M3 produces 1024-dimensional dense embeddings
+EMBEDDING_DIM = 1024
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_api_url() -> str:
+    """Build the Cloudflare Workers AI API URL for BGE-M3."""
+    return (
+        f"https://api.cloudflare.com/client/v4/accounts/"
+        f"{settings.cf_account_id}/ai/run/@cf/baai/bge-m3"
+    )
+
+
+def _get_client() -> httpx.AsyncClient:
+    """Get or create the HTTP client singleton."""
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(
+            headers={"Authorization": f"Bearer {settings.cf_ai_api_token}"},
+            timeout=30.0,
+        )
+    return _client
+
+
+async def embed_text(text: str) -> list[float] | None:
+    """Generate a dense embedding for a single text using BGE-M3.
+
+    Returns a 1024-dimensional vector, or None if the API is unavailable.
+    """
+    if not text.strip():
+        return None
+    if not settings.cf_account_id or not settings.cf_ai_api_token:
+        return None
+
+    truncated = text[:8000]  # Stay within token limits
+
+    try:
+        client = _get_client()
+        resp = await client.post(
+            _get_api_url(),
+            json={"text": [truncated]},
+        )
+
+        if resp.status_code != 200:
+            print(f"[EMBEDDINGS] CF Workers AI error: {resp.status_code} {resp.text[:200]}")
+            return None
+
+        data = resp.json()
+        result = data.get("result", {})
+        vectors = result.get("data", [])
+
+        if vectors and len(vectors) > 0:
+            return vectors[0]
+
+        print(f"[EMBEDDINGS] Unexpected response format: {str(data)[:200]}")
+        return None
+
+    except httpx.TimeoutException:
+        print("[EMBEDDINGS] CF Workers AI timeout")
+        return None
+    except Exception as e:
+        print(f"[EMBEDDINGS] Error generating embedding: {e}")
+        return None
+
+
+async def embed_batch(texts: list[str]) -> list[list[float] | None]:
+    """Generate embeddings for multiple texts.
+
+    Cloudflare Workers AI supports batch inputs (up to 100 texts).
+    Returns a list of embeddings (or None for failed items).
+    """
+    if not texts:
+        return []
+    if not settings.cf_account_id or not settings.cf_ai_api_token:
+        return [None] * len(texts)
+
+    # Filter and track empty strings
+    indexed_texts = [(i, t[:8000]) for i, t in enumerate(texts) if t.strip()]
+    if not indexed_texts:
+        return [None] * len(texts)
+
+    # CF Workers AI has a batch limit — process in chunks of 100
+    embeddings: list[list[float] | None] = [None] * len(texts)
+    chunk_size = 100
+
+    for chunk_start in range(0, len(indexed_texts), chunk_size):
+        chunk = indexed_texts[chunk_start : chunk_start + chunk_size]
+        batch_texts = [t for _, t in chunk]
+
+        try:
+            client = _get_client()
+            resp = await client.post(
+                _get_api_url(),
+                json={"text": batch_texts},
+            )
+
+            if resp.status_code != 200:
+                print(f"[EMBEDDINGS] Batch error: {resp.status_code} {resp.text[:200]}")
+                continue
+
+            data = resp.json()
+            vectors = data.get("result", {}).get("data", [])
+
+            for idx, (orig_idx, _) in enumerate(chunk):
+                if idx < len(vectors):
+                    embeddings[orig_idx] = vectors[idx]
+
+        except Exception as e:
+            print(f"[EMBEDDINGS] Batch chunk error: {e}")
+
+    return embeddings
+
+
+def build_article_text(article: dict) -> str:
+    """Build the text to embed for an article.
+
+    Combines headline + description + body preview for a comprehensive representation.
+    """
+    parts = [
+        article.get("headline", ""),
+        article.get("description", ""),
+        (article.get("article_body_processed", "") or article.get("articlebody", "") or "")[:2000],
+    ]
+    return " ".join(p for p in parts if p).strip()
+
+
+async def close_client() -> None:
+    """Close the HTTP client."""
+    global _client
+    if _client and not _client.is_closed:
+        await _client.aclose()
+        _client = None

--- a/fly-worker/src/services/jwt.py
+++ b/fly-worker/src/services/jwt.py
@@ -1,0 +1,49 @@
+"""Platform JWT utilities — service-to-service auth only.
+
+Signs and verifies HS256 JWTs for communication between
+mukoko-news and mukoko-platform. NOT used for user auth
+(Stytch session tokens handle that).
+"""
+
+import time
+import jwt
+from src.config import settings
+
+ALGORITHM = "HS256"
+ISSUER = "mukoko-news"
+
+
+def create_jwt(
+    user_id: str,
+    *,
+    role: str = "service_role",
+    person_id: str | None = None,
+) -> str:
+    """Create a service JWT for platform-to-platform calls."""
+    now = int(time.time())
+    payload: dict = {
+        "sub": user_id,
+        "aud": "authenticated",
+        "role": role,
+        "iss": ISSUER,
+        "iat": now,
+        "exp": now + 60 * 5,  # 5 minutes — short-lived for service calls
+    }
+    if person_id:
+        payload["person_id"] = person_id
+    return jwt.encode(payload, settings.platform_jwt_secret, algorithm=ALGORITHM)
+
+
+def verify_jwt(token: str) -> dict | None:
+    """Verify a service JWT from mukoko-platform."""
+    try:
+        payload = jwt.decode(
+            token,
+            settings.platform_jwt_secret,
+            algorithms=[ALGORITHM],
+            audience="authenticated",
+            issuer=["mukoko-news", "mukoko-platform"],
+        )
+        return payload
+    except jwt.PyJWTError:
+        return None

--- a/fly-worker/src/services/keyword_extractor.py
+++ b/fly-worker/src/services/keyword_extractor.py
@@ -1,0 +1,151 @@
+"""Keyword extraction from article content.
+
+Two-stage approach:
+1. Match against known keywords/terms from the database
+2. AI extraction for new terms (if Anthropic key is configured)
+"""
+
+import re
+
+from src.services import ai_client
+
+
+async def extract_keywords(
+    article: dict,
+    known_terms: list[dict],
+    section_keywords: list[str] | None = None,
+) -> list[dict]:
+    """Extract keywords from article content.
+
+    Args:
+        article: Article dict with headline, description, article_body.
+        known_terms: List of defined_term dicts from the database.
+        section_keywords: Classification keywords from the article's section.
+
+    Returns:
+        List of dicts with 'term_id', 'name', 'relevance_score', 'source'.
+    """
+    text = _build_search_text(article)
+    if not text:
+        return []
+
+    matched = []
+
+    # Stage 1: Match against known terms
+    text_lower = text.lower()
+    for term in known_terms:
+        name = term.get("name", "")
+        if name and _term_matches(name.lower(), text_lower):
+            matched.append({
+                "term_id": term["id"],
+                "name": name,
+                "relevance_score": _calc_relevance(name.lower(), text_lower),
+                "source": "auto",
+            })
+
+    # Stage 2: Match section classification keywords
+    if section_keywords:
+        for kw in section_keywords:
+            kw_lower = kw.lower()
+            if kw_lower in text_lower:
+                # Only add if not already matched
+                if not any(m["name"].lower() == kw_lower for m in matched):
+                    matched.append({
+                        "term_id": _make_term_id(kw),
+                        "name": kw,
+                        "relevance_score": 0.5,
+                        "source": "auto",
+                    })
+
+    # Stage 3: AI extraction for additional keywords
+    ai_keywords = await _ai_extract(article)
+    for kw in ai_keywords:
+        kw_lower = kw.lower()
+        if not any(m["name"].lower() == kw_lower for m in matched):
+            matched.append({
+                "term_id": _make_term_id(kw),
+                "name": kw,
+                "relevance_score": 0.7,
+                "source": "ai",
+            })
+
+    # Sort by relevance, limit to top 15
+    matched.sort(key=lambda x: x["relevance_score"], reverse=True)
+    return matched[:15]
+
+
+def _build_search_text(article: dict) -> str:
+    """Combine article fields into searchable text."""
+    parts = [
+        article.get("headline", ""),
+        article.get("description", ""),
+        (article.get("article_body", "") or "")[:2000],
+    ]
+    return " ".join(p for p in parts if p)
+
+
+def _term_matches(term: str, text: str) -> bool:
+    """Check if a term appears as a whole word in text."""
+    pattern = r"\b" + re.escape(term) + r"\b"
+    return bool(re.search(pattern, text, re.IGNORECASE))
+
+
+def _calc_relevance(term: str, text: str) -> float:
+    """Calculate relevance score based on frequency and position."""
+    # Count occurrences
+    pattern = r"\b" + re.escape(term) + r"\b"
+    matches = re.findall(pattern, text, re.IGNORECASE)
+    count = len(matches)
+
+    # Base score from count
+    if count >= 5:
+        score = 1.0
+    elif count >= 3:
+        score = 0.8
+    elif count >= 2:
+        score = 0.6
+    else:
+        score = 0.4
+
+    # Bonus if in first 200 chars (likely headline/lead)
+    first_match = re.search(pattern, text[:200], re.IGNORECASE)
+    if first_match:
+        score = min(1.0, score + 0.2)
+
+    return round(score, 2)
+
+
+async def _ai_extract(article: dict) -> list[str]:
+    """Use Claude to extract additional keywords."""
+    headline = article.get("headline", "")
+    description = article.get("description", "")
+    body_preview = (article.get("article_body", "") or "")[:1000]
+
+    if not headline:
+        return []
+
+    prompt = f"""Extract 5-10 key topics/keywords from this news article. Return ONLY a JSON array of strings.
+
+Headline: {headline}
+Description: {description}
+Content: {body_preview}
+
+Return format: ["keyword1", "keyword2", ...]"""
+
+    result = await ai_client.extract_json(
+        prompt,
+        system="You are a keyword extraction system. Return only a JSON array of keyword strings.",
+        max_tokens=256,
+    )
+
+    if isinstance(result, list):
+        return [str(k).strip() for k in result if isinstance(k, str) and k.strip()]
+
+    return []
+
+
+def _make_term_id(name: str) -> str:
+    """Generate a term ID from a keyword name."""
+    slug = re.sub(r"[^\w\s-]", "", name.lower())
+    slug = re.sub(r"[\s_]+", "-", slug).strip("-")
+    return slug[:100] or "unknown"

--- a/fly-worker/src/services/quality_scorer.py
+++ b/fly-worker/src/services/quality_scorer.py
@@ -1,0 +1,108 @@
+"""Deterministic article quality scoring using textstat.
+
+No AI calls — purely algorithmic based on content characteristics.
+"""
+
+import textstat
+
+
+def score_article(article: dict) -> dict:
+    """Score article quality based on content characteristics.
+
+    Returns dict with quality_score (0-100) and component scores.
+    """
+    text = (
+        article.get("articlebody")
+        or article.get("article_body")
+        or article.get("description")
+        or ""
+    )
+    headline = article.get("headline", "")
+
+    scores = {
+        "content_length": _score_content_length(text),
+        "readability": _score_readability(text),
+        "headline_quality": _score_headline(headline),
+        "has_image": 10.0 if article.get("image") else 0.0,
+        "has_author": 5.0 if (article.get("author") or article.get("author_name")) else 0.0,
+    }
+
+    # Weighted sum (out of 100)
+    weights = {
+        "content_length": 0.30,
+        "readability": 0.30,
+        "headline_quality": 0.20,
+        "has_image": 0.10,
+        "has_author": 0.10,
+    }
+
+    quality_score = sum(scores[k] * weights[k] for k in weights)
+
+    return {
+        "quality_score": round(min(100.0, max(0.0, quality_score)), 2),
+        "components": scores,
+    }
+
+
+def _score_content_length(text: str) -> float:
+    """Score based on article length. Sweet spot: 300-2000 words."""
+    if not text:
+        return 0.0
+
+    word_count = len(text.split())
+
+    if word_count < 50:
+        return 10.0
+    elif word_count < 150:
+        return 30.0
+    elif word_count < 300:
+        return 60.0
+    elif word_count <= 2000:
+        return 100.0
+    elif word_count <= 5000:
+        return 80.0
+    else:
+        return 60.0
+
+
+def _score_readability(text: str) -> float:
+    """Score readability using Flesch Reading Ease."""
+    if not text or len(text.split()) < 20:
+        return 50.0
+
+    try:
+        flesch = textstat.flesch_reading_ease(text)
+        # Flesch: 0-30 = very hard, 60-70 = standard, 90-100 = very easy
+        # For news, 50-70 is ideal
+        if 50 <= flesch <= 70:
+            return 100.0
+        elif 30 <= flesch < 50:
+            return 70.0
+        elif 70 < flesch <= 90:
+            return 80.0
+        elif flesch > 90:
+            return 60.0
+        else:
+            return 40.0
+    except Exception:
+        return 50.0
+
+
+def _score_headline(headline: str) -> float:
+    """Score headline quality based on length and characteristics."""
+    if not headline:
+        return 0.0
+
+    word_count = len(headline.split())
+
+    # Ideal headline: 6-15 words
+    if word_count < 3:
+        return 20.0
+    elif word_count < 6:
+        return 60.0
+    elif word_count <= 15:
+        return 100.0
+    elif word_count <= 20:
+        return 70.0
+    else:
+        return 40.0

--- a/fly-worker/src/services/rss_parser.py
+++ b/fly-worker/src/services/rss_parser.py
@@ -1,0 +1,224 @@
+"""RSS/Atom feed parser using feedparser.
+
+Parses RSS/Atom XML into normalized article dicts aligned to schema.org NewsArticle.
+"""
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+import feedparser
+from bs4 import BeautifulSoup
+
+
+def parse_feed(xml_content: str, source: dict) -> dict:
+    """Parse RSS/Atom feed XML into normalized articles.
+
+    Args:
+        xml_content: Raw XML string from the feed.
+        source: Joined feed_source + organization record from the database.
+            Expected keys: id (feed_source UUID), organization_id, org_name,
+            feed_url, country, article_section_slug, language.
+
+    Returns:
+        Dict with 'articles' list and 'feed_title'.
+    """
+    feed = feedparser.parse(xml_content)
+    articles = []
+
+    for entry in feed.entries[:20]:
+        article = _parse_entry(entry, source, feed)
+        if article:
+            articles.append(article)
+
+    return {
+        "articles": articles,
+        "feed_title": getattr(feed.feed, "title", ""),
+        "item_count": len(feed.entries),
+    }
+
+
+def _parse_entry(entry, source: dict, feed) -> dict | None:
+    """Parse a single feed entry into a schema.org-aligned article dict."""
+    headline = _clean_text(getattr(entry, "title", ""))
+    if not headline:
+        return None
+
+    main_entity_of_page = getattr(entry, "link", "")
+    if not main_entity_of_page:
+        return None
+
+    # RSS guid for deduplication
+    rss_guid = getattr(entry, "id", main_entity_of_page)
+
+    # schema:datePublished
+    date_published = _parse_date(entry)
+    if not date_published:
+        date_published = datetime.now(timezone.utc)
+
+    # schema:description
+    description = ""
+    if hasattr(entry, "summary"):
+        description = _strip_html(entry.summary)[:500]
+    elif hasattr(entry, "description"):
+        description = _strip_html(entry.description)[:500]
+
+    # schema:articleBody (from content:encoded or full description)
+    article_body = ""
+    if hasattr(entry, "content") and entry.content:
+        article_body = entry.content[0].get("value", "")
+    elif hasattr(entry, "summary_detail"):
+        article_body = entry.summary_detail.get("value", "")
+
+    # schema:author — JSONB string for asyncpg
+    author_raw = _extract_author(entry)
+    author = json.dumps({"@type": "Person", "name": author_raw}) if author_raw else None
+
+    # schema:image — JSONB string for asyncpg
+    image_url = _extract_image(entry)
+    image = json.dumps({"url": image_url}) if image_url else None
+
+    # schema:articleSection from source default
+    articlesection = source.get("article_section_slug", "general")
+
+    # Generate slug from headline
+    slug = _slugify(headline)
+
+    # Content fingerprint for deduplication
+    content_for_hash = f"{headline}{main_entity_of_page}"
+    source_fingerprint = hashlib.sha256(content_for_hash.encode()).hexdigest()[:16]
+
+    # Publisher as JSONB string for asyncpg
+    org_name = source.get("org_name", "")
+    publisher = json.dumps({"@type": "Organization", "name": org_name}) if org_name else None
+
+    return {
+        "headline": headline[:500],
+        "description": description,
+        "article_body": article_body,
+        "slug": slug,
+        "mainentityofpage": main_entity_of_page,
+        "source_feed_id": rss_guid,
+        "image": image,
+        "author": author,
+        "publisher_organization_id": source.get("organization_id"),
+        "publisher": publisher,
+        "articlesection": articlesection,
+        "primary_location_country": source.get("country", "ZW"),
+        "datepublished": date_published,
+        "source_fingerprint": source_fingerprint,
+        "inlanguage": source.get("language", "en"),
+    }
+
+
+def _parse_date(entry) -> datetime | None:
+    """Extract and parse publication date from a feed entry."""
+    for attr in ("published_parsed", "updated_parsed"):
+        parsed = getattr(entry, attr, None)
+        if parsed:
+            try:
+                from calendar import timegm
+                ts = timegm(parsed)
+                return datetime.fromtimestamp(ts, tz=timezone.utc)
+            except (ValueError, OverflowError):
+                continue
+
+    for attr in ("published", "updated"):
+        raw = getattr(entry, attr, None)
+        if raw:
+            try:
+                return parsedate_to_datetime(raw).replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                pass
+            try:
+                return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                pass
+
+    return None
+
+
+def _extract_author(entry) -> str:
+    """Extract author name from feed entry."""
+    if hasattr(entry, "author_detail"):
+        return getattr(entry.author_detail, "name", "") or ""
+    if hasattr(entry, "author"):
+        return entry.author or ""
+    if hasattr(entry, "dc_creator"):
+        return entry.dc_creator or ""
+    return ""
+
+
+def _extract_image(entry) -> str | None:
+    """Extract primary image URL from feed entry."""
+    # media:content
+    if hasattr(entry, "media_content") and entry.media_content:
+        for media in entry.media_content:
+            url = media.get("url", "")
+            medium = media.get("medium", "")
+            mime = media.get("type", "")
+            if medium == "image" or mime.startswith("image/") or _looks_like_image(url):
+                return url
+
+    # media:thumbnail
+    if hasattr(entry, "media_thumbnail") and entry.media_thumbnail:
+        return entry.media_thumbnail[0].get("url")
+
+    # enclosures
+    if hasattr(entry, "enclosures") and entry.enclosures:
+        for enc in entry.enclosures:
+            if enc.get("type", "").startswith("image/"):
+                return enc.get("href") or enc.get("url")
+
+    # Try to find <img> in content/summary
+    for attr in ("summary", "description"):
+        html = getattr(entry, attr, "")
+        if html:
+            img = _extract_img_from_html(html)
+            if img:
+                return img
+
+    return None
+
+
+def _extract_img_from_html(html: str) -> str | None:
+    """Extract first <img> src from HTML content."""
+    soup = BeautifulSoup(html, "lxml")
+    img = soup.find("img")
+    if img and img.get("src"):
+        src = img["src"]
+        if isinstance(src, str) and src.startswith("http"):
+            return src
+    return None
+
+
+def _looks_like_image(url: str) -> bool:
+    """Check if a URL looks like an image based on extension."""
+    return bool(re.search(r"\.(jpg|jpeg|png|gif|webp|svg)(\?.*)?$", url, re.IGNORECASE))
+
+
+def _strip_html(html: str) -> str:
+    """Remove HTML tags and normalize whitespace."""
+    if not html:
+        return ""
+    soup = BeautifulSoup(html, "lxml")
+    text = soup.get_text(separator=" ")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _clean_text(text: str) -> str:
+    """Clean and normalize text."""
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _slugify(text: str) -> str:
+    """Generate URL-safe slug from text."""
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug)
+    return slug[:200].strip("-")

--- a/fly-worker/src/services/stytch_client.py
+++ b/fly-worker/src/services/stytch_client.py
@@ -1,0 +1,28 @@
+"""Stytch client wrapper for email OTP authentication.
+
+Email OTP is the primary auth method. SMS OTP secondary.
+"""
+
+import stytch
+
+from src.config import settings
+
+_client: stytch.Client | None = None
+
+
+def get_stytch_client() -> stytch.Client:
+    """Get the Stytch client singleton."""
+    global _client
+    if _client is None:
+        if not settings.stytch_project_id or not settings.stytch_secret:
+            raise RuntimeError("Stytch credentials not configured")
+        _client = stytch.Client(
+            project_id=settings.stytch_project_id,
+            secret=settings.stytch_secret,
+        )
+    return _client
+
+
+def is_stytch_configured() -> bool:
+    """Check if Stytch credentials are available."""
+    return bool(settings.stytch_project_id and settings.stytch_secret)

--- a/fly-worker/tests/conftest.py
+++ b/fly-worker/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared test fixtures for Fly.io worker tests."""
+
+import pytest
+
+
+@pytest.fixture
+def sample_source():
+    """A sample organization (RSS source) record."""
+    return {
+        "id": "test-source",
+        "org_name": "Test News",
+        "url": "https://test-news.example.com",
+        "rss_feed_url": "https://test-news.example.com/feed/",
+        "country": "ZW",
+        "article_section_slug": "general",
+        "language": "en",
+        "health_status": "healthy",
+        "consecutive_failures": 0,
+        "last_fetched_at": None,
+    }
+
+
+@pytest.fixture
+def sample_rss_xml():
+    """A minimal valid RSS 2.0 feed."""
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test News</title>
+    <link>https://test-news.example.com</link>
+    <description>Test news feed</description>
+    <item>
+      <title>Zimbabwe Parliament Opens New Session</title>
+      <link>https://test-news.example.com/article/1</link>
+      <description>Parliament opened its new session today with key debates on economic reform.</description>
+      <pubDate>Mon, 10 Mar 2026 10:00:00 +0200</pubDate>
+      <guid>https://test-news.example.com/article/1</guid>
+      <author>Jane Reporter</author>
+      <category>Politics</category>
+      <enclosure url="https://test-news.example.com/images/parliament.jpg" type="image/jpeg" />
+    </item>
+    <item>
+      <title>Gold Prices Surge on Global Demand</title>
+      <link>https://test-news.example.com/article/2</link>
+      <description>Gold prices hit record highs driven by increased demand from Asian markets.</description>
+      <pubDate>Mon, 10 Mar 2026 08:30:00 +0200</pubDate>
+      <guid>https://test-news.example.com/article/2</guid>
+      <author>John Finance</author>
+    </item>
+    <item>
+      <title></title>
+      <link></link>
+      <description>This entry has no title or link and should be skipped.</description>
+    </item>
+  </channel>
+</rss>"""
+
+
+@pytest.fixture
+def sample_atom_xml():
+    """A minimal valid Atom feed."""
+    return """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Test Atom Feed</title>
+  <link href="https://test-news.example.com"/>
+  <entry>
+    <title>New Tech Hub Opens in Harare</title>
+    <link href="https://test-news.example.com/article/3"/>
+    <id>urn:uuid:test-article-3</id>
+    <updated>2026-03-10T12:00:00Z</updated>
+    <summary>A new technology hub has opened in Harare CBD.</summary>
+    <author><name>Tech Reporter</name></author>
+  </entry>
+</feed>"""
+
+
+@pytest.fixture
+def sample_article():
+    """A sample article dict as returned by the RSS parser."""
+    return {
+        "headline": "Zimbabwe Parliament Opens New Session",
+        "description": "Parliament opened its new session today.",
+        "articlebody": "<p>Parliament opened its new session today with key debates.</p>",
+        "slug": "zimbabwe-parliament-opens-new-session",
+        "mainentityofpage": "https://test-news.example.com/article/1",
+        "source_feed_id": "https://test-news.example.com/article/1",
+        "image": {"url": "https://test-news.example.com/images/parliament.jpg"},
+        "author": {"@type": "Person", "name": "Jane Reporter"},
+        "publisher_organization_id": "test-source",
+        "publisher": {"@type": "Organization", "name": "Test News"},
+        "articlesection": "politics",
+        "primary_location_country": "ZW",
+        "datepublished": "2026-03-10T10:00:00+02:00",
+        "source_fingerprint": "abc123def456",
+        "inlanguage": "en",
+    }

--- a/fly-worker/tests/test_content_cleaner.py
+++ b/fly-worker/tests/test_content_cleaner.py
@@ -1,0 +1,68 @@
+"""Tests for content cleaner service."""
+
+from src.services.content_cleaner import clean_html, extract_text, count_words, estimate_reading_time
+
+
+class TestCleanHtml:
+    def test_removes_script_tags(self):
+        html = '<p>Hello</p><script>alert("xss")</script><p>World</p>'
+        result = clean_html(html)
+        assert "script" not in result
+        assert "alert" not in result
+        assert "Hello" in result
+        assert "World" in result
+
+    def test_removes_style_tags(self):
+        html = '<style>.foo{color:red}</style><p>Content</p>'
+        result = clean_html(html)
+        assert "style" not in result.lower() or "<style" not in result
+        assert "Content" in result
+
+    def test_strips_attributes_except_href(self):
+        html = '<p class="fancy" id="p1">Text</p><a href="https://example.com" class="link">Link</a>'
+        result = clean_html(html)
+        assert 'class=' not in result
+        assert 'id=' not in result
+        assert 'href="https://example.com"' in result
+
+    def test_empty_input(self):
+        assert clean_html("") == ""
+        assert clean_html(None) == ""
+
+
+class TestExtractText:
+    def test_extracts_plain_text(self):
+        html = "<h1>Title</h1><p>Paragraph one.</p><p>Paragraph two.</p>"
+        text = extract_text(html)
+        assert "Title" in text
+        assert "Paragraph one." in text
+        assert "Paragraph two." in text
+        assert "<" not in text
+
+    def test_empty_input(self):
+        assert extract_text("") == ""
+
+
+class TestCountWords:
+    def test_counts_words(self):
+        assert count_words("one two three") == 3
+
+    def test_empty_string(self):
+        assert count_words("") == 0
+
+    def test_whitespace_only(self):
+        assert count_words("   ") == 0
+
+
+class TestEstimateReadingTime:
+    def test_short_article(self):
+        assert estimate_reading_time(100) == 1  # 100 words = 0.5 min, rounds to 1
+
+    def test_medium_article(self):
+        assert estimate_reading_time(600) == 3  # 600 / 200 = 3
+
+    def test_zero_words(self):
+        assert estimate_reading_time(0) == 0
+
+    def test_negative_words(self):
+        assert estimate_reading_time(-10) == 0

--- a/fly-worker/tests/test_engagement.py
+++ b/fly-worker/tests/test_engagement.py
@@ -1,0 +1,75 @@
+"""Tests for engagement score computation."""
+
+from datetime import datetime, timezone
+
+from src.jobs.engagement import _compute_score
+
+
+class TestComputeScore:
+    def test_zero_engagement(self):
+        article = {
+            "view_count": 0,
+            "like_count": 0,
+            "bookmark_count": 0,
+            "share_count": 0,
+            "datepublished": datetime.now(timezone.utc),
+        }
+        assert _compute_score(article) == 0.0
+
+    def test_basic_engagement(self):
+        article = {
+            "view_count": 100,
+            "like_count": 10,
+            "bookmark_count": 5,
+            "share_count": 3,
+            "datepublished": datetime.now(timezone.utc),
+        }
+        score = _compute_score(article)
+        # raw = 100*1 + 10*3 + 5*5 + 3*2 = 100 + 30 + 25 + 6 = 161
+        # decay = 1 / (1 + 0/48) = 1.0
+        # score = 161 * 1.0 = 161, but >100 so log scale
+        assert score > 100
+
+    def test_time_decay(self):
+        from datetime import timedelta
+
+        recent = {
+            "view_count": 50,
+            "like_count": 5,
+            "bookmark_count": 0,
+            "share_count": 0,
+            "datepublished": datetime.now(timezone.utc),
+        }
+        old = {
+            "view_count": 50,
+            "like_count": 5,
+            "bookmark_count": 0,
+            "share_count": 0,
+            "datepublished": datetime.now(timezone.utc) - timedelta(hours=96),
+        }
+
+        recent_score = _compute_score(recent)
+        old_score = _compute_score(old)
+
+        assert recent_score > old_score
+
+    def test_none_values_treated_as_zero(self):
+        article = {
+            "view_count": None,
+            "like_count": None,
+            "bookmark_count": None,
+            "share_count": None,
+            "datepublished": datetime.now(timezone.utc),
+        }
+        assert _compute_score(article) == 0.0
+
+    def test_no_date_published(self):
+        article = {
+            "view_count": 10,
+            "like_count": 0,
+            "bookmark_count": 0,
+            "share_count": 0,
+            "datepublished": None,
+        }
+        score = _compute_score(article)
+        assert score > 0  # Uses 0.5 decay fallback

--- a/fly-worker/tests/test_quality_scorer.py
+++ b/fly-worker/tests/test_quality_scorer.py
@@ -1,0 +1,64 @@
+"""Tests for quality scorer service."""
+
+from src.services.quality_scorer import score_article, _score_content_length, _score_headline
+
+
+class TestScoreArticle:
+    def test_high_quality_article(self):
+        article = {
+            "headline": "Zimbabwe Economy Shows Strong Recovery Signs in Q1 2026",
+            "articlebody": " ".join(["word"] * 500),
+            "image": {"url": "https://example.com/img.jpg"},
+            "author": {"@type": "Person", "name": "Jane Reporter"},
+        }
+        result = score_article(article)
+        assert result["quality_score"] > 50
+        assert "components" in result
+
+    def test_low_quality_article(self):
+        article = {
+            "headline": "Hi",
+            "articlebody": "Short.",
+            "image": None,
+            "author": None,
+        }
+        result = score_article(article)
+        assert result["quality_score"] < 50
+
+    def test_empty_article(self):
+        result = score_article({})
+        assert result["quality_score"] >= 0
+        assert result["quality_score"] <= 100
+
+    def test_score_bounded(self):
+        article = {
+            "headline": "A" * 200,
+            "articlebody": " ".join(["word"] * 10000),
+            "image": {"url": "img.jpg"},
+            "author": {"@type": "Person", "name": "Author"},
+        }
+        result = score_article(article)
+        assert 0 <= result["quality_score"] <= 100
+
+
+class TestScoreContentLength:
+    def test_very_short(self):
+        assert _score_content_length("one two three") == 10.0
+
+    def test_ideal_length(self):
+        text = " ".join(["word"] * 500)
+        assert _score_content_length(text) == 100.0
+
+    def test_empty(self):
+        assert _score_content_length("") == 0.0
+
+
+class TestScoreHeadline:
+    def test_ideal_headline(self):
+        assert _score_headline("Zimbabwe Parliament Opens New Session Today") == 100.0
+
+    def test_too_short(self):
+        assert _score_headline("Hi") < 50
+
+    def test_empty(self):
+        assert _score_headline("") == 0.0

--- a/fly-worker/tests/test_rss_parser.py
+++ b/fly-worker/tests/test_rss_parser.py
@@ -1,0 +1,117 @@
+"""Tests for RSS/Atom feed parser."""
+
+import json
+
+from src.services.rss_parser import parse_feed, _slugify, _strip_html, _extract_img_from_html
+
+
+class TestParseFeed:
+    def test_parses_rss_articles(self, sample_rss_xml, sample_source):
+        result = parse_feed(sample_rss_xml, sample_source)
+
+        assert result["feed_title"] == "Test News"
+        assert len(result["articles"]) == 2  # Third item has no title/link
+        assert result["item_count"] == 3
+
+    def test_first_article_fields(self, sample_rss_xml, sample_source):
+        result = parse_feed(sample_rss_xml, sample_source)
+        article = result["articles"][0]
+
+        assert article["headline"] == "Zimbabwe Parliament Opens New Session"
+        assert article["mainentityofpage"] == "https://test-news.example.com/article/1"
+        assert article["source_feed_id"] == "https://test-news.example.com/article/1"
+        assert article["publisher_organization_id"] == sample_source.get("organization_id")
+        publisher = json.loads(article["publisher"])
+        assert publisher["name"] == "Test News"
+        assert article["primary_location_country"] == "ZW"
+        assert article["inlanguage"] == "en"
+        assert article["source_fingerprint"] is not None
+        assert article["slug"] is not None
+
+    def test_extracts_author(self, sample_rss_xml, sample_source):
+        result = parse_feed(sample_rss_xml, sample_source)
+        author_0 = json.loads(result["articles"][0]["author"])
+        author_1 = json.loads(result["articles"][1]["author"])
+        assert author_0["name"] == "Jane Reporter"
+        assert author_1["name"] == "John Finance"
+
+    def test_extracts_image_from_enclosure(self, sample_rss_xml, sample_source):
+        result = parse_feed(sample_rss_xml, sample_source)
+        image = json.loads(result["articles"][0]["image"])
+        assert image["url"] == "https://test-news.example.com/images/parliament.jpg"
+
+    def test_skips_entries_without_title(self, sample_rss_xml, sample_source):
+        result = parse_feed(sample_rss_xml, sample_source)
+        # Only 2 articles because third has empty title
+        assert len(result["articles"]) == 2
+
+    def test_parses_atom_feed(self, sample_atom_xml, sample_source):
+        result = parse_feed(sample_atom_xml, sample_source)
+
+        assert len(result["articles"]) == 1
+        article = result["articles"][0]
+        assert article["headline"] == "New Tech Hub Opens in Harare"
+        author = json.loads(article["author"])
+        assert author["name"] == "Tech Reporter"
+
+    def test_empty_feed(self, sample_source):
+        result = parse_feed("", sample_source)
+        assert result["articles"] == []
+
+    def test_malformed_xml(self, sample_source):
+        result = parse_feed("<not>valid<xml", sample_source)
+        assert result["articles"] == []
+
+    def test_limits_to_20_articles(self, sample_source):
+        items = "".join(
+            f'<item><title>Article {i}</title><link>https://example.com/{i}</link></item>'
+            for i in range(30)
+        )
+        xml = f'<rss version="2.0"><channel><title>Test</title>{items}</channel></rss>'
+        result = parse_feed(xml, sample_source)
+        assert len(result["articles"]) == 20
+
+    def test_headline_truncated_at_500(self, sample_source):
+        long_title = "A" * 600
+        xml = f'<rss version="2.0"><channel><title>T</title><item><title>{long_title}</title><link>https://example.com/1</link></item></channel></rss>'
+        result = parse_feed(xml, sample_source)
+        assert len(result["articles"][0]["headline"]) == 500
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert _slugify("Hello World") == "hello-world"
+
+    def test_special_chars(self):
+        assert _slugify("What's Up? (2026)") == "whats-up-2026"
+
+    def test_multiple_spaces(self):
+        assert _slugify("too   many   spaces") == "too-many-spaces"
+
+    def test_max_length(self):
+        long = "a" * 300
+        assert len(_slugify(long)) <= 200
+
+
+class TestStripHtml:
+    def test_removes_tags(self):
+        assert _strip_html("<p>Hello <b>world</b></p>") == "Hello world"
+
+    def test_empty_string(self):
+        assert _strip_html("") == ""
+
+    def test_preserves_text(self):
+        assert _strip_html("plain text") == "plain text"
+
+
+class TestExtractImgFromHtml:
+    def test_finds_img(self):
+        html = '<p>Text</p><img src="https://example.com/img.jpg" />'
+        assert _extract_img_from_html(html) == "https://example.com/img.jpg"
+
+    def test_no_img(self):
+        assert _extract_img_from_html("<p>No image here</p>") is None
+
+    def test_relative_img_ignored(self):
+        html = '<img src="/relative/path.jpg" />'
+        assert _extract_img_from_html(html) is None


### PR DESCRIPTION
Brings the Fly.io FastAPI backend from PR #104 into the repo as `fly-worker/` — no breaking frontend changes included.

**What's in fly-worker:**
- FastAPI app serving the news API on Fly.io (Johannesburg, `jnb`)
- Supabase PostgreSQL as primary database
- CouchDB for article body storage
- Apache Doris for analytics/search
- APScheduler for background jobs: RSS collection, AI processing, engagement scoring
- Stytch for user auth
- 5 PostgreSQL migrations (schema, seed, pgvector embeddings, auth columns)

**Not included from PR #104:**
- Consumer page removals (discover, newsbytes, search, saved, profile)
- Console rebrand / AuthProvider context changes
- Frontend sign-in page

Those will be addressed in the pipeline/stack redesign phase.

Closes #104

https://claude.ai/code/session_017p7rweMYrwVrr2kq53nJRs

---
_Generated by [Claude Code](https://claude.ai/code/session_017p7rweMYrwVrr2kq53nJRs)_