### PR TITLE
fix(feed): drive category nav + filtering from AI categories, not hardcoded articleSection

### DIFF
--- a/src/lib/mongodb/articles.ts
+++ b/src/lib/mongodb/articles.ts
@@ -93,7 +93,13 @@ function resolveCategory(doc: MongoArticle): string | undefined {
     const label = entryLabel(cats[0])
     if (label) return label
   }
-  return doc.articleSection || undefined
+  // Fall back to `articleSection` ONLY when it carries real signal. The collectors
+  // hardcode it to "general" at ingestion, so an un-enriched article would otherwise
+  // render a misleading "general" badge (the "everything is "general"" symptom).
+  // Genuinely-classified "general" comes from `interest_categories` above and is kept.
+  const section = doc.articleSection?.trim()
+  if (section && section.toLowerCase() !== 'general') return section
+  return undefined
 }
 
 /** Map `engagement.tags` (strings or objects) onto the Article keyword shape. */
@@ -151,11 +157,18 @@ export async function getArticles(params: {
     status: { $ne: 'rejected' },
     moderationStatus: { $ne: 'removed' },
   }
+  // Filter on the AI-classified categories (`engagement.interest_categories`,
+  // an array of slugs) — NOT the legacy `articleSection`, which the collectors
+  // hardcode to "general", so filtering on it returned everything-or-nothing and
+  // never matched a real category the nav surfaced. Case-insensitive so a nav
+  // slug matches regardless of how enrichment cased it.
+  const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   if (categories?.length) {
-    const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    filter.articleSection = { $in: categories.map(c => new RegExp(`^${escapeRegex(c)}$`, 'i')) } as never
+    filter['engagement.interest_categories'] = {
+      $in: categories.map(c => new RegExp(`^${escapeRegex(c)}$`, 'i')),
+    } as never
   } else if (category) {
-    filter.articleSection = category
+    filter['engagement.interest_categories'] = new RegExp(`^${escapeRegex(category)}$`, 'i') as never
   }
   if (countries?.length) {
     const sources = await db.collection<MongoFeedSource>('feedSources')

--- a/src/lib/mongodb/categories.ts
+++ b/src/lib/mongodb/categories.ts
@@ -32,18 +32,53 @@ interface MongoTrendingCache {
   expiresAt: Date
 }
 
+/** Title-case a category slug for display: "international" → "International",
+ *  "arts-culture" → "Arts Culture". Used when a category comes from the AI
+ *  classification (a bare slug) rather than a curated `categories` doc with a name. */
+function slugToName(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
 export async function getCategories(): Promise<Category[]> {
   const db = await getDb()
-  const docs = await db.collection<MongoCategory>('categories')
+
+  // Prefer curated category docs when the collection is populated…
+  const curated = await db.collection<MongoCategory>('categories')
     .find({})
     .sort({ sortOrder: 1 })
     .toArray()
+  if (curated.length > 0) {
+    return curated.map(d => ({
+      id: d._id,
+      name: d.name,
+      slug: d.categorySlug,
+    }))
+  }
 
-  return docs.map(d => ({
-    id: d._id,
-    name: d.name,
-    slug: d.categorySlug,
-  }))
+  // …otherwise derive the list from the categories articles are ACTUALLY
+  // classified into. AI enrichment writes slugs to
+  // `engagement.interest_categories`; the legacy `articleSection` is hardcoded
+  // "general" at ingestion, so grouping on it (the old behaviour) collapsed the
+  // whole nav to a single "general" bucket. Rank by article count so the busiest
+  // real categories lead the quick-nav bar.
+  const rows = await db.collection('articles').aggregate<{ _id: string; n: number }>([
+    { $match: { status: { $ne: 'rejected' }, moderationStatus: { $ne: 'removed' } } },
+    { $unwind: '$engagement.interest_categories' },
+    { $group: { _id: '$engagement.interest_categories', n: { $sum: 1 } } },
+    { $sort: { n: -1 } },
+    { $limit: 24 },
+  ]).toArray()
+
+  return rows
+    .filter((r) => typeof r._id === 'string' && r._id.trim().length > 0)
+    .map((r) => {
+      const slug = r._id.trim()
+      return { id: slug, name: slugToName(slug), slug, article_count: r.n }
+    })
 }
 
 export async function getTrendingTags(limit = 32): Promise<Array<{
@@ -93,18 +128,26 @@ export async function getTrendingCategories(limit = 8): Promise<Array<{
     }))
   }
 
-  // Live fallback: aggregate from articles
+  // Live fallback: aggregate from the AI-classified categories
+  // (`engagement.interest_categories`), NOT the hardcoded-"general"
+  // `articleSection`, so trending reflects real topic distribution.
   const pipeline = [
-    { $match: { status: { $in: ['approved', 'published'] }, articleSection: { $exists: true, $ne: null } } },
-    { $group: { _id: '$articleSection', article_count: { $sum: 1 } } },
+    { $match: { status: { $ne: 'rejected' }, moderationStatus: { $ne: 'removed' } } },
+    { $unwind: '$engagement.interest_categories' },
+    { $group: { _id: '$engagement.interest_categories', article_count: { $sum: 1 } } },
     { $sort: { article_count: -1 } },
     { $limit: limit },
   ]
   const rows = await db.collection('articles').aggregate(pipeline).toArray()
-  return rows.map(r => ({
-    id: r._id as string,
-    name: r._id as string,
-    slug: (r._id as string).toLowerCase().replace(/\s+/g, '-'),
-    article_count: r.article_count as number,
-  }))
+  return rows
+    .filter(r => typeof r._id === 'string' && (r._id as string).trim().length > 0)
+    .map(r => {
+      const slug = (r._id as string).trim()
+      return {
+        id: slug,
+        name: slugToName(slug),
+        slug,
+        article_count: r.article_count as number,
+      }
+    })
 }


