### PR TITLE
feat(images): route article images through the image-worker proxy

### DIFF
--- a/src/components/article-card.tsx
+++ b/src/components/article-card.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { Clock } from "lucide-react";
 import type { Article } from "@/lib/api";
 import { isValidImageUrl, safeCssUrl } from "@/lib/utils";
+import { imageProxyUrl } from "@/lib/image";
 import { SourceBadge } from "@/components/ui/source-icon";
 import { InlineEngagement } from "@/components/ui/engagement-bar";
 
@@ -41,7 +42,7 @@ export function ArticleCard({ article }: ArticleCardProps) {
 
   const coverStyle = hasImage
     ? {
-        background: `linear-gradient(135deg, rgba(0,0,0,0.3), rgba(0,0,0,0.6)), ${safeCssUrl(article.image_url!)} center/cover`,
+        background: `linear-gradient(135deg, rgba(0,0,0,0.3), rgba(0,0,0,0.6)), ${safeCssUrl(imageProxyUrl(article.image_url!, { width: 800 }))} center/cover`,
       }
     : { background: "linear-gradient(135deg, var(--primary), var(--secondary))" };
 

--- a/src/components/hero-card.tsx
+++ b/src/components/hero-card.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import { Clock } from "lucide-react";
 import type { Article } from "@/lib/api";
 import { formatTimeAgo, isValidImageUrl } from "@/lib/utils";
+import { mukokoImageLoader } from "@/lib/image";
 import { SourceIcon } from "@/components/ui/source-icon";
 
 interface HeroCardProps {
@@ -36,6 +37,7 @@ export function HeroCard({ article }: HeroCardProps) {
           {hasImage && article.image_url ? (
             <>
               <Image
+                loader={mukokoImageLoader}
                 src={article.image_url}
                 alt={article.description || article.title || "Article image"}
                 fill

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -1,0 +1,61 @@
+/**
+ * Route article images through the Mukoko image-worker proxy
+ * (`assets.mukoko.com/i/<encoded-original>?w=…&fmt=webp`).
+ *
+ * Why: article `image_url`s are third-party publisher URLs. Rendering them raw
+ * relies on Vercel's optimizer fetching hundreds of unknown hosts (slow/limited)
+ * and on each publisher not hotlink-blocking. The image-worker fetches the origin
+ * server-side, resizes/optimizes (webp/avif), caches in R2, and serves a clean
+ * same-origin image — so images load reliably.
+ *
+ * The original URL is **percent-encoded** into the path segment so its own query
+ * string survives (the worker does one `decodeURIComponent` on the path and reads
+ * `w/h/fmt/q/fit` from the request query separately).
+ */
+const IMAGE_PROXY_BASE = 'https://assets.mukoko.com/i/';
+
+export interface ImageProxyOptions {
+  width?: number;
+  height?: number;
+  quality?: number;
+  fit?: 'cover' | 'contain' | 'scale-down' | 'crop' | 'pad';
+  format?: 'webp' | 'avif' | 'jpeg' | 'png';
+}
+
+/**
+ * Wrap an absolute http(s) image URL with the image-worker proxy. Relative paths
+ * (`/foo.png`), data/blob URLs, and empty values are returned unchanged — only
+ * remote publisher images need proxying.
+ */
+export function imageProxyUrl(src: string | undefined | null, opts: ImageProxyOptions = {}): string {
+  if (!src) return '';
+  // Only proxy absolute http(s) URLs; leave local/relative assets alone.
+  if (!/^https?:\/\//i.test(src)) return src;
+
+  const params = new URLSearchParams();
+  if (opts.width) params.set('w', String(opts.width));
+  if (opts.height) params.set('h', String(opts.height));
+  params.set('fmt', opts.format ?? 'webp');
+  params.set('q', String(opts.quality ?? 80));
+  params.set('fit', opts.fit ?? 'cover');
+  return `${IMAGE_PROXY_BASE}${encodeURIComponent(src)}?${params.toString()}`;
+}
+
+/**
+ * A `next/image` loader that routes optimization to the image-worker instead of
+ * Vercel's optimizer. next/image calls this per srcset width; the worker resizes.
+ */
+export function mukokoImageLoader({
+  src,
+  width,
+  quality,
+}: {
+  src: string;
+  width: number;
+  quality?: number;
+}): string {
+  const proxied = imageProxyUrl(src, { width, quality });
+  // If src wasn't a remote URL, imageProxyUrl returns it unchanged — hand it back
+  // so next/image can still render a local asset.
+  return proxied || src;
+}


### PR DESCRIPTION
## Summary

Article `image_url`s are third-party publisher URLs. Rendering them raw relies on Vercel's optimizer fetching hundreds of unknown hosts (slow/rate-limited) and on each publisher not hotlink-blocking — which is why article images intermittently fail to display in production. This routes them through the Mukoko image-worker (`assets.mukoko.com/i/*`), which fetches the origin server-side, resizes/optimizes to webp/avif, caches in R2, and serves a clean same-origin image behind the existing SSRF guard.

## Changes

- **`src/lib/image.ts`** (new):
  - `imageProxyUrl(src, opts)` — wraps an absolute `http(s)` URL with the proxy (`assets.mukoko.com/i/<encoded-original>?w&fmt=webp&q&fit`). The original URL is percent-encoded into the path so its own query string survives. Relative/`data:`/`blob:`/empty values are returned unchanged.
  - `mukokoImageLoader({src,width,quality})` — a `next/image` loader that routes optimization to the image-worker instead of Vercel's optimizer.
- **`src/components/hero-card.tsx`** — `next/image` now uses `loader={mukokoImageLoader}`.
- **`src/components/article-card.tsx`** — CSS `background-image` wraps `image_url` in `imageProxyUrl(..., { width: 800 })` (still via `safeCssUrl`).

## Testing

- `npm run typecheck` — clean.
- `npx vitest run src/components` — 185 tests pass.

## Notes

- No dependency changes, so no lockfile churn.
- The image-worker's open-proxy + SSRF guard (block RFC1918 / link-local / CGNAT / IPv6 special ranges, per-hop redirect revalidation, 15 MB cap) already shipped separately; this PR is the frontend consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_