### PR TITLE
docs: refresh CLAUDE.md + feed UI fixes (category bar, infinite scroll, category nav)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: read
 
 jobs:
+  # ── Repo hygiene linters (file/format checks) ──────────────────────────────
+  # These five matrix entries are the branch-protection required checks
+  # (lint / actionlint, lint / JSON validity, lint / prettier, …). Keep their
+  # names stable so the org ruleset keeps matching them.
   lint:
     runs-on: ubuntu-latest
     name: lint / ${{ matrix.check }}
@@ -64,31 +68,61 @@ jobs:
         pip install yamllint
         yamllint -c .yamllint.yml .
 
-  test-frontend:
+  # ── Frontend pipeline ──────────────────────────────────────────────────────
+  # Sequential stages (ESLint → Typecheck → Test → Build) so the Actions graph
+  # shows a clear pipeline and pinpoints exactly which stage failed, instead of
+  # bundling everything into one opaque job.
+  eslint:
     runs-on: ubuntu-latest
-    name: Test Frontend (Next.js)
-
+    name: ESLint
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
         cache: 'npm'
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Run frontend unit tests
-      run: npm run test
-
-    - name: Type check
-      run: npm run typecheck
-
-    - name: Lint
+    - run: npm ci
+    - name: Run ESLint
       run: npm run lint
 
+  typecheck:
+    runs-on: ubuntu-latest
+    name: Typecheck
+    needs: eslint
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+    - run: npm ci
+    - name: Run tsc --noEmit
+      run: npm run typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    name: Test
+    needs: typecheck
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+    - run: npm ci
+    - name: Run Vitest
+      run: npm run test
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    needs: test
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+    - run: npm ci
     - name: Build Next.js
       run: npm run build

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,10 +4,6 @@
       "type": "http",
       "url": "https://news.mukoko.com/mcp"
     },