### PR DESCRIPTION
## Summary

Two reported production issues — **"displaying only general"** and **"no category banner / no way to quickly select a category"** — share one root cause: the frontend built category data from `articleSection`, which the collectors **hardcode to `"general"`** at ingestion. The real, diverse classification lives in `engagement.interest_categories` (politics 2,303, international 1,369, business 1,093, …), written by AI enrichment.

Verified against the live DB: the curated `news.categories` collection is **empty** (so the quick-nav rendered nothing), and every recent article has `articleSection: "general"` regardless of its actual AI category.

## Changes (`src/lib/mongodb/`)

- **`categories.ts › getCategories()`** — curated `categories` docs still win when present, but when the collection is empty, derive the list from what articles are *actually* classified into (`engagement.interest_categories`, ranked by count). This is what repopulates the quick-nav bar.
- **`articles.ts › getArticles()`** — filter on `engagement.interest_categories` (case-insensitive) instead of `articleSection`, so selecting a category returns real matches instead of nothing.
- **`categories.ts › getTrendingCategories()`** — live fallback aggregates the AI categories too.
- **`articles.ts › resolveCategory()`** — stop falling back to the hardcoded `"general"` `articleSection`; un-enriched articles now render **no** badge instead of a misleading "general". Genuinely-classified "general" (from `interest_categories`) is preserved.

The home page already had a category quick-nav (`page.tsx`, `allCategories.map`) — it was empty only because `getCategories` returned nothing. No new component needed; it now populates and clicking a chip filters via the fixed `getArticles` path.

## Not in scope (tracked separately)

The deeper driver of "only general" is that **enrichment throughput can't keep up with ingestion** (only 28% of 15,811 articles are enriched; ~49% of daily ingestion gets classified), so the newest articles are still un-enriched. That's being addressed in the Fundi News enrichment-agent rework. This PR makes the UI correctly surface whatever *is* classified and stops mislabelling the rest.

## Testing

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run src/lib` — 148 pass
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_