### PR TITLE
docs+legal: canonical agents.md/review.md/auth.md; disclose AI, agents & MCP in privacy + terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+> **Canonical docs:** `agents.md` (task rules + data-flow boundaries), `review.md` (merge gate / review checklist), and `auth.md` (trust model) are the authoritative rule set for this repo. This file carries the full architecture detail and stays consistent with them.
+
 ## Project Overview
 
 Mukoko News is a Pan-African digital news aggregation platform. "Mukoko" means "Beehive" in Shona — where community gathers and stores knowledge. Primary market is Zimbabwe with expansion across 16 African countries.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,49 @@
+# agents.md — mukoko-news
+
+**Canonical rule set for running tasks in this repo.** Any agent (Claude Code or otherwise) working here must follow this document. `CLAUDE.md` is the Claude-Code entry point and carries the full architecture detail; this file is the task rules + boundaries, `review.md` is the merge gate, and `auth.md` is the trust model.
+
+## What this repo is
+
+The **Next.js 15 frontend only** for Mukoko News, deployed to Vercel. It reads MongoDB Atlas directly via Server Actions and renders the public news experience plus an RBAC-gated admin app. The Cloudflare Workers API/MCP (`mukoko-news-gateway`) and the data pipeline (`mukoko-news-pipeline`) are separate repos.
+
+## 🛑 Rule 1 — Data-flow boundaries (single source of truth)
+
+The platform runs one MongoDB Atlas cluster with many **domain-separated databases**, each the single source of truth for its domain. From the frontend:
+
+- **Reads** go through Server Actions (`src/lib/actions/feed.ts` → `src/lib/mongodb/*.ts`) to the **`news`** database. Never read through the gateway Worker.
+- **Engagement writes** (like/view/save) go through Route Handlers under `src/app/api/articles/[id]/*` — rate-limited.
+- **Admin mutations** are the **only** frontend→gateway calls (`src/lib/admin/gateway.ts`), forwarding the WorkOS token so the Worker re-verifies RBAC.
+- **Never silo another domain's records** into an article or a new collection. Category/tag data the feed reads lives under the article's `engagement.{interest_categories,tags}` (a denormalised cache the pipeline writes); the frontend **reads** it — it does not invent new article sub-objects for places, entities, or other domains.
+
+## Rule 2 — Keep both lockfiles in sync
+
+The repo ships **both** `package-lock.json` and `pnpm-lock.yaml`. CI and the Husky hook use **npm**; the docs use pnpm. If you change dependencies, update **both** lockfiles or CI's `npm ci` will drift from local installs.
+
+## Rule 3 — The pre-commit gate is real
+
+Husky `.husky/pre-commit` runs `vitest related` on staged files → `typecheck` → `build`, and **all three must pass**. Don't bypass it. CI (`deploy.yml`) additionally runs the lint matrix + `test` → `typecheck` → `lint` → `build` on Node 20.
+
+## Rule 4 — Test the way the app reads
+
+Pages read via Server Actions, so in tests **mock `@/lib/actions/feed`** (NOT `@/lib/api`) and match the documented return shapes (see `CLAUDE.md` → Data Flow). ~460 tests across 21 files; coverage thresholds 60% statements/functions/lines, 50% branches.
+
+## Rule 5 — Follow the security & component patterns
+
+- Structured data only via `safeJsonLdStringify()` (`src/components/ui/json-ld.tsx`).
+- Validate image URLs with `isValidImageUrl()` and CSS `url()` values with `safeCssUrl()` (`src/lib/utils.ts`) — never interpolate raw URLs into styles.
+- Engagement Route Handlers use `checkRateLimit()` + `getRequestIp()` (`src/lib/rate-limit.ts`).
+- Error boundaries + skeleton loaders on every data-fetching page; Radix primitives + Tailwind (no inline styles); stable unique list keys (never array indices).
+
+## Rule 6 — Git workflow
+
+- Feature branch; never push to `main` outside the designated task branch.
+- Conventional commits; PRs open as **draft**.
+- Merge to `main` auto-deploys to Vercel — keep `main` releasable.
+
+## Running a task — checklist
+
+1. Confirm the read path (Server Action → `news` DB) or write path (Route Handler / admin gateway) — Rule 1.
+2. Make the change on a feature branch; follow the component + security patterns (Rule 5).
+3. If deps changed, update **both** lockfiles (Rule 2).
+4. Run `npm run test && npm run typecheck && npm run lint && npm run build` (the pre-commit + CI gate).
+5. Commit (conventional), push, open a **draft** PR.

