### PR TITLE
fix(images,a11y): proxy all article images, fix hover contrast, add /about

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           ref: main # tip of main (not the trigger SHA) so rapid merges don't tag a stale commit
           # Org-wide release PAT so the push to a protected `main` and the tag/release
           # are allowed (the default GITHUB_TOKEN can't bypass branch protection).
-          # Set the org secret name here if it differs from RELEASE_TOKEN.
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # Set the org secret name here if it differs from RELEASE_BUMP_TOKEN.
+          token: ${{ secrets.RELEASE_BUMP_TOKEN }}
 
       - name: Compute next version
         id: v
@@ -50,7 +50,7 @@ jobs:
 
       - name: Tag + bump VERSION + release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BUMP_TOKEN }}
           NEW: ${{ steps.v.outputs.new }}
         run: |
           set -euo pipefail

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import Link from "next/link";
+import { Globe, Zap, Users, ChevronRight } from "lucide-react";
+
+const values = [
+  {
+    icon: Globe,
+    title: "Pan-African by design",
+    description:
+      "News from across the continent in one place — starting in Zimbabwe and expanding across 16 African countries, with local sources at the centre.",
+  },
+  {
+    icon: Zap,
+    title: "Fast, clean reading",
+    description:
+      "AI-assisted summaries, categories, and a distraction-free reader let you catch up quickly and dive deeper only where you want to.",
+  },
+  {
+    icon: Users,
+    title: "Community-first",
+    description:
+      "“Mukoko” means beehive in Shona — where the community gathers and stores knowledge. The platform is built to serve African readers first.",
+  },
+];
+
+export default function AboutPage() {
+  return (
+    <div className="max-w-[800px] mx-auto px-6 py-12">
+      <h1 className="text-3xl font-bold text-foreground mb-2">About Mukoko News</h1>
+      <p className="text-text-secondary mb-8">
+        A Pan-African digital news aggregation platform bringing the continent&rsquo;s stories
+        together.
+      </p>
+
+      {/* Mission */}
+      <div className="p-6 bg-primary/10 rounded-xl mb-12">
+        <h2 className="font-semibold text-foreground mb-2">Our mission</h2>
+        <p className="text-text-secondary text-sm leading-relaxed">
+          Mukoko News aggregates trusted journalism from across Africa and makes it fast and easy to
+          follow. &ldquo;Mukoko&rdquo; means <span className="italic">beehive</span> in Shona &mdash;
+          a place where the community gathers and stores knowledge. We started in Zimbabwe and are
+          expanding across 16 African countries, always keeping local voices and local sources at
+          the heart of the feed.
+        </p>
+      </div>
+
+      {/* What we're about */}
+      <h2 className="text-xl font-bold text-foreground mb-6">What we&rsquo;re about</h2>
+      <div className="space-y-4 mb-12">
+        {values.map((value) => (
+          <div key={value.title} className="flex items-start gap-4 p-4 bg-surface rounded-xl">
+            <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center shrink-0">
+              <value.icon className="w-6 h-6 text-primary" />
+            </div>
+            <div>
+              <p className="font-semibold text-foreground">{value.title}</p>
+              <p className="text-sm text-text-secondary leading-relaxed">{value.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Links */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Link
+          href="/help"
+          className="flex items-center justify-between p-4 bg-surface rounded-xl hover:bg-elevated transition-colors"
+        >
+          <span className="font-medium text-foreground">Help Center</span>
+          <ChevronRight className="w-5 h-5 text-text-tertiary" />
+        </Link>
+        <Link
+          href="https://mukoko.com"
+          target="_blank"
+          className="flex items-center justify-between p-4 bg-surface rounded-xl hover:bg-elevated transition-colors"
+        >
+          <span className="font-medium text-foreground">A Mukoko Product</span>
+          <ChevronRight className="w-5 h-5 text-text-tertiary" />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/article/[id]/article-detail-client.tsx
+++ b/src/app/article/[id]/article-detail-client.tsx
@@ -19,6 +19,7 @@ import { Markdown } from "@/components/ui/markdown";
 import { type Article } from "@/lib/api";
 import { getArticleAction } from "@/lib/actions/feed";
 import { getArticleUrl } from "@/lib/constants";
+import { imageProxyUrl } from "@/lib/image";
 import { isValidImageUrl } from "@/lib/utils";
 import { ArticlePageSkeleton } from "@/components/ui/skeleton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
@@ -298,7 +299,7 @@ export default function ArticleDetailClient({
         <div className="max-w-[900px] mx-auto px-6 -mt-6">
           <div className="rounded-2xl overflow-hidden shadow-xl">
             <img
-              src={article.image_url}
+              src={imageProxyUrl(article.image_url, { width: 900 })}
               alt={article.title}
               className="w-full aspect-video object-cover"
             />

--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -229,7 +229,7 @@ export default function DiscoverPage() {
                       {meta.emoji}
                     </div>
                     <div className="min-w-0">
-                      <p className="font-medium text-foreground truncate group-hover:text-primary transition-colors">
+                      <p className="font-medium text-foreground truncate group-hover:underline decoration-2 underline-offset-2">
                         {category.name}
                       </p>
                       <p className="text-xs text-text-tertiary">
@@ -258,7 +258,7 @@ export default function DiscoverPage() {
                       {country.flag}
                     </div>
                     <div className="min-w-0">
-                      <p className="font-medium text-foreground truncate group-hover:text-primary transition-colors">
+                      <p className="font-medium text-foreground truncate group-hover:underline decoration-2 underline-offset-2">
                         {country.name}
                       </p>
                       <p className="text-xs text-text-tertiary">
@@ -313,7 +313,7 @@ function SourcesSection({ sources }: { sources: Source[] }) {
                 <Newspaper className="w-5 h-5 text-primary" />
               </div>
               <div className="min-w-0">
-                <p className="font-medium text-foreground truncate group-hover:text-primary transition-colors">
+                <p className="font-medium text-foreground truncate group-hover:underline decoration-2 underline-offset-2">
                   {source.name}
                 </p>
                 <p className="text-xs text-text-tertiary">

--- a/src/app/embed/iframe/page.tsx
+++ b/src/app/embed/iframe/page.tsx
@@ -7,6 +7,7 @@ import { type Article } from "@/lib/api";
 import { getArticlesAction } from "@/lib/actions/feed";
 import { getArticleUrl, BASE_URL, COUNTRIES } from "@/lib/constants";
 import { isValidImageUrl, formatTimeAgo, safeCssUrl } from "@/lib/utils";
+import { imageProxyUrl } from "@/lib/image";
 import { SourceIcon } from "@/components/ui/source-icon";
 
 const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
@@ -45,7 +46,7 @@ function HeroEmbed({ article }: { article: Article }) {
         {hasImage ? (
           <div
             className="absolute inset-0 bg-cover bg-center"
-            style={{ backgroundImage: safeCssUrl(article.image_url!) }}
+            style={{ backgroundImage: safeCssUrl(imageProxyUrl(article.image_url!, { width: 600 })) }}
           />
         ) : (
           <div className="absolute inset-0 bg-gradient-to-br from-primary to-secondary" />
@@ -92,7 +93,7 @@ function CardEmbed({ article }: { article: Article }) {
         {hasImage && (
           <div
             className="h-[120px] bg-elevated bg-cover bg-center"
-            style={{ backgroundImage: safeCssUrl(article.image_url!) }}
+            style={{ backgroundImage: safeCssUrl(imageProxyUrl(article.image_url!, { width: 600 })) }}
           />
         )}
         <div className="p-3">
@@ -165,7 +166,7 @@ function ListEmbed({ article }: { article: Article }) {
         {hasImage && (
           <div
             className="w-20 h-20 rounded-lg bg-elevated bg-cover bg-center shrink-0"
-            style={{ backgroundImage: safeCssUrl(article.image_url!) }}
+            style={{ backgroundImage: safeCssUrl(imageProxyUrl(article.image_url!, { width: 600 })) }}
           />
         )}
         <div className="flex-1 min-w-0">
@@ -213,7 +214,7 @@ function TickerEmbed({ articles }: { articles: Article[] }) {
               {hasImage && (
                 <div
                   className="h-[100px] bg-elevated bg-cover bg-center"
-                  style={{ backgroundImage: safeCssUrl(article.image_url!) }}
+                  style={{ backgroundImage: safeCssUrl(imageProxyUrl(article.image_url!, { width: 600 })) }}
                 />
               )}
               <div className="p-2.5">

--- a/src/app/embed/iframe/page.tsx
+++ b/src/app/embed/iframe/page.tsx
@@ -59,7 +59,7 @@ function HeroEmbed({ article }: { article: Article }) {
               {category}
             </span>
           )}
-          <h3 className="text-lg font-bold text-white leading-snug line-clamp-3 group-hover:text-primary transition-colors">
+          <h3 className="text-lg font-bold text-white leading-snug line-clamp-3 group-hover:underline decoration-2 underline-offset-2">
             {article.title}
           </h3>
           {article.description && (
@@ -102,7 +102,7 @@ function CardEmbed({ article }: { article: Article }) {
               {category}
             </span>
           )}
-          <h3 className="text-sm font-semibold leading-snug line-clamp-2 mt-0.5 group-hover:text-primary transition-colors">
+          <h3 className="text-sm font-semibold leading-snug line-clamp-2 mt-0.5 group-hover:underline decoration-2 underline-offset-2">
             {article.title}
           </h3>
           <div className="flex items-center gap-2 mt-2 text-text-tertiary">
@@ -137,7 +137,7 @@ function CompactEmbed({ article }: { article: Article }) {
               {category}
             </span>
           )}
-          <h3 className="text-sm font-semibold leading-snug line-clamp-2 group-hover:text-primary transition-colors">
+          <h3 className="text-sm font-semibold leading-snug line-clamp-2 group-hover:underline decoration-2 underline-offset-2">
             {article.title}
           </h3>
           <div className="flex items-center gap-2 mt-1 text-text-tertiary text-[11px]">
@@ -175,7 +175,7 @@ function ListEmbed({ article }: { article: Article }) {
               {category}
             </span>
           )}
-          <h3 className="text-sm font-semibold leading-snug line-clamp-2 group-hover:text-primary transition-colors">
+          <h3 className="text-sm font-semibold leading-snug line-clamp-2 group-hover:underline decoration-2 underline-offset-2">
             {article.title}
           </h3>
           <div className="flex items-center gap-2 mt-1 text-text-tertiary">
@@ -223,7 +223,7 @@ function TickerEmbed({ articles }: { articles: Article[] }) {
                     {category}
                   </span>
                 )}
-                <h3 className="text-xs font-semibold leading-snug line-clamp-2 mt-0.5 group-hover:text-primary transition-colors">
+                <h3 className="text-xs font-semibold leading-snug line-clamp-2 mt-0.5 group-hover:underline decoration-2 underline-offset-2">
                   {article.title}
                 </h3>
                 <span className="text-[10px] text-text-tertiary mt-1 block truncate">

--- a/src/app/newsbytes/page.tsx
+++ b/src/app/newsbytes/page.tsx
@@ -13,6 +13,7 @@ import {
 import { type Article } from "@/lib/api";
 import { getNewsBytesAction } from "@/lib/actions/feed";
 import { isValidImageUrl, safeCssUrl } from "@/lib/utils";
+import { imageProxyUrl } from "@/lib/image";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { NewsBytesSkeleton } from "@/components/ui/discover-skeleton";
 
@@ -273,7 +274,7 @@ export default function NewsBytesPage() {
               ref={(el) => setItemRef(el, index)}
               className="relative w-full h-full snap-start snap-always"
               style={{
-                backgroundImage: `linear-gradient(135deg, rgba(0,0,0,0.3), rgba(0,0,0,0.7)), ${safeCssUrl(byte.image_url ?? "")}`,
+                backgroundImage: `linear-gradient(135deg, rgba(0,0,0,0.3), rgba(0,0,0,0.7)), ${safeCssUrl(imageProxyUrl(byte.image_url ?? "", { width: 800 }))}`,
                 backgroundSize: "cover",
                 backgroundPosition: "center",
               }}

--- a/src/components/compact-card.tsx
+++ b/src/components/compact-card.tsx
@@ -29,7 +29,7 @@ export function CompactCard({ article }: CompactCardProps) {
         )}
 
         {/* Title */}
-        <h3 className="text-base font-semibold mt-1 mb-2 leading-snug line-clamp-2 group-hover:text-primary transition-colors">
+        <h3 className="text-base font-semibold mt-1 mb-2 leading-snug line-clamp-2 group-hover:underline decoration-2 underline-offset-2">
           {article.title}
         </h3>
 

--- a/src/components/hero-card.tsx
+++ b/src/components/hero-card.tsx
@@ -62,7 +62,7 @@ export function HeroCard({ article }: HeroCardProps) {
 
           {/* Content overlay at bottom */}
           <div className="absolute bottom-0 left-0 right-0 p-5 sm:p-6 z-10">
-            <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-white mb-3 leading-tight group-hover:text-primary transition-colors line-clamp-3">
+            <h2 className="text-xl sm:text-2xl md:text-3xl font-bold text-white mb-3 leading-tight group-hover:underline decoration-2 underline-offset-2 line-clamp-3">
               {article.title}
             </h2>
 

--- a/src/components/story-cluster.tsx
+++ b/src/components/story-cluster.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { Clock, Layers, ChevronRight } from "lucide-react";
 import type { StoryCluster as StoryClusterType } from "@/lib/api";
 import { isValidImageUrl, safeCssUrl, formatTimeAgo } from "@/lib/utils";
+import { imageProxyUrl } from "@/lib/image";
 import { SourceIcon } from "@/components/ui/source-icon";
 
 interface StoryClusterProps {
@@ -25,7 +26,7 @@ export function StoryCluster({ cluster }: StoryClusterProps) {
           <div
             className="h-[200px] sm:h-[240px] relative bg-elevated"
             style={{
-              background: `linear-gradient(to bottom, transparent 50%, rgba(0,0,0,0.7)), ${safeCssUrl(primaryArticle.image_url!)} center/cover`,
+              background: `linear-gradient(to bottom, transparent 50%, rgba(0,0,0,0.7)), ${safeCssUrl(imageProxyUrl(primaryArticle.image_url!, { width: 800 }))} center/cover`,
             }}
           >
             {/* Category Badge */}
@@ -51,7 +52,7 @@ export function StoryCluster({ cluster }: StoryClusterProps) {
           </div>
 
           {/* Title */}
-          <h3 className="text-lg font-bold leading-tight line-clamp-2 group-hover:text-primary transition-colors">
+          <h3 className="text-lg font-bold leading-tight line-clamp-2 group-hover:underline decoration-2 underline-offset-2">
             {primaryArticle.title}
           </h3>
 
@@ -78,7 +79,7 @@ export function StoryCluster({ cluster }: StoryClusterProps) {
                 <div
                   className="w-16 h-16 flex-shrink-0 rounded-lg bg-elevated"
                   style={{
-                    background: `${safeCssUrl(article.image_url)} center/cover`,
+                    background: `${safeCssUrl(imageProxyUrl(article.image_url, { width: 400 }))} center/cover`,
                   }}
                 />
               )}
@@ -91,7 +92,7 @@ export function StoryCluster({ cluster }: StoryClusterProps) {
                 </div>
 
                 {/* Title */}
-                <h4 className="text-sm font-medium leading-snug line-clamp-2 hover:text-primary transition-colors">
+                <h4 className="text-sm font-medium leading-snug line-clamp-2 hover:underline decoration-2 underline-offset-2">
                   {article.title}
                 </h4>
 
@@ -137,7 +138,7 @@ export function StoryClusterCompact({ cluster }: StoryClusterProps) {
         <div
           className="h-[140px] relative"
           style={{
-            background: `${safeCssUrl(primaryArticle.image_url!)} center/cover`,
+            background: `${safeCssUrl(imageProxyUrl(primaryArticle.image_url!, { width: 800 }))} center/cover`,
           }}
         >
           {articleCount > 1 && (

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import ReactMarkdown from "react-markdown";
+import { imageProxyUrl } from "@/lib/image";
+import { isValidImageUrl } from "@/lib/utils";
 
 /**
  * Render Markdown as styled React elements. Used for article bodies
@@ -10,6 +12,11 @@ import ReactMarkdown from "react-markdown";
  * default (no `rehype-raw`), so any stray `<script>`/`<img onerror>` in the source
  * is emitted as literal text, never live DOM — no `dangerouslySetInnerHTML` and no
  * separate sanitizer needed. Links are forced to open safely in a new tab.
+ *
+ * Inline body images (`![](…)`) are third-party publisher URLs, so they go through
+ * the image-worker proxy just like every other article image — otherwise the raw
+ * cross-origin fetch is slow, hotlink-blocked, or dropped by OpaqueResponseBlocking.
+ * Unsafe/relative srcs are skipped (`isValidImageUrl`) rather than rendered raw.
  */
 export function Markdown({ children }: { children: string }) {
   return (
@@ -21,6 +28,18 @@ export function Markdown({ children }: { children: string }) {
               {children}
             </a>
           ),
+          img: ({ src, alt }) => {
+            if (typeof src !== "string" || !isValidImageUrl(src)) return null;
+            return (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={imageProxyUrl(src, { width: 900 })}
+                alt={alt ?? ""}
+                loading="lazy"
+                className="rounded-lg"
+              />
+            );
+          },
         }}
       >
         {children}


### PR DESCRIPTION
## Summary

Follow-up to #127, which only proxied feed cards. Several surfaces still emitted **raw source image URLs**, which get blocked or render blank on production. This routes every remaining article image through the image-worker proxy, plus fixes two other reported issues.

### Images — route all remaining raw URLs through the proxy
- `article/[id]/article-detail-client.tsx` — detail hero image (`width: 900`)
- `components/story-cluster.tsx` — CSS-bg images (`width: 800` / `400`)
- `newsbytes/page.tsx` — full-bleed byte image (`width: 800`)
- `embed/iframe/page.tsx` — all 4 layout background images (`width: 600`)

All wrapped in the existing `imageProxyUrl()` helper; CSS-bg usages remain wrapped in `safeCssUrl()`.

### Accessibility — hover contrast on card titles
Card titles used `group-hover:text-primary` (tanzanite), which on card surfaces failed contrast and became unreadable on hover. Replaced with an underline treatment on `hero-card`, `compact-card`, and `story-cluster`.

### `/about` 404
The footer links to `/about` but the page did not exist (404 on `/about?_rsc`). Added an on-brand About page mirroring the `/help` layout (mission + values + links).

### CI
- `release.yml` now references `secrets.RELEASE_BUMP_TOKEN` (the actual org secret name) on both `token:` and `GH_TOKEN:`.

## Testing
- `npm run typecheck` ✅
- `npm run build` ✅ (`/about` prerenders as static)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_