### PR TITLE
chore: point gateway + MCP references to news.mukoko.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ NEXT_PUBLIC_API_URL=
 
 # ── Gateway Worker (admin mutations only) ─────────────────────────────────────
 # The gateway Worker handles admin writes; reads never touch it.
-GATEWAY_API_URL=https://news.mukoko.com
+GATEWAY_API_URL=https://news.mukoko.dev
 
 # ── Pipeline trigger ──────────────────────────────────────────────────────────
 # URL of the Fly.io pipeline worker (for the manual refresh action).

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mukoko-news": {
       "type": "http",
-      "url": "https://news.mukoko.com/mcp"
+      "url": "https://news.mukoko.dev/mcp"
     },
     "fly": {
       "type": "stdio",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ Auto-deploys to Vercel on push to `main`.
 
 | Server | Type / URL | Auth |
 | --- | --- | --- |
-| `mukoko-news` | http — `https://news.mukoko.com/mcp` | Product MCP (gateway) |
+| `mukoko-news` | http — `https://news.mukoko.dev/mcp` | Product MCP (gateway) |
 | `fly` | stdio — `flyctl mcp server` | Local `flyctl` auth |
 
 **MongoDB access**: the nyuchi MongoDB MCP (`https://mongodb.nyuchi.dev/mcp`) is **not** project-scoped — it is added per-developer as a **personal Claude connector** (Claude → Settings → Connectors), not via this repo's `.mcp.json`. So it is not listed above.
@@ -178,7 +178,7 @@ WORKOS_PLATFORM_ORG_ID=org_...                     # platform-team org → /admi
 NEXT_PUBLIC_API_URL=
 
 # Gateway Worker (admin mutations only)
-GATEWAY_API_URL=https://news.mukoko.com
+GATEWAY_API_URL=https://news.mukoko.dev
 
 # Pipeline trigger (manual refresh action)
 FLY_WORKER_URL=https://news-ingestion.fly-worker.nyuchi.dev

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The frontend reads news data directly from MongoDB Atlas via Next.js Server Acti
 - **Search** — full-text search across all articles
 - **Dark mode** — respects system preference
 - **Embed widgets** — drop a news feed into any site with one `<script>` tag
-- **MCP server** — AI assistants can query Pan-African news at `news.mukoko.com/mcp`
+- **MCP server** — AI assistants can query Pan-African news at `news.mukoko.dev/mcp`
 - **Accessible** — Radix UI primitives, WCAG AAA contrast, Schema.org structured data
 
 ---
@@ -135,7 +135,7 @@ AI assistants and agents can query Pan-African news via the [Model Context Proto
   "mcpServers": {
     "mukoko-news": {
       "type": "http",
-      "url": "https://news.mukoko.com/mcp"
+      "url": "https://news.mukoko.dev/mcp"
     }
   }
 }

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -298,7 +298,7 @@ export default function AnalyticsPage() {
             /api/analytics
           </code>{" "}
           or via our{" "}
-          <Link href="https://news.mukoko.com/mcp" className="text-primary underline underline-offset-2">
+          <Link href="https://news.mukoko.dev/mcp" className="text-primary underline underline-offset-2">
             MCP server
           </Link>
           .

--- a/src/lib/admin/gateway.ts
+++ b/src/lib/admin/gateway.ts
@@ -8,7 +8,7 @@ import { withAuth } from '@workos-inc/authkit-nextjs'
 // admin UI gated on. Reads stay in MongoDB (src/lib/mongodb/admin.ts); only
 // mutations route through the Worker — it owns the writes.
 
-const GATEWAY_BASE = process.env.GATEWAY_API_URL || 'https://news.mukoko.com'
+const GATEWAY_BASE = process.env.GATEWAY_API_URL || 'https://news.mukoko.dev'
 
 export interface GatewayResult<T = unknown> {
   ok: boolean


### PR DESCRIPTION
## Summary

Follow-up to the gateway move onto its own host. The gateway/MCP now lives at **`news.mukoko.dev`** (see `nyuchi/mukoko-news-gateway#7`); this repoints the frontend's references so admin mutations and the dev MCP hit the working host.

- **`src/lib/admin/gateway.ts`** — `GATEWAY_API_URL` default → `https://news.mukoko.dev` (admin mutations; the prod value is still set in Vercel env — update that too).
- **`.mcp.json`** — project MCP server URL → `https://news.mukoko.dev/mcp`.
- **`src/app/analytics/page.tsx`** — the public "MCP server" link → `news.mukoko.dev/mcp`.
- **`.env.example` / `CLAUDE.md` / `README.md`** — docs + example config → `.dev`.

The frontend itself stays on `news.mukoko.com` (Vercel) — unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Set the real `GATEWAY_API_URL=https://news.mukoko.dev` in Vercel env (the code default only applies if the env var is unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_