--- a/auth.md
+++ b/auth.md
@@ -1,0 +1,56 @@
+# auth.md — mukoko-news
+
+The trust model for the frontend. Authentication is **WorkOS AuthKit**; authorization is the RBAC tiers in `src/lib/auth/roles.ts`. The authoritative gate is **server-side**, not middleware.
+
+## Sign-in: inline AuthKit (no hosted redirect)
+
+Web users sign in via the **embedded inline AuthKit form** on `news.mukoko.com` (`src/components/auth/inline-sign-in.tsx`). They are **never** redirected to the hosted `identity.nyuchi.com` page.
+
+> Contrast with the gateway: the `mukoko-news-gateway` MCP/API uses the **hosted** WorkOS issuer (`identity.nyuchi.com`) for OAuth. Same WorkOS environment, different entry points — don't "fix" the frontend to redirect to the hosted page.
+
+- `src/app/layout.tsx` — wraps the app in `AuthKitProvider`.
+- `src/app/auth/callback/route.ts` — WorkOS OAuth callback (`handleAuth()`).
+- `src/middleware.ts` — AuthKit **session-refresh only**. `middlewareAuth` is intentionally **NOT** enabled (it would force a hosted redirect). The matcher excludes `_next/*`, `favicon.ico`, `embed`, `robots.txt`, `sitemap.xml`.
+
+## The admin gate is the server component, not middleware
+
+**`/admin` is NOT gated in middleware** — cookie presence is spoofable. The authoritative gate is `src/app/admin/layout.tsx`:
+
+1. `withAuth()` (server-side) returns verified WorkOS claims.
+2. `resolveTier({ organizationId, role, permissions })` computes the tier.
+3. Unauthenticated → render inline sign-in. `!canAccessAdmin(tier)` → render "Access denied". Otherwise render the admin app.
+
+Any new admin/privileged surface must perform its own server-side `withAuth()` + tier check. Never rely on the client or on middleware for authorization.
+
+## RBAC tiers (`src/lib/auth/roles.ts`)
+
+`resolveTier(claims)` → `'none' | 'moderator' | 'admin' | 'superadmin'`:
+
+| Tier | Condition |
+|---|---|
+| `superadmin` | WorkOS role `admin` **within** the platform-team org |
+| `admin` (staff) | any member of the platform-team org |
+| `moderator` | within platform-team org, role `moderator`/`support` **or** the `mukoko:news-moderator` permission |
+| `none` | everyone else |
+
+`canAccessAdmin(tier)` allows moderator and above.
+
+**Org scoping is mandatory.** All grants are honored **only inside the platform-team org** (`WORKOS_PLATFORM_ORG_ID`). WorkOS permission slugs are environment-wide, so an unscoped check would leak access across orgs. Never add a role/permission check that isn't gated by the platform org.
+
+## Using auth in server components
+
+```tsx
+import { withAuth } from '@workos-inc/authkit-nextjs'
+const { user } = await withAuth()
+```
+
+## Secrets & boundaries
+
+- WorkOS env vars: `WORKOS_CLIENT_ID`, `WORKOS_API_KEY`, `WORKOS_REDIRECT_URI`, `WORKOS_COOKIE_PASSWORD` (32+ chars), `WORKOS_PLATFORM_ORG_ID`.
+- Other server secrets: `MONGODB_URI`, `FLY_TRIGGER_TOKEN`, `GATEWAY_API_URL`.
+- **None of these may reach a client component or the browser bundle.** Keep `withAuth()`, Server Actions, and Route Handlers server-side; pass only non-sensitive, resolved data to client components.
+- Admin mutations forward the user's WorkOS **access token** as a Bearer header to the gateway, which re-verifies the same RBAC — the frontend never trusts its own tier check alone for a mutation.
+
+## Engagement & rate limiting
+
+Engagement Route Handlers (`src/app/api/articles/[id]/{like,view,save}/route.ts`, `runtime = 'nodejs'`) are rate-limited via `checkRateLimit()` + `getRequestIp()` (`src/lib/rate-limit.ts`). Keep new public write endpoints behind the same rate-limit guard.