-    "nyuchi-mongodb": {
-      "type": "http",
-      "url": "https://mongodb.nyuchi.dev/mcp"
-    },
     "fly": {
       "type": "stdio",
       "command": "flyctl",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,37 +11,43 @@ Mukoko News is a Pan-African digital news aggregation platform. "Mukoko" means "
 This repo (`nyuchi/mukoko-news`) is the **Next.js frontend only**. It deploys to Vercel.
 
 | Repo | Contents | Deploys to |
-|---|---|---|
+| --- | --- | --- |
 | `nyuchi/mukoko-news` | Next.js 15 frontend | Vercel |
 | `nyuchi/mukoko-news-gateway` | Cloudflare Workers API + MCP | Cloudflare Workers |
 | `nyuchi/mukoko-news-pipeline` | Fly.io pipeline + Cloudflare processing | Fly.io + Cloudflare |
 
 **Hard rules for this repo:**
 - Frontend reads/writes directly to MongoDB Atlas via Next.js Server Actions — never through the gateway Worker
-- The gateway (`news.mukoko.com/api/*`, `/mcp`) is a separate product API; the frontend does not call it except for admin mutations (see `src/lib/admin/gateway.ts`)
-- The only external trigger is the pipeline refresh (one server action that pings the fly-worker)
+- The gateway (`news.mukoko.com/api/*`, `/mcp`) is a separate product API; the frontend does not call it except for **admin mutations** (see `src/lib/admin/gateway.ts`)
+- The only external trigger is the pipeline refresh — one server action (`src/lib/actions/refresh.ts`) that pings the Fly.io worker's `/trigger/collect` endpoint
+
+> History: the gateway and pipeline used to live in this repo. They were extracted in the v5.1.0 three-repo split (see `CHANGELOG.md`). If you find references to `backend/`, `fly-worker/`, `processing/`, etc., they are stale — those directories no longer exist here.
 
 ## Commands
 
+The repo ships **both** a `package-lock.json` and a `pnpm-lock.yaml`. The human-facing docs (`README.md`, `CONTRIBUTING.md`) use **pnpm**, but **CI (`deploy.yml`) and the Husky pre-commit hook use `npm`**. Either works locally; if you change dependencies, update **both** lockfiles to keep them consistent (or CI's `npm ci` will drift from local `pnpm install`).
+
 ```bash
-pnpm dev              # Next.js dev server (port 3000)
-pnpm build            # Production build
-pnpm lint             # ESLint check
-pnpm lint:fix         # ESLint auto-fix
-pnpm typecheck        # TypeScript check
-pnpm test             # Vitest (single run)
-pnpm test:watch       # Vitest (watch mode)
-pnpm test:coverage    # Vitest with v8 coverage
+# pnpm (documented dev workflow) / npm equivalents both shown
+pnpm dev              # next dev — dev server on :3000   (npm run dev)
+pnpm build            # next build — production build      (npm run build)
+pnpm start            # next start — serve the build       (npm run start)
+pnpm lint             # next lint (ESLint)                 (npm run lint)
+pnpm lint:fix         # next lint --fix                    (npm run lint:fix)
+pnpm typecheck        # tsc --noEmit                       (npm run typecheck)
+pnpm test             # vitest run (single run)            (npm run test)
+pnpm test:watch       # vitest (watch mode)               (npm run test:watch)
+pnpm test:coverage    # vitest run --coverage (v8)         (npm run test:coverage)
+pnpm clean            # rm -rf .next out                   (npm run clean)
 
 # Run a single test file
 pnpm vitest run src/lib/__tests__/utils.test.ts
-# Run tests matching a pattern
+# Run tests matching a pattern (-t = test name)
 pnpm vitest run -t "formatTimeAgo"
 
-# Install dependencies
-pnpm install
-# Add a new package
-pnpm add <package>
+# Install dependencies / add a package
+pnpm install          # or: npm ci  (CI uses npm ci)
+pnpm add <package>    # or: npm install <package>
 ```
 
 ## Architecture
@@ -52,88 +58,149 @@ pnpm add <package>
 - **Tailwind CSS 4.x** with CSS variables for theming (defined in `src/app/globals.css`)
 - **Radix UI** primitives for accessible components
 - **Lucide React** for icons, **next-themes** for dark mode
-- **MongoDB** — Server Actions in `src/lib/actions/feed.ts` call `src/lib/mongodb/*.ts` → MongoDB Atlas directly
-- **WorkOS AuthKit** (`@workos-inc/authkit-nextjs`) — authentication, session management via `src/middleware.ts`
-- **State**: React Context (`PreferencesContext` for country/category, `ThemeContext`)
+- **MongoDB driver v7** — Server Actions in `src/lib/actions/*.ts` call `src/lib/mongodb/*.ts` → MongoDB Atlas directly
+- **WorkOS AuthKit** (`@workos-inc/authkit-nextjs`, `authkit-js`, `@workos-inc/node`) — authentication + RBAC
+- **State**: React Context — `PreferencesContext` (`src/contexts/preferences-context.tsx`, country/category) and theme via `next-themes`
 - **Path alias**: `@/*` maps to `src/*`
-- **Package manager**: pnpm (v10+)
 
-### Data Flow
+### Directory Map
 
-All news data reads go through Server Actions → MongoDB Atlas (`news` database):
+```
+src/
+  app/                     # App Router pages (kebab-case dirs)
+    page.tsx               # Home feed
+    article/[id]/          # Article detail (server page + client component)
+    discover/ search/ saved/ categories/ sources/ newsbytes/ insights/ analytics/
+    admin/                 # RBAC-gated admin app (layout.tsx enforces tier)
+    embed/ embed/iframe/   # Embeddable widget renderer
+    auth/callback/route.ts # WorkOS OAuth callback
+    api/                   # Route Handlers (engagement + health) — see below
+    sitemap.ts globals.css layout.tsx
+  components/              # UI + feature components
+    ui/                    # Primitives (button, card, skeleton, error-boundary, json-ld, …)
+    admin/ auth/ layout/   # Feature-scoped components
+    article-card.tsx hero-card.tsx compact-card.tsx story-cluster.tsx share-modal.tsx …
+  contexts/               # React Context providers
+  lib/
+    actions/              # 'use server' Server Actions (feed.ts, refresh.ts)
+    mongodb/              # Mongo client + collection queries (articles, categories, sources, admin)
+    admin/gateway.ts      # The ONLY frontend→gateway calls (admin mutations)
+    auth/                 # roles.ts (RBAC tiers), actions.ts
+    api.ts constants.ts utils.ts rate-limit.ts source-profiles.ts
+  middleware.ts           # AuthKit session-refresh middleware
+  __tests__/setup.ts      # Vitest global setup
+```
 
-- `src/lib/actions/feed.ts` — `getArticlesAction`, `getCategoriesAction`, `getSourcesAction`, `getKeywordsAction`
-- `src/lib/mongodb/articles.ts` — article queries
-- `src/lib/mongodb/categories.ts` — category queries
-- `src/lib/mongodb/sources.ts` — source queries
+### Data Flow (reads)
 
-**Return shapes** (important for test mocks):
-- `getArticlesAction(params)` → `{ articles: Article[], total: number }`
-- `getCategoriesAction()` → `Category[]`
-- `getSourcesAction()` → `Source[]`
+All news data reads go through Server Actions → MongoDB Atlas (`news` database). Server Actions live in `src/lib/actions/feed.ts` and delegate to `src/lib/mongodb/*.ts`:
 
-Admin mutations call the gateway Worker (`src/lib/admin/gateway.ts`) — this is the only place the frontend touches the gateway, and only with WorkOS access tokens.
+| Server Action | Backed by | Returns |
+| --- | --- | --- |
+| `getSectionedFeedAction(params)` | articles/categories/sources | `SectionedFeed` (topStories, yourNews, byCategory, latest, …) |
+| `getArticlesAction(params)` | `getArticles` | `{ articles: Article[], total: number }` |
+| `getArticleAction(id)` | `getArticleById` | `Article \| null` |
+| `getNewsBytesAction(limit)` | `getNewsByteArticles` | `Article[]` |
+| `searchArticlesAction(q, …)` | `searchArticles` | `{ articles, total }` |
+| `getSavedArticlesAction()` | `getSavedArticles` | `Article[]` |
+| `getCategoriesAction()` | `getCategories` | `Category[]` |
+| `getTrendingCategoriesAction(limit)` | `getTrendingCategories` | trending categories |
+| `getSourcesAction()` | `getSources` | `Source[]` |
+| `getStatsAction()` | `getStats` | aggregate stats |
+| `getTrendingAuthorsAction(limit)` | `getTrendingAuthors` | trending authors |
+
+`mongodb/client.ts` owns the singleton `MongoClient` (reads `MONGODB_URI` / `MONGODB_DATABASE`). `mongodb/admin.ts` powers admin **reads**; admin **writes** go through the gateway (below).
+
+### Data Flow (writes / mutations)
+
+- **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit`, `getRequestIp`). `src/app/api/health/route.ts` is the health probe.
+- **Admin mutations** — `src/lib/admin/gateway.ts` proxies to the gateway Worker's WorkOS-gated `/api/admin/*` endpoints, forwarding the WorkOS access token as a Bearer header so the Worker re-verifies the same RBAC. **This is the only place the frontend touches the gateway.**
+- **Pipeline refresh** — `src/lib/actions/refresh.ts` `triggerFeedCollection()` fire-and-forget `POST`s to `FLY_WORKER_URL/trigger/collect` with `FLY_TRIGGER_TOKEN`.
 
 ### API Client (`src/lib/api.ts`)
 
-Used for client-side fetches and the embed widget. `NEXT_PUBLIC_API_URL` is empty by default (relative URLs → Next.js Route Handlers → MongoDB). Only set it to an external URL for the Cloudflare widget/resale API.
+Used for client-side fetches and the embed widget, and exports the shared `Article` type. `NEXT_PUBLIC_API_URL` is empty by default (relative URLs → Next.js Route Handlers → MongoDB). Only set it to an external URL for the Cloudflare widget/resale API.
 
 ## Testing
 
-**448 frontend tests** — Vitest with jsdom environment + React Testing Library
+**~460 frontend tests across 21 files** — Vitest 4 with jsdom + React Testing Library.
 
+- Config: `vitest.config.ts` (globals on, `@` alias, `include: src/**/*.{test,spec}.*`)
 - Setup: `src/__tests__/setup.ts`
-- Coverage thresholds: 60% statements/functions/lines, 50% branches
-- **Mock pattern for pages**: Always mock `@/lib/actions/feed` (NOT `@/lib/api`) since pages use Server Actions
+- Coverage (v8): thresholds **60%** statements/functions/lines, **50%** branches
+- **Mock pattern for pages**: always mock `@/lib/actions/feed` (NOT `@/lib/api`) — pages read via Server Actions. Match the return shapes in the table above.
 
-**Pre-commit hook** (Husky): typecheck + build validation
+**Pre-commit hook** (Husky, `.husky/pre-commit`): runs `vitest related` on staged files, then `typecheck`, then `build`. All three must pass (uses `npm run`).
 
-**CI** (`.github/workflows/deploy.yml`): lint matrix (actionlint, JSON validity, prettier, markdownlint, yamllint) + `test-frontend` (tests, typecheck, lint, build)
+**CI** (`.github/workflows/deploy.yml`):
+- `lint` matrix — actionlint, JSON validity, prettier (`**/*.json`), markdownlint (`**/*.md`), yamllint
+- `test-frontend` — `npm ci` → `npm run test` → `npm run typecheck` → `npm run lint` → `npm run build` (Node 20)
+
+There are also `claude.yml` and `claude-code-review.yml` workflows for the Claude GitHub app.
 
 ## Deployment
 
-Auto-deploys to Vercel on push to main.
+Auto-deploys to Vercel on push to `main`.
 
 ## MCP Servers
 
 `.mcp.json` registers project-scoped MCP servers that load automatically in Claude Code.
 
-| Server | URL | Auth |
-|---|---|---|
-| `nyuchi-mongodb` | `https://mongodb.nyuchi.dev/mcp` | OAuth — each developer authenticates on first use; tokens stored in `~/.claude.json`, never committed |
+| Server | Type / URL | Auth |
+| --- | --- | --- |
+| `mukoko-news` | http — `https://news.mukoko.com/mcp` | Product MCP (gateway) |
+| `nyuchi-mongodb` | http — `https://mongodb.nyuchi.dev/mcp` | OAuth — each developer authenticates on first use; tokens in `~/.claude.json`, never committed |
+| `fly` | stdio — `flyctl mcp server` | Local `flyctl` auth |
 
-**First-time setup**: On session start, Claude Code will prompt for OAuth authentication with `nyuchi-mongodb`. This grants read/write access to the MongoDB cluster. Only team members with nyuchi.dev credentials should approve this.
+**First-time setup**: On session start, Claude Code prompts for OAuth with `nyuchi-mongodb` (read/write to the MongoDB cluster). Only team members with nyuchi.dev credentials should approve.
 
 ## Environment Variables
 
-### Frontend (`.env.local`)
+### Frontend (`.env.local`) — see `.env.example` for the full annotated list
 
 ```bash
+# Base URL
+NEXT_PUBLIC_BASE_URL=https://news.mukoko.com
+
 # MongoDB Atlas — Server Actions read/write directly
 MONGODB_URI=mongodb+srv://<user>:<pass>@nyuchi-platform-doc-db.ge8d8qi.mongodb.net/?appName=nyuchi-platform-doc-db
 MONGODB_DATABASE=news
 
-# Leave empty — Server Actions serve all reads from MongoDB.
-# Set to Cloudflare Worker URL only for the external widget/resale API.
-NEXT_PUBLIC_API_URL=
-NEXT_PUBLIC_BASE_URL=https://news.mukoko.com
-
-# WorkOS AuthKit
-WORKOS_API_KEY=sk_live_...
+# WorkOS AuthKit (inline sign-in on news.mukoko.com)
 WORKOS_CLIENT_ID=client_01KV2G41CHGBSH6HG57AQBFKDD
-WORKOS_COOKIE_PASSWORD=<32+ char random string>
+WORKOS_API_KEY=sk_live_...
+WORKOS_REDIRECT_URI=https://news.mukoko.com/auth/callback
+WORKOS_COOKIE_PASSWORD=<32+ char random string>   # openssl rand -base64 32
+WORKOS_PLATFORM_ORG_ID=org_...                     # platform-team org → /admin access
+
+# External API (widget/resale only) — leave EMPTY; reads go through Server Actions
+NEXT_PUBLIC_API_URL=
 
 # Gateway Worker (admin mutations only)
 GATEWAY_API_URL=https://news.mukoko.com
+
+# Pipeline trigger (manual refresh action)
+FLY_WORKER_URL=https://news-ingestion.fly-worker.nyuchi.dev
+FLY_TRIGGER_TOKEN=...                              # must match the fly secret
 ```
 
-## Authentication (WorkOS AuthKit)
+## Authentication & RBAC (WorkOS AuthKit)
 
-**WorkOS AuthKit** handles all user authentication via the custom auth domain `identity.nyuchi.com`.
+**WorkOS AuthKit** handles all user authentication. Web users sign in via the **embedded inline AuthKit form** on `news.mukoko.com` (`src/components/auth/inline-sign-in.tsx`) — they are **never** redirected to the hosted `identity.nyuchi.com` page.
 
-- `src/middleware.ts` — AuthKit session-refresh middleware (no forced redirect; embedded sign-in handles gating)
-- `src/app/auth/callback/route.ts` — WorkOS OAuth callback handler
-- `src/app/layout.tsx` — wraps app in `AuthKitProvider`
+- `src/middleware.ts` — AuthKit **session-refresh only** (`middlewareAuth` intentionally NOT enabled; it would force a hosted redirect). `/admin` is NOT gated here — cookie presence is spoofable.
+- `src/app/admin/layout.tsx` — the **authoritative** admin gate: calls `withAuth()` and enforces RBAC via `src/lib/auth/roles.ts`, rendering inline sign-in for unauthenticated users.
+- `src/app/auth/callback/route.ts` — WorkOS OAuth callback handler.
+- `src/app/layout.tsx` — wraps the app in `AuthKitProvider`.
+
+**RBAC tiers** (`src/lib/auth/roles.ts`) — `resolveTier(claims)` → `'none' | 'moderator' | 'admin' | 'superadmin'`:
+
+- `superadmin` — WorkOS role `admin` within the platform-team org
+- `admin` (staff) — any member of the platform-team org
+- `moderator` — within platform-team, role `moderator`/`support` OR the `mukoko:news-moderator` permission
+- `none` — everyone else
+
+All grants are honored **only inside the platform-team org** (`WORKOS_PLATFORM_ORG_ID`) — WorkOS permission slugs are environment-wide, so an unscoped check would leak access across orgs. `canAccessAdmin(tier)` allows moderator and above.
 
 **Usage in Server Components:**
 ```tsx
@@ -147,13 +214,15 @@ The MCP OAuth server (`news.mukoko.com/.well-known/oauth-authorization-server`, 
 
 **Colors** (African Minerals palette): Primary Tanzanite (#4B0082), Secondary Cobalt (#0047AB), Accent Gold (#5D4037), Success Malachite (#2E8B57), Warning Terracotta (#E07A4D), Surface Warm Cream (#FAF9F5)
 
-**Typography**: Noto Serif (headings), Plus Jakarta Sans (body) — loaded via CSS `@import` with preconnect hints in layout.tsx
+**Typography**: Noto Serif (headings), Plus Jakarta Sans (body) — loaded via CSS `@import` with preconnect hints in `layout.tsx`
 
 **Spacing**: 12px border-radius buttons, 16px cards. WCAG AAA compliant (7:1 contrast).
 
-CSS variables in `src/app/globals.css`. Use Tailwind classes: `bg-primary`, `text-foreground`, `bg-surface`, etc.
+CSS variables in `src/app/globals.css`. Use Tailwind classes: `bg-primary`, `text-foreground`, `bg-surface`, etc. (`components.json` configures the shadcn-style component generator; `tailwind.config.ts` holds the theme.)
 
 ## Code Conventions
+
+Prettier (`.prettierrc.json`): single quotes, semicolons, 2-space tabs, `es5` trailing commas, 100 print width.
 
 ### Naming
 
@@ -183,7 +252,9 @@ style={{ backgroundImage: safeCssUrl(src) }}  // Good
 style={{ backgroundImage: `url(${src})` }}    // Bad — injectable
 ```
 
-**Base URL helpers**: Use `BASE_URL`, `getArticleUrl(id)`, `getFullUrl(path)` from `src/lib/constants.ts`.
+**Rate limiting**: Engagement Route Handlers use `checkRateLimit()` + `getRequestIp()` from `src/lib/rate-limit.ts`.
+
+**Base URL helpers**: Use `BASE_URL`, `getArticleUrl(id)`, `getFullUrl(path)` from `src/lib/constants.ts` (which also exports `COUNTRIES`, `CATEGORY_META`, `getCategoryEmoji`).
 
 ### React Patterns (Project-Specific)
 
@@ -215,6 +286,6 @@ const countryKey = useMemo(() => selectedCountries.slice().sort().join(","), [se
 Embeddable news widgets for sister apps (e.g., weather.mukoko.com):
 
 - Widget script: `public/embed/widget.js` (vanilla JS IIFE, ~2KB)
-- Iframe renderer: `src/app/embed/iframe/page.tsx`
+- Iframe renderer: `src/app/embed/iframe/page.tsx` (excluded from auth middleware matcher)
 - 5 layouts (cards, compact, hero, ticker, list) × 4 feed types (top, featured, latest, location)
 - Sandbox: `allow-scripts allow-popups allow-popups-to-escape-sandbox` (no `allow-same-origin`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,10 +149,9 @@ Auto-deploys to Vercel on push to `main`.
 | Server | Type / URL | Auth |
 | --- | --- | --- |
 | `mukoko-news` | http — `https://news.mukoko.com/mcp` | Product MCP (gateway) |
-| `nyuchi-mongodb` | http — `https://mongodb.nyuchi.dev/mcp` | OAuth — each developer authenticates on first use; tokens in `~/.claude.json`, never committed |
 | `fly` | stdio — `flyctl mcp server` | Local `flyctl` auth |
 
-**First-time setup**: On session start, Claude Code prompts for OAuth with `nyuchi-mongodb` (read/write to the MongoDB cluster). Only team members with nyuchi.dev credentials should approve.
+**MongoDB access**: the nyuchi MongoDB MCP (`https://mongodb.nyuchi.dev/mcp`) is **not** project-scoped — it is added per-developer as a **personal Claude connector** (Claude → Settings → Connectors), not via this repo's `.mcp.json`. So it is not listed above.
 
 ## Environment Variables
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Loader2, ChevronLeft, ChevronRight, Compass, RefreshCw, WifiOff, TrendingUp, Newspaper } from "lucide-react";
 import { CategoryChip } from "@/components/ui/category-chip";
 import { ArticleCard } from "@/components/article-card";
@@ -12,15 +13,19 @@ import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { FeedPageSkeleton } from "@/components/ui/skeleton";
 import { CollectionPageJsonLd, ItemListJsonLd } from "@/components/ui/json-ld";
 import { usePreferences } from "@/contexts/preferences-context";
-import { type Article, type StoryCluster as StoryClusterType, type CategorySection } from "@/lib/api";
-import { getSectionedFeedAction } from "@/lib/actions/feed";
+import { type Article, type Category, type StoryCluster as StoryClusterType, type CategorySection } from "@/lib/api";
+import { getSectionedFeedAction, getArticlesAction, getCategoriesAction } from "@/lib/actions/feed";
 import { isValidImageUrl } from "@/lib/utils";
 import { BASE_URL } from "@/lib/constants";
 import { triggerFeedCollection } from "@/lib/actions/refresh";
 
+// How many articles each "Latest" page fetches — must match the server action's latest limit.
+const LATEST_PAGE_SIZE = 20;
+
 // Redesigned layout - Top Stories, Your News, By Category, Latest
 
 export default function FeedPage() {
+  const router = useRouter();
   const { selectedCategories, selectedCountries } = usePreferences();
 
   // Sectioned feed state
@@ -29,13 +34,24 @@ export default function FeedPage() {
   const [byCategory, setByCategory] = useState<CategorySection[]>([]);
   const [latestArticles, setLatestArticles] = useState<Article[]>([]);
 
+  // Full category list for the quick-nav bar (independent of what's in the latest feed)
+  const [allCategories, setAllCategories] = useState<Category[]>([]);
+
+  // Infinite scroll for the chronological "Latest" feed
+  const [latestPage, setLatestPage] = useState(1);
+  const [hasMoreLatest, setHasMoreLatest] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  // Measured height of the global sticky header, so the category bar sits flush
+  // beneath it instead of using a brittle hardcoded offset.
+  const [headerOffset, setHeaderOffset] = useState(64);
+
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isSticky, setIsSticky] = useState(false);
   const [pullDistance, setPullDistance] = useState(0);
-  const filtersSectionRef = useRef<HTMLDivElement>(null);
   const topStoriesScrollRef = useRef<HTMLDivElement>(null);
+  const latestSentinelRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef(0);
   const isPulling = useRef(false);
   const rafIdRef = useRef<number | null>(null);
@@ -71,10 +87,14 @@ export default function FeedPage() {
         categories: categories.length > 0 ? categories : undefined,
       });
 
+      const latest = response.latest || [];
       setTopStories(response.topStories || []);
       setYourNews(response.yourNews || []);
       setByCategory(response.byCategory || []);
-      setLatestArticles(response.latest || []);
+      setLatestArticles(latest);
+      // Reset infinite-scroll pagination for the new filter set
+      setLatestPage(1);
+      setHasMoreLatest(latest.length >= LATEST_PAGE_SIZE);
     } catch (err) {
       console.error("Failed to fetch feed:", err);
       setError(err instanceof Error ? err.message : "Failed to load news feed");
@@ -83,6 +103,81 @@ export default function FeedPage() {
       setRefreshing(false);
     }
   }, [countryKey, categoryKey]);
+
+  // Track the global header's height (it changes between breakpoints and scroll states)
+  useEffect(() => {
+    const header = document.querySelector<HTMLElement>("[data-app-header]");
+    if (!header) return;
+    const update = () => setHeaderOffset(header.getBoundingClientRect().height);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(header);
+    window.addEventListener("resize", update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
+  // Load the full category list once for the quick-nav bar
+  useEffect(() => {
+    let cancelled = false;
+    getCategoriesAction()
+      .then((categories) => {
+        if (!cancelled) setAllCategories((categories || []).filter((c) => c.id !== "all"));
+      })
+      .catch((err) => console.error("Failed to fetch categories:", err));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load the next page of the chronological "Latest" feed (sorted by timestamp,
+  // across all sources — never grouped by source).
+  const loadMoreLatest = useCallback(async () => {
+    if (loadingMore || !hasMoreLatest) return;
+    setLoadingMore(true);
+    try {
+      const nextPage = latestPage + 1;
+      const countries = countryKey ? countryKey.split(",") : [];
+      const { articles, total } = await getArticlesAction({
+        sort: "latest",
+        page: nextPage,
+        limit: LATEST_PAGE_SIZE,
+        countries: countries.length > 0 ? countries : undefined,
+      });
+      setLatestArticles((prev) => {
+        const seen = new Set(prev.map((a) => a.id));
+        return [...prev, ...articles.filter((a) => !seen.has(a.id))];
+      });
+      setLatestPage(nextPage);
+      setHasMoreLatest(articles.length >= LATEST_PAGE_SIZE && nextPage * LATEST_PAGE_SIZE < total);
+    } catch (err) {
+      console.error("Failed to load more articles:", err);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [loadingMore, hasMoreLatest, latestPage, countryKey]);
+
+  // Keep a stable ref to the latest loader so the observer never re-registers
+  const loadMoreLatestRef = useRef(loadMoreLatest);
+  useEffect(() => {
+    loadMoreLatestRef.current = loadMoreLatest;
+  }, [loadMoreLatest]);
+
+  // IntersectionObserver sentinel — fetches the next page as it nears the viewport
+  useEffect(() => {
+    const sentinel = latestSentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMoreLatestRef.current();
+      },
+      { rootMargin: "400px" }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loading, error]);
 
   // Ref to always hold the latest handleRefresh
   const handleRefreshRef = useRef(() => {});
@@ -176,18 +271,6 @@ export default function FeedPage() {
         cancelAnimationFrame(rafIdRef.current);
       }
     };
-  }, []);
-
-  // Sticky header on scroll
-  useEffect(() => {
-    const handleScroll = () => {
-      if (filtersSectionRef.current) {
-        const rect = filtersSectionRef.current.getBoundingClientRect();
-        setIsSticky(rect.top <= 72);
-      }
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   const scrollTopStories = (direction: "left" | "right") => {
@@ -287,34 +370,35 @@ export default function FeedPage() {
         </div>
       </header>
 
-      {/* Quick Category Pills */}
-      <div ref={filtersSectionRef}>
-        <nav
-          aria-label="Quick navigation"
-          className={`py-3 border-b border-elevated transition-all duration-300 ${
-            isSticky
-              ? "fixed top-[72px] left-0 right-0 z-40 bg-background/80 backdrop-blur-xl shadow-sm"
-              : ""
-          }`}
-        >
-          <div className={isSticky ? "max-w-[1200px] mx-auto px-4 sm:px-6" : ""}>
-            <div className="flex gap-2 overflow-x-auto scrollbar-hide" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
-              <CategoryChip label="Top Stories" active icon={<TrendingUp className="w-3.5 h-3.5" />} onClick={() => document.getElementById('top-stories')?.scrollIntoView({ behavior: 'smooth' })} />
-              {selectedCategories.length > 0 && (
-                <CategoryChip label="Your News" icon={<Newspaper className="w-3.5 h-3.5" />} onClick={() => document.getElementById('your-news')?.scrollIntoView({ behavior: 'smooth' })} />
-              )}
-              {byCategory.map((section) => (
-                <CategoryChip
-                  key={section.id}
-                  label={section.name}
-                  onClick={() => document.getElementById(`category-${section.id}`)?.scrollIntoView({ behavior: 'smooth' })}
-                />
-              ))}
-            </div>
-          </div>
-        </nav>
-        {isSticky && <div className="h-[52px]" />}
-      </div>
+      {/* Quick Category Pills — sticks flush beneath the measured global header height */}
+      <nav
+        aria-label="Quick navigation"
+        className="sticky z-40 py-3 border-b border-elevated bg-background/80 backdrop-blur-xl"
+        style={{ top: headerOffset }}
+      >
+        <div className="flex gap-2 overflow-x-auto scrollbar-hide" style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}>
+          <CategoryChip label="Top Stories" active icon={<TrendingUp className="w-3.5 h-3.5" />} onClick={() => document.getElementById('top-stories')?.scrollIntoView({ behavior: 'smooth' })} />
+          {selectedCategories.length > 0 && (
+            <CategoryChip label="Your News" icon={<Newspaper className="w-3.5 h-3.5" />} onClick={() => document.getElementById('your-news')?.scrollIntoView({ behavior: 'smooth' })} />
+          )}
+          {allCategories.map((category) => {
+            // Scroll to the on-page section if this category is present in the feed;
+            // otherwise open the full category view in Discover.
+            const section = byCategory.find((s) => s.id === category.id || s.name === category.name);
+            return (
+              <CategoryChip
+                key={category.id}
+                label={category.name}
+                onClick={() =>
+                  section
+                    ? document.getElementById(`category-${section.id}`)?.scrollIntoView({ behavior: 'smooth' })
+                    : router.push(`/discover?category=${category.id}`)
+                }
+              />
+            );
+          })}
+        </div>
+      </nav>
 
       {/* Main Content */}
       <main>
@@ -465,6 +549,20 @@ export default function FeedPage() {
                       <ArticleCard key={article.id} article={article} />
                     ))}
                   </div>
+
+                  {/* Infinite scroll: sentinel triggers the next chronological page */}
+                  {hasMoreLatest && (
+                    <div ref={latestSentinelRef} className="flex justify-center py-8" aria-hidden="true">
+                      {loadingMore && (
+                        <Loader2 className="w-6 h-6 animate-spin text-text-tertiary" />
+                      )}
+                    </div>
+                  )}
+                  {!hasMoreLatest && latestArticles.length > LATEST_PAGE_SIZE && (
+                    <p className="text-center text-sm text-text-tertiary py-8" role="status">
+                      You&apos;re all caught up
+                    </p>
+                  )}
                 </section>
               </ErrorBoundary>
             )}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -136,6 +136,7 @@ export function Header() {
 
   return (
     <header
+      data-app-header
       className={`sticky top-0 z-50 transition-all duration-300 ${
         isNewsBytes
           ? "bg-gradient-to-b from-black/60 via-black/30 to-transparent"

--- a/src/lib/mongodb/articles.ts
+++ b/src/lib/mongodb/articles.ts
@@ -28,7 +28,14 @@ interface MongoArticle {
   articleBodyProcessed?: string
   articleSection?: string
   datePublished?: Date
-  image?: Array<{ '@type'?: string; url?: string }>
+  // Image has been stored in several shapes across pipeline versions:
+  //   schema.org array:  image: [{ url }]       (fly-worker rss/newsdata collectors)
+  //   schema.org object: image: { url }         (parser intermediate)
+  //   flat string:       image: "https://…"
+  //   flat field:        imageUrl / image_url   (processing worker / edge cache)
+  image?: Array<{ '@type'?: string; url?: string }> | { '@type'?: string; url?: string } | string
+  imageUrl?: string
+  image_url?: string
   wordCount?: number
   readingTimeMinutes?: number
   categoryIds?: string[]
@@ -47,8 +54,23 @@ interface MongoFeedSource {
   mediaOrganizationId: string
 }
 
+/**
+ * Resolve an article's image URL across the schema variants the pipeline has
+ * written over time (schema.org array/object, a flat string, or a flat
+ * imageUrl / image_url field). Returns the first non-empty candidate.
+ */
+function resolveImageUrl(doc: MongoArticle): string | null {
+  const img = doc.image
+  let fromImage: string | undefined
+  if (Array.isArray(img)) fromImage = img[0]?.url
+  else if (img && typeof img === 'object') fromImage = img.url
+  else if (typeof img === 'string') fromImage = img
+
+  return fromImage || doc.imageUrl || doc.image_url || null
+}
+
 function toArticle(doc: MongoArticle, source?: MongoFeedSource): Article {
-  const imageUrl = doc.image?.[0]?.url || null
+  const imageUrl = resolveImageUrl(doc)
   return {
     id: doc._id,
     title: doc.headline,
@@ -193,8 +215,15 @@ export async function getNewsByteArticles(limit = 10): Promise<Article[]> {
       status: { $ne: 'rejected' },
       moderationStatus: { $ne: 'removed' },
       wordCount: { $lte: 300 },
-      'image.0': { $exists: true },
-    })
+      // An image in any of the shapes the pipeline has used (see resolveImageUrl)
+      $or: [
+        { 'image.0': { $exists: true } },
+        { 'image.url': { $exists: true, $ne: null } },
+        { image: { $type: 'string', $ne: '' } },
+        { imageUrl: { $exists: true, $ne: null } },
+        { image_url: { $exists: true, $ne: null } },
+      ],
+    } as Filter<MongoArticle>)
     .sort({ datePublished: -1 })
     .limit(limit)
     .toArray()


### PR DESCRIPTION
## Summary

Two related changes:

1. **`CLAUDE.md` refresh** — updated to match the current state of the repo after the v5.1.0 three-repo split.
2. **Feed UI fixes** (`src/app/page.tsx`, `src/components/layout/header.tsx`) — three issues reported on the home feed.

## CLAUDE.md changes

- Documents npm-vs-pnpm reality (CI/Husky use **npm**; both lockfiles committed), full Server Action table with return shapes, engagement Route Handlers + rate limiting, the RBAC tier model (`src/lib/auth/roles.ts`), all three MCP servers, added env vars, a directory map, and corrected test count.
- Validated: `markdownlint-cli2 --config .markdownlint.json CLAUDE.md` → 0 errors.

## Feed UI fixes

- **Gap between header and category bar** — the category bar previously switched to `fixed top-[72px]`, which didn't match the real header height (~64px mobile / ~84px on `sm`, driven by the actions pill), leaving a visible gap. It now uses CSS `sticky` with the header's **measured** height (`ResizeObserver` on a `data-app-header` marker), so it always sits flush.
- **Infinite scroll** — the chronological **Latest** feed now pages via an `IntersectionObserver` sentinel calling `getArticlesAction({ sort: 'latest', page })`. Articles stream in by published timestamp **across all sources** (never grouped by source), de-duplicated by id, stopping with an "all caught up" marker at the end.
- **Only one category visible** — the quick-nav bar now renders the **full** category list from `getCategories()` instead of only the categories present in the latest 20 articles. Chips scroll to an on-page section when one exists, otherwise open that category in Discover (`/discover?category=<id>`, matching Discover's convention).

## Validation

- `npm run typecheck` ✓ · `npm run lint` ✓ · `npm run test` (448 tests) ✓ · `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)