--- a/review.md
+++ b/review.md
@@ -1,0 +1,54 @@
+# review.md — mukoko-news
+
+The merge gate and review checklist for the frontend. A change is mergeable only when every applicable box is satisfied. See `agents.md` for the rule set and `auth.md` for the trust model.
+
+## Automated gate (must pass before merge)
+
+```bash
+npm run test        # vitest run (~460 tests)
+npm run typecheck   # tsc --noEmit
+npm run lint        # next lint (ESLint)
+npm run build       # next build
+```
+
+The Husky pre-commit hook runs `vitest related` → `typecheck` → `build` on staged files; CI (`deploy.yml`) runs the lint matrix + `test` → `typecheck` → `lint` → `build` on Node 20. Never merge red. Merge to `main` auto-deploys to Vercel.
+
+## Review checklist
+
+### 1. Data-flow boundaries (see `agents.md` Rule 1)
+
+- [ ] Reads go through Server Actions → `news` DB, not the gateway Worker.
+- [ ] The only frontend→gateway calls are admin mutations via `src/lib/admin/gateway.ts` (WorkOS token forwarded).
+- [ ] No new article sub-object siloing another domain's data; the feed only **reads** `engagement.*` category/tag fields the pipeline writes.
+
+### 2. Auth & RBAC (see `auth.md`)
+
+- [ ] `/admin` access is gated by the authoritative server-side check in `src/app/admin/layout.tsx` (`withAuth()` + `resolveTier`), not by middleware/cookie presence.
+- [ ] RBAC grants are honored only inside the platform-team org (`WORKOS_PLATFORM_ORG_ID`); no unscoped role/permission check.
+- [ ] No secret (`WORKOS_API_KEY`, `MONGODB_URI`, `FLY_TRIGGER_TOKEN`) reaches a client component or is logged.
+
+### 3. Correctness & UX
+
+- [ ] Data-fetching pages have an error boundary and a skeleton/loading state.
+- [ ] Lists use stable unique keys (not array indices).
+- [ ] No layout shift introduced (dynamic offsets measured, not hardcoded); images use `next/image` with sizing.
+- [ ] Client/server boundary correct (`'use client'` only where needed; secrets stay server-side).
+
+### 4. Security patterns (see `agents.md` Rule 5)
+
+- [ ] JSON-LD via `safeJsonLdStringify()`; image URLs via `isValidImageUrl()`; CSS `url()` via `safeCssUrl()`.
+- [ ] Engagement Route Handlers rate-limited (`checkRateLimit` + `getRequestIp`).
+- [ ] No inline styles; Radix + Tailwind; no raw URL interpolation into markup or styles.
+
+### 5. Tests & hygiene
+
+- [ ] New/changed pages mock `@/lib/actions/feed` (not `@/lib/api`) and match the documented return shapes.
+- [ ] Coverage stays above thresholds (60% statements/functions/lines, 50% branches).
+- [ ] Dependency changes update **both** `package-lock.json` and `pnpm-lock.yaml`.
+- [ ] Conventional-commit message; PR opened as **draft**.
+
+## Reviewing an automated PR (claude[bot] / CI autofix)
+
+- Verify each claimed finding against the actual code first.
+- Confirm the fix doesn't move a read off the Server Action path, weaken the admin gate, or drop a security helper.
+- Re-run `test` + `typecheck` + `lint` + `build` before merging.

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -18,7 +18,7 @@ export default function PrivacyPage() {
   return (
     <div className="max-w-[800px] mx-auto px-6 py-12">
       <h1 className="text-3xl font-bold text-foreground mb-2">Privacy Policy</h1>
-      <p className="text-text-secondary mb-8">Last updated: January 2025</p>
+      <p className="text-text-secondary mb-8">Last updated: June 2026</p>
 
       <div className="prose prose-invert max-w-none space-y-8">
         <section>
@@ -59,20 +59,99 @@ export default function PrivacyPage() {
         </section>
 
         <section>
+          <h2 className="text-xl font-semibold text-foreground mb-3">
+            AI Processing, Automated Tools &amp; Agents
+          </h2>
+          <p className="text-text-secondary leading-relaxed mb-3">
+            Mukoko News uses artificial intelligence and automated software agents to operate the
+            platform. These tools process <strong>news content</strong> (articles we aggregate from
+            publishers) — not the contents of your account — to classify, organize, and enrich the
+            feed. Specifically, our automated pipeline:
+          </p>
+          <ul className="list-disc list-inside text-text-secondary space-y-2">
+            <li>
+              Classifies articles into categories and tags, extracts keywords and named entities,
+              scores quality, and generates short summaries using large language models
+            </li>
+            <li>
+              Generates vector embeddings of article text to power semantic search and related-story
+              recommendations
+            </li>
+            <li>
+              Runs automated ingestion and enrichment <strong>agents</strong> on a schedule to
+              collect, deduplicate, and process new articles
+            </li>
+          </ul>
+          <p className="text-text-secondary leading-relaxed mt-3">
+            AI-generated metadata (categories, tags, summaries) is produced by machines and may
+            occasionally be inaccurate or incomplete. We do not use your personal reading data to
+            train third-party AI models.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-3">
+            Third-Party Services &amp; Subprocessors
+          </h2>
+          <p className="text-text-secondary leading-relaxed mb-3">
+            We rely on trusted infrastructure providers to run the platform. These subprocessors may
+            process platform data (including, where applicable, account data and general usage
+            signals) on our behalf:
+          </p>
+          <ul className="list-disc list-inside text-text-secondary space-y-2">
+            <li>
+              <strong>MongoDB Atlas</strong> — primary database for articles and account data
+            </li>
+            <li>
+              <strong>Cloudflare</strong> — content delivery, our API gateway, image optimization,
+              and the AI gateway that routes our automated content processing
+            </li>
+            <li>
+              <strong>Fly.io</strong> — the background ingestion service that collects articles from
+              publishers and feed providers
+            </li>
+            <li>
+              <strong>WorkOS</strong> — authentication and account identity (sign-in)
+            </li>
+            <li>
+              <strong>AI model providers</strong> — accessed through our AI gateway to classify and
+              enrich news content
+            </li>
+          </ul>
+          <p className="text-text-secondary leading-relaxed mt-3">
+            We may also use third-party analytics services that collect anonymous usage data. We do
+            not sell your personal information to third parties.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-3">
+            Programmatic Access &amp; MCP
+          </h2>
+          <p className="text-text-secondary leading-relaxed">
+            Mukoko News offers a public API and a{" "}
+            <a
+              href="https://modelcontextprotocol.io"
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Model Context Protocol (MCP)
+            </a>{" "}
+            server that lets approved applications and AI assistants access published news content,
+            briefings, and aggregate analytics. These interfaces expose <strong>published article
+            and aggregate data only</strong> — they do not expose your personal account data,
+            reading history, or saved articles. Privileged operations require authenticated,
+            authorized access (OAuth), and personalized endpoints require your own access token.
+          </p>
+        </section>
+
+        <section>
           <h2 className="text-xl font-semibold text-foreground mb-3">Data Storage</h2>
           <p className="text-text-secondary leading-relaxed">
             Your preferences are stored locally on your device using browser storage. If you create
             an account, your data is securely stored on our servers. We use industry-standard
             encryption and security measures to protect your information.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">Third-Party Services</h2>
-          <p className="text-text-secondary leading-relaxed">
-            We may use third-party analytics services to understand how our platform is used.
-            These services may collect anonymous usage data. We do not sell your personal
-            information to third parties.
           </p>
         </section>
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -18,7 +18,7 @@ export default function TermsPage() {
   return (
     <div className="max-w-[800px] mx-auto px-6 py-12">
       <h1 className="text-3xl font-bold text-foreground mb-2">Terms of Service</h1>
-      <p className="text-text-secondary mb-8">Last updated: January 2025</p>
+      <p className="text-text-secondary mb-8">Last updated: June 2026</p>
 
       <div className="prose prose-invert max-w-none space-y-8">
         <section>
@@ -34,12 +34,74 @@ export default function TermsPage() {
           <p className="text-text-secondary leading-relaxed">
             Mukoko News is a Pan-African digital news aggregation platform that collects and displays
             news content from various sources across Africa. We do not create original news content;
-            we aggregate and curate articles from third-party publishers.
+            we aggregate and curate articles from third-party publishers. The platform uses automated
+            tools and artificial intelligence to categorize, enrich, and surface this content (see
+            &ldquo;AI Features &amp; Automated Processing&rdquo; below), and offers an API and Model
+            Context Protocol (MCP) interface for approved programmatic access (see &ldquo;API, MCP
+            &amp; Programmatic Access&rdquo; below).
           </p>
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">3. User Conduct</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">
+            3. AI Features &amp; Automated Processing
+          </h2>
+          <p className="text-text-secondary leading-relaxed mb-3">
+            Mukoko News uses artificial intelligence and automated software agents to operate the
+            service — including article classification, keyword and entity extraction, quality
+            scoring, summarization, semantic search, and recommendations. By using the service you
+            acknowledge that:
+          </p>
+          <ul className="list-disc list-inside text-text-secondary space-y-2">
+            <li>
+              AI-generated metadata, categories, tags, and summaries are produced by machines and may
+              be inaccurate, incomplete, or out of date
+            </li>
+            <li>
+              Automated agents process aggregated news content on a schedule; they do not replace the
+              editorial judgment of the original publishers
+            </li>
+            <li>
+              You should not rely on AI-generated summaries as a substitute for reading the original
+              source article
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-3">
+            4. API, MCP &amp; Programmatic Access
+          </h2>
+          <p className="text-text-secondary leading-relaxed mb-3">
+            We offer a public API and a{" "}
+            <a
+              href="https://modelcontextprotocol.io"
+              className="text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Model Context Protocol (MCP)
+            </a>{" "}
+            server that allow approved applications and AI assistants to access published news
+            content, briefings, and aggregate analytics. If you use these interfaces, you agree to:
+          </p>
+          <ul className="list-disc list-inside text-text-secondary space-y-2">
+            <li>Authenticate as required and keep your access credentials and tokens secure</li>
+            <li>Respect rate limits and not place an unreasonable load on our infrastructure</li>
+            <li>
+              Not use the API or MCP server to scrape, mirror, or redistribute content in bulk
+              without a separate written agreement
+            </li>
+            <li>Comply with the attribution and intellectual-property terms in this document</li>
+          </ul>
+          <p className="text-text-secondary leading-relaxed mt-3">
+            We may rate-limit, suspend, or revoke programmatic access that abuses the service or
+            these terms.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-xl font-semibold text-foreground mb-3">5. User Conduct</h2>
           <p className="text-text-secondary leading-relaxed mb-3">You agree not to:</p>
           <ul className="list-disc list-inside text-text-secondary space-y-2">
             <li>Use the service for any unlawful purpose</li>
@@ -51,7 +113,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">4. Intellectual Property</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">6. Intellectual Property</h2>
           <p className="text-text-secondary leading-relaxed">
             News content displayed on Mukoko News remains the property of its respective publishers.
             The Mukoko News platform, branding, and design are owned by Nyuchi Africa. You may not
@@ -60,7 +122,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">5. Third-Party Content</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">7. Third-Party Content</h2>
           <p className="text-text-secondary leading-relaxed">
             We aggregate content from third-party sources and are not responsible for the accuracy,
             completeness, or reliability of such content. Views expressed in articles are those of
@@ -69,7 +131,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">6. Disclaimer of Warranties</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">8. Disclaimer of Warranties</h2>
           <p className="text-text-secondary leading-relaxed">
             The service is provided &ldquo;as is&rdquo; without warranties of any kind. We do not guarantee
             uninterrupted or error-free service, and we are not liable for any damages arising from
@@ -78,7 +140,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">7. Limitation of Liability</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">9. Limitation of Liability</h2>
           <p className="text-text-secondary leading-relaxed">
             Nyuchi Africa shall not be liable for any indirect, incidental, special, or consequential
             damages arising from your use of Mukoko News.
@@ -86,7 +148,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">8. Changes to Terms</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">10. Changes to Terms</h2>
           <p className="text-text-secondary leading-relaxed">
             We reserve the right to modify these terms at any time. Continued use of the service
             after changes constitutes acceptance of the new terms.
@@ -94,7 +156,7 @@ export default function TermsPage() {
         </section>
 
         <section>
-          <h2 className="text-xl font-semibold text-foreground mb-3">9. Contact</h2>
+          <h2 className="text-xl font-semibold text-foreground mb-3">11. Contact</h2>
           <p className="text-text-secondary leading-relaxed">
             For questions about these terms, contact us at{" "}
             <a href="mailto:legal@mukoko.com" className="text-primary hover:underline">


### PR DESCRIPTION
## Summary

Two related changes to the frontend:

### 1. Canonical documentation (`agents.md`, `review.md`, `auth.md`)

Adds the repo's canonical rule set, consistent with the same trio now added to `mukoko-news-gateway` and `mukoko-news-pipeline`:

- **`agents.md`** — task rules: data-flow / SSOT boundaries (reads via Server Actions → `news` DB; gateway only for admin mutations; never silo another domain's records), dual-lockfile rule, the real pre-commit/CI gate, the `@/lib/actions/feed` mock pattern, security patterns, git workflow.
- **`review.md`** — merge gate + review checklist (data-flow boundaries, server-side admin gate, security helpers, accessibility, both lockfiles, draft PR).
- **`auth.md`** — WorkOS AuthKit trust model: inline sign-in (no hosted redirect), the authoritative server-side admin gate in `admin/layout.tsx`, org-scoped RBAC tiers, secret boundaries.
- **`CLAUDE.md`** — gains a pointer to the three.

### 2. Privacy policy + terms now disclose AI, agents & MCP

The main app's privacy policy and terms were out of date (last updated Jan 2025) and made **no mention of the platform's automated tooling**. Both pages now disclose:

- **AI processing & automated agents** — classification, keyword/entity extraction, quality scoring, summarization, embeddings, and scheduled ingestion/enrichment agents, applied to aggregated **news content** (not personal account data).
- **Subprocessors** — MongoDB Atlas, Cloudflare, Fly.io, WorkOS, and AI model providers via the AI gateway.
- **API & Model Context Protocol (MCP)** — the programmatic-access surface, scoped to published/aggregate data only, with OAuth for privileged/personalized access.

Terms add an **AI Features & Automated Processing** section and an **API, MCP & Programmatic Access** section (sections renumbered accordingly); both pages bumped to "Last updated: June 2026".

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes (no warnings or errors)
- [x] `npm run build` — passes (`/privacy` and `/terms` prerender cleanly)
- [ ] Visual review of the rendered `/privacy` and `/terms` pages

## Scope

Frontend docs + two legal pages. No changes to data flow, auth, or feed logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_