### PR TITLE
feat(brand): adopt Mzizi N3 brand components + N1 harness (modern news cards)

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -175,8 +175,8 @@ export default function DiscoverPage() {
             </Link>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredArticles.map((article) => (
-              <ArticleCard key={article.id} article={article} />
+            {filteredArticles.map((article, index) => (
+              <ArticleCard key={article.id} article={article} index={index} />
             ))}
           </div>
           {filteredArticles.length === 0 && (
@@ -202,8 +202,8 @@ export default function DiscoverPage() {
               </Link>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {articles.slice(0, 6).map((article) => (
-                <ArticleCard key={article.id} article={article} />
+              {articles.slice(0, 6).map((article, index) => (
+                <ArticleCard key={article.id} article={article} index={index} />
               ))}
             </div>
           </section>

--- a/src/app/embed/iframe/page.tsx
+++ b/src/app/embed/iframe/page.tsx
@@ -55,7 +55,7 @@ function HeroEmbed({ article }: { article: Article }) {
 
         <div className="relative flex flex-col justify-end h-full p-5" style={{ minHeight: 280 }}>
           {category && (
-            <span className="self-start bg-primary text-white px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-2">
+            <span className="self-start bg-black/70 text-white backdrop-blur-sm px-2.5 py-1 rounded-full text-[10px] font-bold uppercase tracking-wider mb-2">
               {category}
             </span>
           )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -246,6 +246,60 @@
   --radius-input: 8px;
   --radius-badge: 9999px;
   --radius: 0.75rem;
+
+  /* Mzizi N1 radii consumed by the brand components (nyuchi-listing-card, …) */
+  --radius-inner: 7px;
+  --radius-pill: 9999px;
+
+  /* Status colors (mzizi styling-semantic-colors) */
+  --color-status-success: var(--status-success);
+  --color-status-warning: var(--status-warning);
+  --color-status-error: var(--status-error);
+  --color-status-neutral: var(--status-neutral);
+}
+
+/* ── Mzizi N1 semantic status tokens (theme-aware) ─────────────────
+   Consumed by the nyuchi brand components (factcheck + credibility
+   indicators). Mirrors the mineral roles: success=malachite,
+   warning=gold, error=red ramp, neutral=tertiary text. */
+:root,
+.dark {
+  --status-success: #64FFDA;
+  --status-warning: #FFD740;
+  --status-error: #FF5252;
+  --status-neutral: #8A8A85;
+  /* Focus ring (mzizi styling-accessibility-checks) */
+  --focusRing-width: 2px;
+  --focusRing-offset: 2px;
+}
+
+.light {
+  --status-success: #004D40;
+  --status-warning: #5D4037;
+  --status-error: #B3261E;
+  --status-neutral: #595959;
+}
+
+/* ── Mzizi motion tokens: entry animation used by the nyuchi harness ── */
+@keyframes nyuchi-fade-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.nyuchi-animate-in {
+  animation: nyuchi-fade-slide-up 200ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nyuchi-animate-in {
+    animation: none;
+  }
 }
 
 body {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -484,8 +484,8 @@ export default function FeedPage() {
                   </div>
 
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {yourNews.slice(0, 6).map((article) => (
-                      <ArticleCard key={article.id} article={article} />
+                    {yourNews.slice(0, 6).map((article, index) => (
+                      <ArticleCard key={article.id} article={article} index={index} />
                     ))}
                   </div>
                 </section>
@@ -523,8 +523,8 @@ export default function FeedPage() {
 
                       {/* Compact cards for rest */}
                       <div className="space-y-3">
-                        {section.articles.slice(1, 5).map((article) => (
-                          <CompactCard key={article.id} article={article} />
+                        {section.articles.slice(1, 5).map((article, index) => (
+                          <CompactCard key={article.id} article={article} index={index} />
                         ))}
                       </div>
                     </div>
@@ -545,8 +545,8 @@ export default function FeedPage() {
                   </div>
 
                   <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {latestArticles.map((article) => (
-                      <ArticleCard key={article.id} article={article} />
+                    {latestArticles.map((article, index) => (
+                      <ArticleCard key={article.id} article={article} index={index} />
                     ))}
                   </div>
 

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -52,8 +52,8 @@ function SavedContent() {
 
       {savedArticles.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {savedArticles.map((article) => (
-            <ArticleCard key={article.id} article={article} />
+          {savedArticles.map((article, index) => (
+            <ArticleCard key={article.id} article={article} index={index} />
           ))}
         </div>
       ) : (

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -179,8 +179,8 @@ export default function SearchPage() {
 
           {results.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {results.map((article) => (
-                <ArticleCard key={article.id} article={article} />
+              {results.map((article, index) => (
+                <ArticleCard key={article.id} article={article} index={index} />
               ))}
             </div>
           ) : (

--- a/src/components/__tests__/article-card.test.tsx
+++ b/src/components/__tests__/article-card.test.tsx
@@ -15,6 +15,18 @@ vi.mock('next/link', () => ({
   ),
 }));
 
+// Mock next/image → plain <img> so we can assert the rendered source
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="cover-image" />
+  ),
+}));
+
+// Mock the proxy loader to a stable pass-through so assertions are simple
+vi.mock('@/lib/image', () => ({
+  mukokoImageLoader: ({ src }: { src: string }) => src,
+}));
+
 // Mock child components
 vi.mock('@/components/ui/source-icon', () => ({
   SourceBadge: ({ source }: { source: string }) => (
@@ -82,24 +94,25 @@ describe('ArticleCard', () => {
   });
 
   describe('image handling', () => {
-    it('should display image background when valid image_url', () => {
+    it('should render the cover image when valid image_url', () => {
       const article = {
         ...baseArticle,
         image_url: 'https://example.com/image.jpg',
       };
       render(<ArticleCard article={article} />);
 
-      // The component should have a background style with the image
-      const container = document.querySelector('[style*="background"]');
-      expect(container).toBeInTheDocument();
+      const img = screen.getByTestId('cover-image');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', 'https://example.com/image.jpg');
     });
 
     it('should display gradient fallback when no image', () => {
       render(<ArticleCard article={baseArticle} />);
 
-      // Should use gradient background
-      const container = document.querySelector('[style*="linear-gradient"]');
-      expect(container).toBeInTheDocument();
+      // No <img> is rendered; a gradient fallback element stands in
+      expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+      const fallback = document.querySelector('[class*="bg-gradient-to-br"]');
+      expect(fallback).toBeInTheDocument();
     });
 
     it('should not display image for invalid URLs', () => {
@@ -109,9 +122,10 @@ describe('ArticleCard', () => {
       };
       render(<ArticleCard article={article} />);
 
-      // Should use gradient fallback for invalid URLs
-      const container = document.querySelector('[style*="var(--primary)"]');
-      expect(container).toBeInTheDocument();
+      // Invalid/unsafe URLs are rejected → gradient fallback, no <img>
+      expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
+      const fallback = document.querySelector('[class*="bg-gradient-to-br"]');
+      expect(fallback).toBeInTheDocument();
     });
   });
 
@@ -167,28 +181,6 @@ describe('ArticleCard', () => {
       render(<ArticleCard article={article} />);
 
       expect(screen.getByText('Recently')).toBeInTheDocument();
-    });
-  });
-
-  describe('date badge', () => {
-    it('should display day number', () => {
-      const article = {
-        ...baseArticle,
-        published_at: '2024-01-15T10:00:00Z',
-      };
-      render(<ArticleCard article={article} />);
-
-      expect(screen.getByText('15')).toBeInTheDocument();
-    });
-
-    it('should display month abbreviation', () => {
-      const article = {
-        ...baseArticle,
-        published_at: '2024-01-15T10:00:00Z',
-      };
-      render(<ArticleCard article={article} />);
-
-      expect(screen.getByText('JAN')).toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/article-card.test.tsx
+++ b/src/components/__tests__/article-card.test.tsx
@@ -15,15 +15,9 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Mock next/image → plain <img> so we can assert the rendered source
-vi.mock('next/image', () => ({
-  default: ({ src, alt }: { src: string; alt: string }) => (
-    <img src={src} alt={alt} data-testid="cover-image" />
-  ),
-}));
-
-// Mock the proxy loader to a stable pass-through so assertions are simple
+// Mock the image proxy to a stable pass-through so assertions are simple
 vi.mock('@/lib/image', () => ({
+  imageProxyUrl: (src: string) => src,
   mukokoImageLoader: ({ src }: { src: string }) => src,
 }));
 
@@ -101,18 +95,17 @@ describe('ArticleCard', () => {
       };
       render(<ArticleCard article={article} />);
 
-      const img = screen.getByTestId('cover-image');
+      const img = document.querySelector('img');
       expect(img).toBeInTheDocument();
       expect(img).toHaveAttribute('src', 'https://example.com/image.jpg');
     });
 
-    it('should display gradient fallback when no image', () => {
+    it('should render a text-only card when no image', () => {
       render(<ArticleCard article={baseArticle} />);
 
-      // No <img> is rendered; a gradient fallback element stands in
-      expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
-      const fallback = document.querySelector('[class*="bg-gradient-to-br"]');
-      expect(fallback).toBeInTheDocument();
+      // The brand card omits the cover area entirely without an image
+      expect(document.querySelector('img')).not.toBeInTheDocument();
+      expect(screen.getByText('Test Article Title')).toBeInTheDocument();
     });
 
     it('should not display image for invalid URLs', () => {
@@ -122,10 +115,8 @@ describe('ArticleCard', () => {
       };
       render(<ArticleCard article={article} />);
 
-      // Invalid/unsafe URLs are rejected → gradient fallback, no <img>
-      expect(screen.queryByTestId('cover-image')).not.toBeInTheDocument();
-      const fallback = document.querySelector('[class*="bg-gradient-to-br"]');
-      expect(fallback).toBeInTheDocument();
+      // Invalid/unsafe URLs are rejected → no <img> at all
+      expect(document.querySelector('img')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/compact-card.test.tsx
+++ b/src/components/__tests__/compact-card.test.tsx
@@ -9,11 +9,20 @@ vi.mock('next/link', () => ({
   ),
 }));
 
-// Mock SourceIcon component
+// Mock source icon/badge components
 vi.mock('../ui/source-icon', () => ({
   SourceIcon: ({ source }: { source: string }) => (
     <span data-testid="source-icon">{source}</span>
   ),
+  SourceBadge: ({ source }: { source: string }) => (
+    <span data-testid="source-badge">{source}</span>
+  ),
+}));
+
+// Mock the image proxy to a stable pass-through
+vi.mock('@/lib/image', () => ({
+  imageProxyUrl: (src: string) => src,
+  mukokoImageLoader: ({ src }: { src: string }) => src,
 }));
 
 const mockArticle = {
@@ -34,9 +43,7 @@ describe('CompactCard', () => {
 
   it('should render article source', () => {
     render(<CompactCard article={mockArticle} />);
-    // Source appears both in SourceIcon and text span
-    const sourceElements = screen.getAllByText('Test Source');
-    expect(sourceElements.length).toBeGreaterThan(0);
+    expect(screen.getByTestId('source-badge')).toHaveTextContent('Test Source');
   });
 
   it('should render category', () => {
@@ -62,15 +69,16 @@ describe('CompactCard', () => {
     expect(link).toHaveClass('focus-visible:ring-2');
   });
 
-  it('should use article element for semantic HTML', () => {
+  it('should render as the nyuchi article-card brand component (row variant)', () => {
     render(<CompactCard article={mockArticle} />);
-    const article = screen.getByRole('article');
-    expect(article).toBeInTheDocument();
+    const card = document.querySelector('[data-slot="nyuchi-article-card"]');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveAttribute('data-variant', 'row');
   });
 
-  it('should render time element with datetime attribute', () => {
+  it('should render relative published time', () => {
     render(<CompactCard article={mockArticle} />);
-    const timeElement = screen.getByRole('time');
-    expect(timeElement).toHaveAttribute('dateTime', '2024-01-15T10:00:00Z');
+    // 2024-01-15 is older than 7 days → absolute short date
+    expect(screen.getByText(/Jan 15/)).toBeInTheDocument();
   });
 });

--- a/src/components/article-card.tsx
+++ b/src/components/article-card.tsx
@@ -1,85 +1,43 @@
 "use client";
 
-import Link from "next/link";
-import Image from "next/image";
-import { Clock } from "lucide-react";
 import type { Article } from "@/lib/api";
 import { isValidImageUrl, formatTimeAgo } from "@/lib/utils";
-import { mukokoImageLoader } from "@/lib/image";
+import { imageProxyUrl } from "@/lib/image";
+import { NyuchiArticleCard } from "@/components/brand/nyuchi-article-card";
 import { SourceBadge } from "@/components/ui/source-icon";
 import { InlineEngagement } from "@/components/ui/engagement-bar";
 
 interface ArticleCardProps {
   article: Article;
+  /** Position in the feed — drives the harness stagger animation */
+  index?: number;
 }
 
 /**
- * Modern news card: clean cover image (routed through the image-worker proxy),
- * a category eyebrow, a 2-line title, a short dek, and a source · time meta row.
- * No date-stamp overlay or dark image wash — the image reads as itself and the
- * metadata lives in the content well, the way contemporary news feeds present it.
+ * Mukoko feed card = the canonical Mzizi N3 brand component
+ * (nyuchi-article-card, compact variant) fed from our Article shape:
+ * proxied cover image, category eyebrow, favicon source badge in the
+ * sourceSlot, relative time, and the engagement bar in the footer slot.
  */
-export function ArticleCard({ article }: ArticleCardProps) {
+export function ArticleCard({ article, index }: ArticleCardProps) {
   const hasImage = article.image_url && isValidImageUrl(article.image_url);
   const category = article.category_id || article.category;
-  const timeAgo = formatTimeAgo(article.published_at);
   const hasEngagement =
     article.likesCount !== undefined || article.commentsCount !== undefined;
 
   return (
-    <Link
+    <NyuchiArticleCard
+      variant="compact"
       href={`/article/${article.id}`}
-      className="group block rounded-[var(--radius-card)] overflow-hidden bg-surface border border-border transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
-      aria-label={`Read article: ${article.title}`}
-    >
-      {/* Cover */}
-      <div className="relative aspect-[16/10] w-full overflow-hidden bg-elevated">
-        {hasImage ? (
-          <Image
-            loader={mukokoImageLoader}
-            src={article.image_url!}
-            alt=""
-            fill
-            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 400px"
-          />
-        ) : (
-          <div
-            className="absolute inset-0 bg-gradient-to-br from-container-tanzanite to-container-sodalite"
-            aria-hidden="true"
-          />
-        )}
-      </div>
-
-      {/* Info */}
-      <div className="p-4">
-        {category && (
-          <span className="text-[11px] font-bold uppercase tracking-wider text-secondary">
-            {category}
-          </span>
-        )}
-
-        <h3 className="text-base font-bold leading-snug line-clamp-2 mt-1 mb-2 group-hover:underline decoration-2 underline-offset-2">
-          {article.title}
-        </h3>
-
-        {article.description && (
-          <p className="text-sm text-text-secondary line-clamp-2 mb-3">
-            {article.description}
-          </p>
-        )}
-
-        <div className="flex items-center justify-between">
-          <SourceBadge source={article.source} iconSize={18} />
-
-          <div className="flex items-center gap-1.5 text-xs text-text-tertiary">
-            <Clock className="w-3.5 h-3.5" aria-hidden="true" />
-            <span>{timeAgo}</span>
-          </div>
-        </div>
-
-        {/* Engagement */}
-        {hasEngagement && (
+      title={article.title}
+      excerpt={article.description}
+      image={hasImage ? imageProxyUrl(article.image_url!, { width: 600 }) : undefined}
+      category={category}
+      publishedAt={formatTimeAgo(article.published_at)}
+      index={index}
+      sourceSlot={<SourceBadge source={article.source} iconSize={16} />}
+      footer={
+        hasEngagement ? (
           <div className="mt-3 pt-3 border-t border-elevated">
             <InlineEngagement
               likesCount={article.likesCount || 0}
@@ -87,8 +45,8 @@ export function ArticleCard({ article }: ArticleCardProps) {
               isLiked={article.isLiked}
             />
           </div>
-        )}
-      </div>
-    </Link>
+        ) : undefined
+      }
+    />
   );
 }

--- a/src/components/article-card.tsx
+++ b/src/components/article-card.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import Link from "next/link";
+import Image from "next/image";
 import { Clock } from "lucide-react";
 import type { Article } from "@/lib/api";
-import { isValidImageUrl, safeCssUrl } from "@/lib/utils";
-import { imageProxyUrl } from "@/lib/image";
+import { isValidImageUrl, formatTimeAgo } from "@/lib/utils";
+import { mukokoImageLoader } from "@/lib/image";
 import { SourceBadge } from "@/components/ui/source-icon";
 import { InlineEngagement } from "@/components/ui/engagement-bar";
 
@@ -10,97 +13,81 @@ interface ArticleCardProps {
   article: Article;
 }
 
-function formatDate(dateString: string): { day: string; month: string; time: string } {
-  try {
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return { day: "--", month: "---", time: "Recently" };
-
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-    let time = "";
-    if (diffHours < 1) time = "Just now";
-    else if (diffHours < 24) time = `${diffHours}h ago`;
-    else if (diffDays < 7) time = `${diffDays}d ago`;
-    else time = date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-
-    return {
-      day: String(date.getDate()).padStart(2, "0"),
-      month: date.toLocaleDateString("en-US", { month: "short" }).toUpperCase(),
-      time,
-    };
-  } catch {
-    return { day: "--", month: "---", time: "Recently" };
-  }
-}
-
+/**
+ * Modern news card: clean cover image (routed through the image-worker proxy),
+ * a category eyebrow, a 2-line title, a short dek, and a source · time meta row.
+ * No date-stamp overlay or dark image wash — the image reads as itself and the
+ * metadata lives in the content well, the way contemporary news feeds present it.
+ */
 export function ArticleCard({ article }: ArticleCardProps) {
   const hasImage = article.image_url && isValidImageUrl(article.image_url);
-  const dateInfo = formatDate(article.published_at);
-
-  const coverStyle = hasImage
-    ? {
-        background: `linear-gradient(135deg, rgba(0,0,0,0.3), rgba(0,0,0,0.6)), ${safeCssUrl(imageProxyUrl(article.image_url!, { width: 800 }))} center/cover`,
-      }
-    : { background: "linear-gradient(135deg, var(--primary), var(--secondary))" };
+  const category = article.category_id || article.category;
+  const timeAgo = formatTimeAgo(article.published_at);
+  const hasEngagement =
+    article.likesCount !== undefined || article.commentsCount !== undefined;
 
   return (
-    <Link href={`/article/${article.id}`} className="block">
-      <div className="rounded-[var(--radius-card)] overflow-hidden bg-surface cursor-pointer transition-all duration-200 hover:-translate-y-1 hover:shadow-2xl hover:shadow-black/40 border border-border">
-        {/* Cover */}
-        <div className="h-[180px] relative" style={coverStyle}>
-          {/* Date Badge - glassmorphism for image overlay */}
-          <div className="absolute top-4 left-4 bg-black/60 backdrop-blur-md px-3.5 py-2.5 rounded-xl text-center border border-white/10">
-            <div className="text-2xl font-extrabold text-white leading-none">
-              {dateInfo.day}
-            </div>
-            <div className="text-[11px] font-semibold text-white/70 uppercase tracking-wide">
-              {dateInfo.month}
-            </div>
-          </div>
+    <Link
+      href={`/article/${article.id}`}
+      className="group block rounded-[var(--radius-card)] overflow-hidden bg-surface border border-border transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+      aria-label={`Read article: ${article.title}`}
+    >
+      {/* Cover */}
+      <div className="relative aspect-[16/10] w-full overflow-hidden bg-elevated">
+        {hasImage ? (
+          <Image
+            loader={mukokoImageLoader}
+            src={article.image_url!}
+            alt=""
+            fill
+            className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 400px"
+          />
+        ) : (
+          <div
+            className="absolute inset-0 bg-gradient-to-br from-container-tanzanite to-container-sodalite"
+            aria-hidden="true"
+          />
+        )}
+      </div>
 
-          {/* Category Badge */}
-          {(article.category_id || article.category) && (
-            <div className="absolute top-4 right-4 bg-secondary text-white px-3 py-1.5 rounded-full text-[11px] font-bold uppercase">
-              {article.category_id || article.category}
-            </div>
-          )}
+      {/* Info */}
+      <div className="p-4">
+        {category && (
+          <span className="text-[11px] font-bold uppercase tracking-wider text-secondary">
+            {category}
+          </span>
+        )}
+
+        <h3 className="text-base font-bold leading-snug line-clamp-2 mt-1 mb-2 group-hover:underline decoration-2 underline-offset-2">
+          {article.title}
+        </h3>
+
+        {article.description && (
+          <p className="text-sm text-text-secondary line-clamp-2 mb-3">
+            {article.description}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between">
+          <SourceBadge source={article.source} iconSize={18} />
+
+          <div className="flex items-center gap-1.5 text-xs text-text-tertiary">
+            <Clock className="w-3.5 h-3.5" aria-hidden="true" />
+            <span>{timeAgo}</span>
+          </div>
         </div>
 
-        {/* Info */}
-        <div className="p-5">
-          <h3 className="text-lg font-bold mb-2.5 leading-tight line-clamp-2">
-            {article.title}
-          </h3>
-
-          {article.description && (
-            <p className="text-sm text-foreground/60 line-clamp-2 mb-4">
-              {article.description}
-            </p>
-          )}
-
-          <div className="flex items-center justify-between">
-            <SourceBadge source={article.source} iconSize={18} />
-
-            <div className="flex items-center gap-1.5 text-xs text-text-tertiary">
-              <Clock className="w-3.5 h-3.5 text-text-tertiary" />
-              <span>{dateInfo.time}</span>
-            </div>
+        {/* Engagement */}
+        {hasEngagement && (
+          <div className="mt-3 pt-3 border-t border-elevated">
+            <InlineEngagement
+              likesCount={article.likesCount || 0}
+              commentsCount={article.commentsCount || 0}
+              isLiked={article.isLiked}
+            />
           </div>
-
-          {/* Engagement */}
-          {(article.likesCount !== undefined || article.commentsCount !== undefined) && (
-            <div className="mt-3 pt-3 border-t border-elevated">
-              <InlineEngagement
-                likesCount={article.likesCount || 0}
-                commentsCount={article.commentsCount || 0}
-                isLiked={article.isLiked}
-              />
-            </div>
-          )}
-        </div>
+        )}
       </div>
     </Link>
   );

--- a/src/components/brand/nyuchi-article-card.tsx
+++ b/src/components/brand/nyuchi-article-card.tsx
@@ -1,0 +1,291 @@
+"use client";
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+// Every brand component participates in observability, motion, a11y,
+// and health monitoring via the harness. Zero manual config.
+import { useNyuchiHarness } from "@/lib/harness";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  Clock,
+  BookOpen,
+  CheckCircle,
+  AlertTriangle,
+  HelpCircle,
+  type BrandIcon,
+} from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI ARTICLE CARD — News Brand Component
+
+   Canonical source: mzizi_db → component_documents (node 3,
+   collection brand, name nyuchi-article-card). "News article card
+   extending nyuchi-listing-card with factcheck badge, source
+   attribution, journalist byline, and read time."
+
+   Documented deviations from the canonical source (upstreamable):
+   - fixed duplicate className on the hero variant root
+   - `loading` added to the props interface (destructured upstream
+     but never declared)
+   - entry animation (animStyle) is actually applied to the root
+   - optional `href` renders the card as a next/link (whole-card nav)
+   - `sourceSlot` / `footer` ReactNode slots so apps can inject a
+     richer source badge (favicon) and engagement row
+   - images are expected pre-proxied (imageProxyUrl) + lazy
+   ═══════════════════════════════════════════════════════════════ */
+
+type FactCheckStatus = "verified" | "disputed" | "unverified" | "false" | "pending";
+
+const factCheckConfig: Record<FactCheckStatus, { label: string; color: string; icon: BrandIcon }> = {
+  verified: { label: "Verified", color: "var(--status-success, #64FFDA)", icon: CheckCircle },
+  disputed: { label: "Disputed", color: "var(--status-warning, #FFD740)", icon: AlertTriangle },
+  unverified: { label: "Unverified", color: "var(--status-neutral, #6B6B66)", icon: HelpCircle },
+  false: { label: "False", color: "var(--status-error, #FF5252)", icon: AlertTriangle },
+  pending: { label: "Checking", color: "var(--color-cobalt,#00B0FF)", icon: Clock },
+};
+
+interface NyuchiArticleCardProps {
+  loading?: boolean;
+  title: string;
+  excerpt?: string;
+  /** Image URL — pass an already-proxied URL (imageProxyUrl) */
+  image?: string;
+  sourceName?: string;
+  sourceVerified?: boolean;
+  authorName?: string;
+  publishedAt?: string;
+  readTime?: string;
+  category?: string;
+  factCheckStatus?: FactCheckStatus;
+  viewCount?: number;
+  variant?: "row" | "compact" | "hero";
+  /** Whole-card navigation target (internal routes use next/link) */
+  href?: string;
+  /** Rich source attribution slot (e.g. favicon SourceBadge) — replaces sourceName text */
+  sourceSlot?: React.ReactNode;
+  /** Footer slot rendered below the meta row (e.g. engagement bar) */
+  footer?: React.ReactNode;
+  /** Index in a list — used for stagger animation delay */
+  index?: number;
+  onClick?: () => void;
+  className?: string;
+}
+
+function NyuchiArticleCard({
+  loading = false,
+  title,
+  excerpt,
+  image,
+  sourceName,
+  sourceVerified,
+  authorName,
+  publishedAt,
+  readTime,
+  category,
+  factCheckStatus,
+  variant = "row",
+  href,
+  sourceSlot,
+  footer,
+  index,
+  onClick,
+  className,
+}: NyuchiArticleCardProps) {
+  const { motion, observabilityAttrs } = useNyuchiHarness("article-card");
+  const animStyle = React.useMemo(
+    () =>
+      motion.prefersReduced
+        ? {}
+        : {
+            animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+            animationDelay: index != null ? `${motion.staggerDelay(index)}ms` : "0ms",
+          },
+    [motion, index]
+  );
+
+  if (loading) {
+    return (
+      <div
+        data-slot="nyuchi-article-card"
+        {...observabilityAttrs}
+        data-loading
+        role="article"
+        className="animate-pulse rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10 space-y-3"
+      >
+        <div className="flex gap-3">
+          <div className="size-20 shrink-0 rounded-[var(--radius-inner,7px)] bg-muted" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3.5 w-3/4 rounded bg-muted" />
+            <div className="h-2.5 w-full rounded bg-muted" />
+            <div className="h-2.5 w-1/2 rounded bg-muted" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const fcConfig = factCheckStatus ? factCheckConfig[factCheckStatus] : null;
+  const FcIcon = fcConfig?.icon;
+
+  // Wraps the variant body in a next/link (internal), anchor (external),
+  // or plain div (onClick), carrying the shared data attributes.
+  const wrap = (body: React.ReactNode, classes: string) => {
+    // role="article" only on the non-interactive wrapper — putting it on an
+    // anchor would override the link role for assistive tech (canonical bug).
+    const sharedAttrs = {
+      "data-slot": "nyuchi-article-card",
+      "data-variant": variant,
+      ...observabilityAttrs,
+    };
+    if (href) {
+      const linkClasses = cn(
+        classes,
+        "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+      );
+      if (href.startsWith("/")) {
+        return (
+          <Link {...sharedAttrs} href={href} aria-label={`Read article: ${title}`} className={linkClasses} style={animStyle}>
+            {body}
+          </Link>
+        );
+      }
+      return (
+        <a {...sharedAttrs} href={href} aria-label={`Read article: ${title}`} className={linkClasses} style={animStyle}>
+          {body}
+        </a>
+      );
+    }
+    return (
+      <div
+        {...sharedAttrs}
+        role="article"
+        onClick={onClick}
+        className={cn(classes, onClick && "cursor-pointer")}
+        style={animStyle}
+      >
+        {body}
+      </div>
+    );
+  };
+
+  if (variant === "hero") {
+    return wrap(
+      <>
+        {image && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={image} alt="" className="absolute inset-0 size-full object-cover" />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
+        <div className="relative z-10">
+          {category && (
+            <span className="mb-2 inline-flex rounded-full bg-black/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white">
+              {category}
+            </span>
+          )}
+          <h3 className="font-serif text-lg font-bold leading-snug text-white">{title}</h3>
+          <div className="mt-2 flex items-center gap-3 text-xs text-white/80">
+            {sourceSlot || (sourceName && <span>{sourceName}</span>)}
+            {publishedAt && <span>{publishedAt}</span>}
+            {readTime && (
+              <span className="flex items-center gap-1">
+                <BookOpen className="size-3" />
+                {readTime}
+              </span>
+            )}
+          </div>
+          {footer}
+        </div>
+      </>,
+      "relative flex min-h-[200px] flex-col justify-end overflow-hidden rounded-[var(--radius-card,14px)] p-5"
+    );
+  }
+
+  if (variant === "compact") {
+    return wrap(
+      <>
+        {image && (
+          <div className="aspect-video overflow-hidden bg-muted">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={image}
+              alt=""
+              loading="lazy"
+              className="size-full object-cover transition-transform duration-300 group-hover/article:scale-105"
+            />
+          </div>
+        )}
+        <div className="p-4">
+          {category && (
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-secondary">
+              {category}
+            </span>
+          )}
+          <h4 className="mt-1 line-clamp-2 text-sm font-semibold text-foreground group-hover/article:underline decoration-2 underline-offset-2">
+            {title}
+          </h4>
+          {excerpt && <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{excerpt}</p>}
+          <div className="mt-2 flex items-center justify-between text-[10px] text-muted-foreground">
+            {sourceSlot || <span>{sourceName || authorName}</span>}
+            <div className="flex items-center gap-2">
+              {publishedAt && <span>{publishedAt}</span>}
+              {readTime && <span>{readTime}</span>}
+              {fcConfig && FcIcon && <FcIcon className="size-3" style={{ color: fcConfig.color }} />}
+            </div>
+          </div>
+          {footer}
+        </div>
+      </>,
+      "group/article flex flex-col overflow-hidden rounded-[var(--radius-card,14px)] bg-card ring-1 ring-foreground/10 hover:shadow-md transition-shadow"
+    );
+  }
+
+  return wrap(
+    <>
+      <div className="min-w-0 flex-1">
+        {category && (
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-secondary">
+            {category}
+          </span>
+        )}
+        <h4 className="line-clamp-2 text-sm font-semibold text-foreground group-hover/article:underline decoration-2 underline-offset-2">
+          {title}
+        </h4>
+        <div className="mt-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+          {sourceSlot ||
+            (sourceName && (
+              <span className="flex items-center gap-1">
+                {sourceName}
+                {sourceVerified && <CheckCircle className="size-2.5 text-[var(--status-success)]" />}
+              </span>
+            ))}
+          {publishedAt && <span>· {publishedAt}</span>}
+          {readTime && (
+            <span className="flex items-center gap-1">
+              <BookOpen className="size-3" />
+              {readTime}
+            </span>
+          )}
+        </div>
+        {fcConfig && FcIcon && (
+          <span className="mt-1 flex items-center gap-1 text-[10px] font-medium" style={{ color: fcConfig.color }}>
+            <FcIcon className="size-3" />
+            {fcConfig.label}
+          </span>
+        )}
+        {footer}
+      </div>
+      {image && (
+        <div className="size-16 shrink-0 overflow-hidden rounded-[var(--radius-inner,7px)] bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" loading="lazy" className="size-full object-cover" />
+        </div>
+      )}
+    </>,
+    "group/article flex items-center gap-3 rounded-[var(--radius-card,14px)] bg-card py-3 px-4 ring-1 ring-foreground/10 hover:shadow-md transition-shadow"
+  );
+}
+
+export { NyuchiArticleCard };
+export type { NyuchiArticleCardProps, FactCheckStatus };

--- a/src/components/brand/nyuchi-listing-card.tsx
+++ b/src/components/brand/nyuchi-listing-card.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+import { useNyuchiHarness } from "@/lib/harness";
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI LISTING CARD — Universal Brand Component (Pre-Wired)
+
+   Canonical source: mzizi_db → component_documents (node 3,
+   collection brand, name nyuchi-listing-card). Adopted for Mukoko
+   News with two documented deviations:
+   - internal hrefs render through next/link (client-side nav)
+   - callers pass already-proxied image URLs (imageProxyUrl)
+
+   This component is FULLY WIRED into the Mukoko infrastructure:
+
+   ✅ OBSERVABILITY — Render timing, mount/unmount logging via harness
+   ✅ MOTION — Entry animation using motion tokens, reduced-motion safe
+   ✅ A11Y — Screen reader announcements for dynamic content, focus ring
+   ✅ TOKENS — Uses CSS custom properties (--color-*, --radius-*)
+   ═══════════════════════════════════════════════════════════════ */
+
+const mineralAccents = {
+  cobalt: "border-l-[var(--color-cobalt)]",
+  tanzanite: "border-l-[var(--color-tanzanite)]",
+  malachite: "border-l-[var(--color-malachite)]",
+  gold: "border-l-[var(--color-gold)]",
+  terracotta: "border-l-[var(--color-terracotta)]",
+} as const;
+
+const mineralBadgeBg = {
+  cobalt: "bg-[var(--color-cobalt)]/15 text-[var(--color-cobalt)]",
+  tanzanite: "bg-[var(--color-tanzanite)]/15 text-[var(--color-tanzanite)]",
+  malachite: "bg-[var(--color-malachite)]/15 text-[var(--color-malachite)]",
+  gold: "bg-[var(--color-gold)]/15 text-[var(--color-gold)]",
+  terracotta: "bg-[var(--color-terracotta)]/15 text-[var(--color-terracotta)]",
+} as const;
+
+const listingCardVariants = cva(
+  "group/listing bg-card text-card-foreground ring-1 ring-foreground/10 transition-shadow hover:shadow-md focus-visible:outline-[length:var(--focusRing-width,2px)] focus-visible:outline-[var(--color-primary)] focus-visible:outline-offset-[var(--focusRing-offset,2px)]",
+  {
+    variants: {
+      variant: {
+        row: "flex items-center gap-3 rounded-[var(--radius-card,14px)] border-l-4 py-3 pr-4 pl-3",
+        compact: "flex flex-col overflow-hidden rounded-[var(--radius-card,14px)]",
+        hero: "relative flex flex-col justify-end overflow-hidden rounded-[var(--radius-card,14px)] min-h-[200px] p-5",
+      },
+    },
+    defaultVariants: { variant: "row" },
+  }
+);
+
+type Mineral = keyof typeof mineralAccents;
+
+interface MukokoListingMeta {
+  icon?: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: string;
+}
+
+interface NyuchiListingCardProps extends VariantProps<typeof listingCardVariants> {
+  /** When true, renders a skeleton matching the card variant proportions */
+  loading?: boolean;
+  title: string;
+  description?: string;
+  category?: string;
+  mineral?: Mineral;
+  /** Image URL — pass an already-proxied URL (imageProxyUrl) for remote images */
+  image?: string;
+  meta?: MukokoListingMeta[];
+  price?: string | number;
+  currency?: string;
+  trailing?: React.ReactNode;
+  href?: string;
+  heroGradient?: [string, string];
+  className?: string;
+  onClick?: () => void;
+  /** Index in a list — used for stagger animation delay */
+  index?: number;
+}
+
+function NyuchiListingCard({
+  loading = false,
+  title,
+  description,
+  category,
+  mineral = "malachite",
+  image,
+  meta,
+  price,
+  currency = "USD",
+  trailing,
+  href,
+  heroGradient,
+  variant = "row",
+  className,
+  onClick,
+  index,
+}: NyuchiListingCardProps) {
+  // ── HARNESS: Connect to infrastructure ──────────────────
+  const { motion, LiveRegion, observabilityAttrs } = useNyuchiHarness("listing-card");
+
+  // ── MOTION: Entry animation with stagger for lists ──────
+  // (Hook order: before any early return.)
+  const animStyle = React.useMemo(() => {
+    if (motion.prefersReduced) return {};
+    return {
+      animation: `nyuchi-fade-slide-up ${motion.enterDuration}ms ${motion.enterEasing} both`,
+      animationDelay: index != null ? `${motion.staggerDelay(index)}ms` : "0ms",
+    };
+  }, [motion, index]);
+
+  // ── BUILT-IN LOADING STATE ──────────────────────────────────
+  if (loading) {
+    return (
+      <div
+        data-slot="nyuchi-listing-card"
+        {...observabilityAttrs}
+        role="article"
+        data-loading
+        className={cn(listingCardVariants({ variant }), "animate-pulse", className)}
+      >
+        {variant === "hero" ? (
+          <div className="space-y-3 p-4">
+            <div className="h-32 rounded-[var(--radius-md,12px)] bg-muted" />
+            <div className="h-4 w-3/4 rounded bg-muted" />
+            <div className="h-3 w-1/2 rounded bg-muted" />
+          </div>
+        ) : variant === "compact" ? (
+          <div className="flex items-center gap-3 p-3">
+            <div className="size-10 shrink-0 rounded-[var(--radius-sm,7px)] bg-muted" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-3.5 w-2/3 rounded bg-muted" />
+              <div className="h-2.5 w-1/3 rounded bg-muted" />
+            </div>
+          </div>
+        ) : (
+          <div className="flex gap-3 p-3">
+            <div className="size-20 shrink-0 rounded-[var(--radius-md,12px)] bg-muted" />
+            <div className="flex-1 space-y-2 py-0.5">
+              <div className="h-3.5 w-3/4 rounded bg-muted" />
+              <div className="h-2.5 w-full rounded bg-muted" />
+              <div className="h-2.5 w-1/2 rounded bg-muted" />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const isHero = variant === "hero";
+  const isRow = variant === "row";
+  const isCompact = variant === "compact";
+
+  const formattedPrice =
+    typeof price === "number"
+      ? new Intl.NumberFormat(undefined, { style: "currency", currency }).format(price)
+      : price;
+
+  const content = (
+    <>
+      {/* Screen reader live region for dynamic updates */}
+      {LiveRegion}
+
+      {isCompact && image && (
+        <div className="aspect-video overflow-hidden bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={image}
+            alt=""
+            loading="lazy"
+            className="size-full object-cover transition-transform duration-300 group-hover/listing:scale-105"
+          />
+        </div>
+      )}
+
+      {isHero && (
+        <div
+          className="absolute inset-0"
+          style={{
+            background: heroGradient
+              ? `linear-gradient(135deg, ${heroGradient[0]}, ${heroGradient[1]})`
+              : "linear-gradient(135deg, var(--container-tanzanite), var(--container-sodalite))",
+          }}
+        >
+          <div
+            className="absolute inset-0 opacity-5"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at 20% 80%, rgba(255,255,255,0.3) 0%, transparent 50%)",
+            }}
+          />
+          {image && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={image} alt="" className="size-full object-cover opacity-30 mix-blend-overlay" />
+          )}
+        </div>
+      )}
+
+      {isRow && image && (
+        <div className="size-12 shrink-0 overflow-hidden rounded-[var(--radius-inner,7px)] bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" loading="lazy" className="size-full object-cover" />
+        </div>
+      )}
+
+      <div
+        className={cn(
+          "relative flex min-w-0 flex-1 flex-col gap-1.5",
+          isCompact && "p-4",
+          isHero && "z-10"
+        )}
+      >
+        {category && (
+          <span
+            className={cn(
+              "inline-flex w-fit items-center rounded-full px-2 py-0.5 text-[10px] font-semibold tracking-wider uppercase",
+              isHero ? "bg-black/60 text-white" : mineralBadgeBg[mineral]
+            )}
+          >
+            {category}
+          </span>
+        )}
+        <h3
+          className={cn(
+            "font-medium leading-snug",
+            isHero && "font-serif text-lg text-white sm:text-xl",
+            (isRow || isCompact) && "text-sm text-foreground"
+          )}
+        >
+          {title}
+        </h3>
+        {description && (
+          <p
+            className={cn(
+              "line-clamp-2 text-xs leading-relaxed",
+              isHero ? "text-white/70" : "text-muted-foreground"
+            )}
+          >
+            {description}
+          </p>
+        )}
+        {meta && meta.length > 0 && (
+          <div
+            className={cn(
+              "flex flex-wrap items-center gap-x-3 gap-y-1 text-xs",
+              isHero ? "text-white/65" : "text-muted-foreground"
+            )}
+          >
+            {meta.map((m) => (
+              <span key={m.label} className="inline-flex items-center gap-1">
+                {m.icon && <m.icon className="size-3" />}
+                {m.value}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {(trailing || formattedPrice) && isRow && (
+        <div className="flex shrink-0 items-center gap-2">
+          {formattedPrice && (
+            <span
+              className={cn(
+                "text-sm font-semibold",
+                formattedPrice === "Free" || price === 0
+                  ? "text-[var(--color-malachite)]"
+                  : "text-foreground"
+              )}
+            >
+              {price === 0 ? "Free" : formattedPrice}
+            </span>
+          )}
+          {trailing}
+        </div>
+      )}
+
+      {formattedPrice && isCompact && (
+        <div className="px-4 pb-3">
+          <span className="text-sm font-semibold text-foreground">
+            {price === 0 ? "Free" : formattedPrice}
+          </span>
+        </div>
+      )}
+    </>
+  );
+
+  const classes = cn(
+    listingCardVariants({ variant }),
+    isRow && mineralAccents[mineral],
+    (href || onClick) && "cursor-pointer",
+    className
+  );
+
+  // role="article" only on the non-interactive wrapper — putting it on an
+  // anchor would override the link role for assistive tech (canonical bug).
+  const sharedAttrs = {
+    "data-slot": "nyuchi-listing-card",
+    "data-mineral": mineral,
+    "data-variant": variant ?? "row",
+    ...observabilityAttrs,
+  } as const;
+
+  if (href) {
+    // Internal routes go through next/link for client-side navigation;
+    // external URLs fall back to a plain anchor.
+    if (href.startsWith("/")) {
+      return (
+        <Link {...sharedAttrs} href={href} aria-label={title} className={classes} style={animStyle}>
+          {content}
+        </Link>
+      );
+    }
+    return (
+      <a {...sharedAttrs} href={href} aria-label={title} className={classes} style={animStyle}>
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div {...sharedAttrs} role="article" onClick={onClick} className={classes} style={animStyle}>
+      {content}
+    </div>
+  );
+}
+
+export { NyuchiListingCard, listingCardVariants };
+export type { NyuchiListingCardProps, MukokoListingMeta, Mineral };

--- a/src/components/brand/nyuchi-source-badge.tsx
+++ b/src/components/brand/nyuchi-source-badge.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+import { useNyuchiHarness } from "@/lib/harness";
+
+import * as React from "react";
+import { Newspaper, CheckCircle, AlertCircle, HelpCircle, type BrandIcon } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI SOURCE BADGE — News Source Credibility Indicator
+
+   Canonical source: mzizi_db → component_documents (node 3,
+   collection brand, name nyuchi-source-badge). "News source
+   credibility indicator badge tied to verification tier. Maps to
+   news.feedSources / news.newsMediaOrganizations verification
+   status. Used inline on article cards and in source attribution."
+   ═══════════════════════════════════════════════════════════════ */
+
+type SourceCredibility = "verified" | "community" | "unverified" | "disputed";
+
+const credibilityConfig: Record<SourceCredibility, { color: string; icon: BrandIcon; label: string }> = {
+  verified: { color: "var(--status-success)", icon: CheckCircle, label: "Verified Source" },
+  community: { color: "var(--color-terracotta)", icon: CheckCircle, label: "Community Source" },
+  unverified: { color: "var(--status-neutral)", icon: HelpCircle, label: "Unverified Source" },
+  disputed: { color: "var(--status-error)", icon: AlertCircle, label: "Disputed Source" },
+};
+
+interface NyuchiSourceBadgeProps {
+  loading?: boolean;
+  sourceName: string;
+  credibility?: SourceCredibility;
+  showLabel?: boolean;
+  className?: string;
+}
+
+function NyuchiSourceBadge({
+  loading = false,
+  sourceName,
+  credibility = "unverified",
+  showLabel = false,
+  className,
+}: NyuchiSourceBadgeProps) {
+  const { observabilityAttrs } = useNyuchiHarness("source-badge");
+
+  if (loading) {
+    return (
+      <div
+        data-slot="nyuchi-source-badge"
+        {...observabilityAttrs}
+        data-loading
+        role="status"
+        className="animate-pulse inline-flex items-center gap-1.5"
+      >
+        <div className="size-4 rounded-full bg-muted" />
+        <div className="h-2.5 w-12 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  const config = credibilityConfig[credibility];
+  const Icon = config.icon;
+  return (
+    <span
+      data-slot="nyuchi-source-badge"
+      {...observabilityAttrs}
+      role="status"
+      className={cn("inline-flex items-center gap-1.5 text-xs", className)}
+      title={config.label}
+    >
+      <Newspaper className="size-3 text-muted-foreground" />
+      <span className="font-medium text-foreground">{sourceName}</span>
+      <Icon className="size-3" style={{ color: config.color }} />
+      {showLabel && (
+        <span className="text-[10px]" style={{ color: config.color }}>
+          {config.label}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export { NyuchiSourceBadge };
+export type { NyuchiSourceBadgeProps, SourceCredibility };

--- a/src/components/brand/nyuchi-verified-badge.tsx
+++ b/src/components/brand/nyuchi-verified-badge.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+// ── INFRASTRUCTURE HARNESS (auto-wired) ──
+import { useNyuchiHarness } from "@/lib/harness";
+
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Users, Phone, ShieldCheck, Award, Ban, Flower2 } from "@/lib/icons";
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   MUKOKO VERIFIED BADGE — Brand Identity Component
+
+   Canonical source: mzizi_db → component_documents (node 3,
+   collection brand, name nyuchi-verified-badge). Adopted verbatim
+   (icons resolve via the @/lib/icons shim).
+
+   Three-axis trust model (nyuchi_platform_db):
+
+   AXIS 1 — STATUS (identity.person.mit_status)
+     Platform lifecycle. Independent of verification.
+     pre_verification | living | liveness_pending |
+     suspended | presumed_ancestral | verified_ancestral
+
+   AXIS 2 — VERIFICATION TIER (system.verification_tier)
+     Identity ladder. How real are you?
+     Level 0: Unverified — no badge
+     Level 1: Community  — Terracotta — +0.10
+     Level 2: OTP        — Cobalt     — +0.10 (cumulative 0.20)
+     Level 3: Government — Gold       — +0.10 (cumulative 0.30)
+     Level 4: Licensed   — Tanzanite  — +0.20 (cumulative 0.50)
+
+   AXIS 3 — TRUST SCORE (computed output)
+     trust = sum(tier_increments up to current level) + status_modifier
+     Suspended/ancestral = fixed at status modifier (trust frozen)
+
+   The badge renders based on TIER (which mineral check you see)
+   but respects STATUS (dimmed if suspended, memorial if ancestral).
+   ═══════════════════════════════════════════════════════════════ */
+
+/** Verification tier codes from system.verification_tier.tier_code */
+type VerificationTier = "unverified" | "community" | "otp" | "government" | "licensed";
+
+/** Platform status from identity.person.mit_status */
+type PlatformStatus =
+  | "pre_verification"
+  | "living"
+  | "liveness_pending"
+  | "suspended"
+  | "presumed_ancestral"
+  | "verified_ancestral";
+
+/** Full tier configuration mapping to system.verification_tier */
+const TIER_CONFIG = {
+  unverified: {
+    level: 0,
+    mineral: null,
+    label: "Unverified",
+    trustIncrement: 0.0,
+    cumulativeTrust: 0.0,
+    fg: "transparent",
+    bg: "transparent",
+    icon: null,
+  },
+  community: {
+    level: 1,
+    mineral: "Terracotta",
+    label: "Community Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.1,
+    fg: "var(--color-terracotta)",
+    bg: "color-mix(in srgb, var(--color-terracotta) 15%, transparent)",
+    icon: Users,
+  },
+  otp: {
+    level: 2,
+    mineral: "Cobalt",
+    label: "Contact Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.2,
+    fg: "var(--color-cobalt)",
+    bg: "color-mix(in srgb, var(--color-cobalt) 15%, transparent)",
+    icon: Phone,
+  },
+  government: {
+    level: 3,
+    mineral: "Gold",
+    label: "Government Verified",
+    trustIncrement: 0.1,
+    cumulativeTrust: 0.3,
+    fg: "var(--color-gold)",
+    bg: "color-mix(in srgb, var(--color-gold) 15%, transparent)",
+    icon: ShieldCheck,
+  },
+  licensed: {
+    level: 4,
+    mineral: "Tanzanite",
+    label: "Licensed Professional",
+    trustIncrement: 0.2,
+    cumulativeTrust: 0.5,
+    fg: "var(--color-tanzanite)",
+    bg: "color-mix(in srgb, var(--color-tanzanite) 15%, transparent)",
+    icon: Award,
+  },
+} as const;
+
+/** Status overlay configuration from system.platform_status_trust */
+const STATUS_OVERLAY = {
+  pre_verification: { modifier: 0.0, active: true, overlay: null },
+  living: { modifier: 0.0, active: true, overlay: null },
+  liveness_pending: { modifier: 0.0, active: true, overlay: null },
+  suspended: { modifier: -0.05, active: false, overlay: "suspended" as const },
+  presumed_ancestral: { modifier: 0.05, active: false, overlay: "ancestral" as const },
+  verified_ancestral: { modifier: 0.05, active: false, overlay: "ancestral" as const },
+} as const;
+
+const badgeSizeVariants = cva(
+  "inline-flex shrink-0 items-center justify-center rounded-full transition-opacity",
+  {
+    variants: {
+      size: {
+        sm: "size-3.5" /* Inline with text — next to names */,
+        md: "size-[18px]" /* Default — cards, headers */,
+        lg: "size-6" /* Profile pages */,
+        xl: "size-8" /* Verification detail views */,
+      },
+    },
+    defaultVariants: { size: "md" },
+  }
+);
+
+const iconSizeMap = { sm: 10, md: 12, lg: 16, xl: 20 } as const;
+
+interface NyuchiVerifiedBadgeProps extends VariantProps<typeof badgeSizeVariants> {
+  /** Verification tier code (system.verification_tier.tier_code) */
+  tier: VerificationTier;
+  /** Platform status (identity.person.mit_status). Affects badge appearance. */
+  status?: PlatformStatus;
+  /** Show tooltip with tier name on hover */
+  showTooltip?: boolean;
+  /** Render skeleton placeholder while verification status is loading */
+  loading?: boolean;
+  className?: string;
+}
+
+function NyuchiVerifiedBadge({
+  tier,
+  status = "living",
+  size = "md",
+  showTooltip = true,
+  loading = false,
+  className,
+}: NyuchiVerifiedBadgeProps) {
+  const { observabilityAttrs } = useNyuchiHarness("verified-badge");
+
+  if (loading) {
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        {...observabilityAttrs}
+        data-loading
+        className="inline-flex size-4 animate-pulse rounded-full bg-muted"
+      />
+    );
+  }
+
+  const config = TIER_CONFIG[tier];
+  const statusConfig = STATUS_OVERLAY[status];
+  const iconSize = iconSizeMap[size || "md"];
+
+  /* Level 0 = no badge */
+  if (!config.icon || tier === "unverified") return null;
+
+  /* Suspended: show ban overlay instead of tier icon */
+  if (statusConfig.overlay === "suspended") {
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        data-tier={tier}
+        data-status="suspended"
+        {...observabilityAttrs}
+        aria-label="Account Suspended"
+        title={showTooltip ? "Account Suspended" : undefined}
+        className={cn(badgeSizeVariants({ size }), "opacity-40", className)}
+        style={{ backgroundColor: "color-mix(in srgb, var(--status-neutral) 15%, transparent)" }}
+      >
+        <Ban width={iconSize} height={iconSize} strokeWidth={2.5} color="var(--status-neutral)" />
+      </span>
+    );
+  }
+
+  /* Ancestral: show memorial flower with dimmed tier color */
+  if (statusConfig.overlay === "ancestral") {
+    return (
+      <span
+        data-slot="nyuchi-verified-badge"
+        data-tier={tier}
+        data-status={status}
+        {...observabilityAttrs}
+        aria-label={`${config.label} — Memorial`}
+        title={showTooltip ? `${config.label} — Memorial` : undefined}
+        className={cn(badgeSizeVariants({ size }), "opacity-60", className)}
+        style={{ backgroundColor: config.bg }}
+      >
+        <Flower2 width={iconSize} height={iconSize} strokeWidth={2} style={{ color: config.fg }} />
+      </span>
+    );
+  }
+
+  /* Active: show full tier badge */
+  const Icon = config.icon;
+  return (
+    <span
+      data-slot="nyuchi-verified-badge"
+      data-tier={tier}
+      data-level={config.level}
+      data-trust={config.cumulativeTrust}
+      {...observabilityAttrs}
+      aria-label={config.label}
+      title={showTooltip ? `${config.label} · Trust ${config.cumulativeTrust}` : undefined}
+      className={cn(badgeSizeVariants({ size }), className)}
+      style={{ backgroundColor: config.bg }}
+    >
+      <Icon width={iconSize} height={iconSize} strokeWidth={2.5} style={{ color: config.fg }} />
+    </span>
+  );
+}
+
+/* ── Utility: compute trust score on the client ──────────────── */
+function computeTrustScore(tier: VerificationTier, status: PlatformStatus): number {
+  const statusConfig = STATUS_OVERLAY[status];
+
+  // Suspended/ancestral = fixed at modifier only
+  if (!statusConfig.active) return statusConfig.modifier;
+
+  // Active = cumulative tier score + status modifier
+  return TIER_CONFIG[tier].cumulativeTrust + statusConfig.modifier;
+}
+
+export { NyuchiVerifiedBadge, computeTrustScore, TIER_CONFIG, STATUS_OVERLAY };
+export type { NyuchiVerifiedBadgeProps, VerificationTier, PlatformStatus };

--- a/src/components/compact-card.tsx
+++ b/src/components/compact-card.tsx
@@ -1,48 +1,36 @@
 "use client";
 
-import Link from "next/link";
-import { Clock } from "lucide-react";
 import type { Article } from "@/lib/api";
-import { formatTimeAgo } from "@/lib/utils";
-import { SourceIcon } from "@/components/ui/source-icon";
+import { isValidImageUrl, formatTimeAgo } from "@/lib/utils";
+import { imageProxyUrl } from "@/lib/image";
+import { NyuchiArticleCard } from "@/components/brand/nyuchi-article-card";
+import { SourceBadge } from "@/components/ui/source-icon";
 
 interface CompactCardProps {
   article: Article;
+  /** Position in the list — drives the harness stagger animation */
+  index?: number;
 }
 
-export function CompactCard({ article }: CompactCardProps) {
-  const timeAgo = formatTimeAgo(article.published_at);
+/**
+ * Sidebar/list card = the canonical Mzizi N3 brand component
+ * (nyuchi-article-card, row variant): title + source + time with a
+ * small proxied thumbnail on the right.
+ */
+export function CompactCard({ article, index }: CompactCardProps) {
+  const hasImage = article.image_url && isValidImageUrl(article.image_url);
   const category = article.category_id || article.category;
 
   return (
-    <Link
+    <NyuchiArticleCard
+      variant="row"
       href={`/article/${article.id}`}
-      className="block group focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-xl"
-      aria-label={`Read article: ${article.title}`}
-    >
-      <article className="p-4 rounded-xl bg-surface hover:bg-elevated transition-colors border border-border hover:border-primary/60">
-        {/* Category */}
-        {category && (
-          <span className="text-xs font-semibold text-primary uppercase tracking-wide">
-            {category}
-          </span>
-        )}
-
-        {/* Title */}
-        <h3 className="text-base font-semibold mt-1 mb-2 leading-snug line-clamp-2 group-hover:underline decoration-2 underline-offset-2">
-          {article.title}
-        </h3>
-
-        {/* Meta */}
-        <div className="flex items-center gap-3 text-text-tertiary">
-          <SourceIcon source={article.source} size={14} showBorder={false} />
-          <span className="text-xs">{article.source}</span>
-          <time className="flex items-center gap-1 text-xs" dateTime={article.published_at}>
-            <Clock className="w-3 h-3" aria-hidden="true" />
-            <span>{timeAgo}</span>
-          </time>
-        </div>
-      </article>
-    </Link>
+      title={article.title}
+      image={hasImage ? imageProxyUrl(article.image_url!, { width: 200 }) : undefined}
+      category={category}
+      publishedAt={formatTimeAgo(article.published_at)}
+      index={index}
+      sourceSlot={<SourceBadge source={article.source} iconSize={14} />}
+    />
   );
 }

--- a/src/components/hero-card.tsx
+++ b/src/components/hero-card.tsx
@@ -55,7 +55,7 @@ export function HeroCard({ article }: HeroCardProps) {
 
           {/* Category badge */}
           {category && (
-            <span className="absolute top-4 left-4 bg-primary text-white px-3 py-1.5 rounded-full text-xs font-bold uppercase tracking-wide z-10">
+            <span className="absolute top-4 left-4 bg-black/70 text-white backdrop-blur-sm px-3 py-1.5 rounded-full text-xs font-bold uppercase tracking-wide z-10">
               {category}
             </span>
           )}

--- a/src/components/story-cluster.tsx
+++ b/src/components/story-cluster.tsx
@@ -31,7 +31,7 @@ export function StoryCluster({ cluster }: StoryClusterProps) {
           >
             {/* Category Badge */}
             {(primaryArticle.category_id || primaryArticle.category) && (
-              <div className="absolute top-3 left-3 bg-secondary text-white px-2.5 py-1 rounded-full text-[10px] font-bold uppercase">
+              <div className="absolute top-3 left-3 bg-black/70 text-white backdrop-blur-sm px-2.5 py-1 rounded-full text-[10px] font-bold uppercase">
                 {primaryArticle.category_id || primaryArticle.category}
               </div>
             )}

--- a/src/lib/harness.tsx
+++ b/src/lib/harness.tsx
@@ -1,0 +1,493 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/* ═══════════════════════════════════════════════════════════════
+   NYUCHI COMPONENT HARNESS — Zero-Config Infrastructure Wiring
+
+   Canonical source: mzizi_db → component_documents (node 1,
+   collection styling-libs, name nyuchi-harness). Adopted for
+   Mukoko News with no behavioural changes.
+
+   The vertical spine that connects N3, N4, and N5 to
+   infrastructure. Every brand component (N3), safety gate (N4),
+   and resilience wrapper (N5) uses the harness for:
+
+   - Observability (scoped logging, render timing, health reporting)
+   - Accessibility (LiveRegion auto-mount, announce(), focus ring)
+   - Motion (enter animations, reduced-motion, stagger)
+
+   N2 (primitives) does NOT use the harness — raw building blocks.
+   N1 (tokens) does NOT use the harness — pure data.
+
+   TWO USAGE PATTERNS:
+
+   1. NyuchiHarness — declarative wrapper for page sections:
+      <NyuchiHarness name="events-feed" skeleton={<FeedSkeleton />}>
+        <EventsFeed />
+      </NyuchiHarness>
+
+   2. useNyuchiHarness — imperative hook for N3/N4/N5 components:
+      const { log, motion, announce } = useNyuchiHarness("listing-card")
+   ═══════════════════════════════════════════════════════════════ */
+
+// ─── SCOPED LOGGER (from observability) ────────────────────
+// Each component gets its own logger prefixed with the component name.
+
+interface ScopedLogger {
+  debug: (message: string, data?: Record<string, unknown>) => void;
+  info: (message: string, data?: Record<string, unknown>) => void;
+  warn: (message: string, data?: Record<string, unknown>) => void;
+  error: (message: string, error?: Error, data?: Record<string, unknown>) => void;
+}
+
+function createScopedLogger(componentName: string): ScopedLogger {
+  const prefix = `[nyuchi:${componentName}]`;
+  return {
+    debug: (msg, data) => console.debug(`${prefix} ${msg}`, data || ""),
+    info: (msg, data) => console.info(`${prefix} ${msg}`, data || ""),
+    warn: (msg, data) => console.warn(`${prefix} ${msg}`, data || ""),
+    error: (msg, err, data) => console.error(`${prefix} ${msg}`, err || "", data || ""),
+  };
+}
+
+// ─── MOTION CONFIG (from nyuchi-motion) ────────────────────
+// Provides the correct duration/easing for the current user preference.
+
+interface MotionConfig {
+  /** Whether user prefers reduced motion */
+  prefersReduced: boolean;
+  /** Duration for entry animations (0 if reduced motion) */
+  enterDuration: number;
+  /** Duration for exit animations */
+  exitDuration: number;
+  /** CSS easing for entry */
+  enterEasing: string;
+  /** CSS easing for exit */
+  exitEasing: string;
+  /** Get stagger delay for item at index in a list */
+  staggerDelay: (index: number) => number;
+  /** CSS class for entry animation */
+  enterClass: string;
+}
+
+function getMotionConfig(): MotionConfig {
+  const prefersReduced =
+    typeof window !== "undefined"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  return {
+    prefersReduced,
+    enterDuration: prefersReduced ? 0 : 200,
+    exitDuration: prefersReduced ? 0 : 100,
+    enterEasing: prefersReduced ? "linear" : "cubic-bezier(0, 0, 0.2, 1)",
+    exitEasing: prefersReduced ? "linear" : "cubic-bezier(0.4, 0, 1, 1)",
+    staggerDelay: (index: number) => (prefersReduced ? 0 : Math.min(index, 8) * 50),
+    enterClass: prefersReduced ? "" : "nyuchi-animate-in",
+  };
+}
+
+// ─── ANNOUNCER (from nyuchi-a11y) ──────────────────────────
+// Imperative screen reader announcements for dynamic content.
+
+interface Announcer {
+  /** Announce a message to screen readers (polite — waits for current speech) */
+  announce: (message: string) => void;
+  /** Announce urgently (assertive — interrupts current speech) */
+  announceUrgent: (message: string) => void;
+  /** The live region element to render (must be in the DOM) */
+  LiveRegion: React.ReactNode;
+}
+
+function useAnnouncer(): Announcer {
+  const [message, setMessage] = React.useState("");
+  const [politeness, setPoliteness] = React.useState<"polite" | "assertive">("polite");
+  const portalRef = React.useRef<HTMLDivElement | null>(null);
+
+  // Auto-mount LiveRegion via a shared DOM node — components no longer
+  // need to render <LiveRegion /> themselves.
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+    let el = document.getElementById("nyuchi-live-region");
+    if (!el) {
+      el = document.createElement("div");
+      el.id = "nyuchi-live-region";
+      el.setAttribute("role", "status");
+      el.setAttribute("aria-live", "polite");
+      el.setAttribute("aria-atomic", "true");
+      el.className = "sr-only";
+      document.body.appendChild(el);
+    }
+    portalRef.current = el as HTMLDivElement;
+    return () => {
+      /* keep mounted — shared across components */
+    };
+  }, []);
+
+  const announce = React.useCallback((msg: string) => {
+    setMessage("");
+    setPoliteness("polite");
+    requestAnimationFrame(() => {
+      setMessage(msg);
+      if (portalRef.current) {
+        portalRef.current.setAttribute("aria-live", "polite");
+        portalRef.current.textContent = msg;
+      }
+    });
+  }, []);
+
+  const announceUrgent = React.useCallback((msg: string) => {
+    setMessage("");
+    setPoliteness("assertive");
+    requestAnimationFrame(() => {
+      setMessage(msg);
+      if (portalRef.current) {
+        portalRef.current.setAttribute("aria-live", "assertive");
+        portalRef.current.textContent = msg;
+      }
+    });
+  }, []);
+
+  const LiveRegion = React.useMemo(
+    () => (
+      <div
+        role="status"
+        aria-live={politeness}
+        aria-atomic="true"
+        style={{
+          position: "absolute",
+          width: 1,
+          height: 1,
+          margin: -1,
+          padding: 0,
+          overflow: "hidden",
+          clip: "rect(0,0,0,0)",
+          whiteSpace: "nowrap",
+          border: 0,
+        }}
+      >
+        {message}
+      </div>
+    ),
+    [message, politeness]
+  );
+
+  return { announce, announceUrgent, LiveRegion };
+}
+
+// ─── HEALTH REPORTER ───────────────────────────────────────
+// Reports component health via structured log events (the N8
+// assurance monitor picks these up).
+
+type HealthStatus = "healthy" | "degraded" | "error" | "loading";
+
+interface HealthReporter {
+  reportHealthy: () => void;
+  reportDegraded: (reason?: string) => void;
+  reportError: (error: Error) => void;
+  reportLoading: () => void;
+}
+
+function useHealthReporter(componentName: string): HealthReporter {
+  const log = React.useMemo(() => createScopedLogger(componentName), [componentName]);
+
+  return React.useMemo(
+    () => ({
+      reportHealthy: () => log.debug("status: healthy"),
+      reportDegraded: (reason?: string) =>
+        log.warn(`status: degraded${reason ? ` — ${reason}` : ""}`),
+      reportError: (error: Error) => log.error("status: error", error),
+      reportLoading: () => log.debug("status: loading"),
+    }),
+    [log]
+  );
+}
+
+// ─── TOKEN VERIFIER ────────────────────────────────────────
+// Dev-only check that CSS custom properties are present.
+
+function useTokenVerifier(componentName: string) {
+  React.useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    if (typeof window === "undefined") return;
+
+    const root = document.documentElement;
+    const style = getComputedStyle(root);
+
+    const requiredTokens = [
+      "--color-malachite",
+      "--color-cobalt",
+      "--color-tanzanite",
+      "--color-gold",
+      "--color-terracotta",
+      "--radius-card",
+      "--radius-inner",
+      "--radius-pill",
+    ];
+
+    const missing = requiredTokens.filter((token) => {
+      const value = style.getPropertyValue(token).trim();
+      return !value;
+    });
+
+    if (missing.length > 0) {
+      console.warn(
+        `[nyuchi:${componentName}] Missing CSS tokens: ${missing.join(", ")}. ` +
+          `Check src/app/globals.css defines the mineral palette and radii.`
+      );
+    }
+  }, [componentName]);
+}
+
+// ─── OBSERVABILITY (domain-gated) ────────────────────────────
+// Design portal backlinks and observability only render on allowed domains.
+// This protects privacy: no tracking on unauthorized domains.
+
+export const INTERNAL_DOMAINS = ["nyuchi.com", "mukoko.com", "localhost"];
+
+function isObservabilityAllowedDomain(): boolean {
+  if (typeof window === "undefined") return false;
+  const hostname = window.location.hostname;
+  return INTERNAL_DOMAINS.some((d) => hostname === d || hostname.endsWith("." + d));
+}
+
+function getObservabilityAttrs(componentName: string): Record<string, string> {
+  if (!isObservabilityAllowedDomain()) return {};
+  return { "data-portal": `https://mzizi.dev/components/${componentName}` };
+}
+
+// ─── useNyuchiHarness HOOK ──────────────────────────────
+// The imperative API for leaf components.
+
+export interface ComponentHarnessResult {
+  /** Scoped observability logger */
+  log: ScopedLogger;
+  /** Motion configuration respecting user preferences */
+  motion: MotionConfig;
+  /** Screen reader announcer */
+  announce: (message: string) => void;
+  announceUrgent: (message: string) => void;
+  /** Health reporter */
+  health: HealthReporter;
+  /** Live region element (render this in the component) */
+  LiveRegion: React.ReactNode;
+  /** Render timing tracker — call at start of render */
+  trackRenderStart: () => void;
+  /** Render timing tracker — call at end of render (useEffect) */
+  trackRenderEnd: () => void;
+  /** Domain-gated observability attributes for root element (data-portal) */
+  observabilityAttrs: Record<string, string>;
+}
+
+export function useNyuchiHarness(componentName: string): ComponentHarnessResult {
+  const log = React.useMemo(() => createScopedLogger(componentName), [componentName]);
+  const motion = React.useMemo(() => getMotionConfig(), []);
+  const { announce, announceUrgent, LiveRegion } = useAnnouncer();
+  const health = useHealthReporter(componentName);
+  const renderStartRef = React.useRef(0);
+
+  // Token verification (dev only)
+  useTokenVerifier(componentName);
+
+  // Report healthy on mount
+  React.useEffect(() => {
+    health.reportHealthy();
+    log.debug("mounted");
+    return () => {
+      log.debug("unmounted");
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const trackRenderStart = React.useCallback(() => {
+    renderStartRef.current = performance.now();
+  }, []);
+
+  const trackRenderEnd = React.useCallback(() => {
+    if (renderStartRef.current > 0) {
+      const duration = Math.round((performance.now() - renderStartRef.current) * 100) / 100;
+      if (duration > 16) {
+        // Only log slow renders (>1 frame)
+        log.warn(`slow render: ${duration}ms`, { duration });
+      }
+    }
+  }, [log]);
+
+  const observabilityAttrs = React.useMemo(
+    () => getObservabilityAttrs(componentName),
+    [componentName]
+  );
+  return {
+    log,
+    motion,
+    announce,
+    announceUrgent,
+    health,
+    LiveRegion,
+    trackRenderStart,
+    trackRenderEnd,
+    observabilityAttrs,
+  };
+}
+
+// ─── NyuchiHarness COMPONENT ───────────────────────────────
+// The declarative wrapper for page sections.
+// Provides error boundary + skeleton + observability + motion.
+
+interface NyuchiHarnessProps {
+  /** Unique name for this section (used in logs and health reports) */
+  name: string;
+  /** Content to render */
+  children: React.ReactNode;
+  /** Whether the section is loading */
+  loading?: boolean;
+  /** Custom skeleton for loading state */
+  skeleton?: React.ReactNode;
+  /** Custom fallback for error state */
+  fallback?: React.ReactNode;
+  /** Whether errors should bubble up instead of being caught */
+  critical?: boolean;
+  /** Animate entry */
+  animate?: boolean;
+  className?: string;
+}
+
+interface HarnessState {
+  hasError: boolean;
+  error: Error | null;
+  retryCount: number;
+}
+
+class NyuchiHarnessBoundary extends React.Component<NyuchiHarnessProps, HarnessState> {
+  private log: ScopedLogger;
+  private renderStart = 0;
+
+  constructor(props: NyuchiHarnessProps) {
+    super(props);
+    this.state = { hasError: false, error: null, retryCount: 0 };
+    this.log = createScopedLogger(props.name);
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<HarnessState> {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error) {
+    this.log.error("render crash", error, {
+      retryCount: this.state.retryCount,
+      componentStack: error.stack?.split("\n").slice(0, 5),
+    });
+  }
+
+  componentDidMount() {
+    this.trackRender();
+    this.log.debug("mounted");
+  }
+
+  componentDidUpdate() {
+    this.trackRender();
+  }
+
+  componentWillUnmount() {
+    this.log.debug("unmounted");
+  }
+
+  private trackRender() {
+    if (this.renderStart > 0) {
+      const duration = Math.round((performance.now() - this.renderStart) * 100) / 100;
+      if (duration > 16) {
+        this.log.warn(`slow render: ${duration}ms`);
+      }
+    }
+  }
+
+  private handleRetry = () => {
+    this.log.info(`retry attempt ${this.state.retryCount + 1}`);
+    this.setState((prev) => ({ hasError: false, error: null, retryCount: prev.retryCount + 1 }));
+  };
+
+  render() {
+    this.renderStart = performance.now();
+    const { name, children, loading, skeleton, fallback, critical, animate, className } =
+      this.props;
+
+    // Loading state
+    if (loading) {
+      return (
+        <div
+          data-slot="nyuchi-harness"
+          data-section={name}
+          data-status="loading"
+          className={className}
+          role="status"
+          aria-label={`${name} loading`}
+        >
+          {skeleton || (
+            <div className="animate-pulse rounded-[var(--radius-card,14px)] bg-card p-4 ring-1 ring-foreground/10">
+              <div className="h-4 w-2/3 rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-full rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+              <div className="mt-2 h-3 w-1/2 rounded-[var(--radius-inner,7px)] bg-foreground/[0.06]" />
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // Error state
+    if (this.state.hasError) {
+      if (critical) throw this.state.error;
+
+      return (
+        <div
+          data-slot="nyuchi-harness"
+          data-section={name}
+          data-status="error"
+          data-retry-count={this.state.retryCount}
+          className={className}
+          role="alert"
+          aria-label={`${name} error`}
+        >
+          {fallback || (
+            <div className="flex flex-col items-center rounded-[var(--radius-card,14px)] bg-card px-6 py-6 text-center ring-1 ring-foreground/10">
+              <div className="mb-3 flex size-10 items-center justify-center rounded-full bg-[var(--color-terracotta,#D4A574)]/10">
+                <span className="text-lg text-[var(--color-terracotta,#D4A574)]">!</span>
+              </div>
+              <p className="text-sm font-medium text-foreground">{name} could not load</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {this.state.error?.message || "An unexpected error occurred"}
+              </p>
+              <button
+                onClick={this.handleRetry}
+                className={cn(
+                  "mt-4 flex h-9 items-center gap-2 rounded-full px-4 text-xs font-medium transition-colors",
+                  "border border-border text-foreground hover:bg-foreground/[0.05]"
+                )}
+              >
+                Try Again{this.state.retryCount > 0 ? ` (${this.state.retryCount})` : ""}
+              </button>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // Healthy state — render with optional entry animation
+    return (
+      <div
+        data-slot="nyuchi-harness"
+        data-section={name}
+        data-status="healthy"
+        className={cn(animate && "nyuchi-animate-in", className)}
+      >
+        {children}
+      </div>
+    );
+  }
+}
+
+export function NyuchiHarness(props: NyuchiHarnessProps) {
+  return <NyuchiHarnessBoundary {...props} />;
+}
+
+export type { NyuchiHarnessProps, ScopedLogger, MotionConfig, HealthReporter, HealthStatus };

--- a/src/lib/icons.ts
+++ b/src/lib/icons.ts
@@ -1,0 +1,38 @@
+import type * as React from "react";
+
+/**
+ * Icon shim for Mzizi brand components.
+ *
+ * The canonical nyuchi-* components (mzizi_db → component_documents, N3 brand)
+ * import icons from `@/lib/icons` so the icon library is swappable per app.
+ * Mukoko News uses lucide-react, so this module just re-exports the set the
+ * brand components need. Keeping the canonical import path means future
+ * component syncs from the mzizi registry drop in without edits.
+ */
+export {
+  AlertCircle,
+  AlertTriangle,
+  Award,
+  Ban,
+  BookOpen,
+  Check,
+  CheckCircle,
+  Clock,
+  Eye,
+  Flower2,
+  HelpCircle,
+  Newspaper,
+  Phone,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+
+/** Prop surface the brand components rely on — any lucide icon satisfies it. */
+export type BrandIcon = React.ComponentType<{
+  className?: string;
+  style?: React.CSSProperties;
+  width?: number | string;
+  height?: number | string;
+  strokeWidth?: number | string;
+  color?: string;
+}>;


### PR DESCRIPTION
## Summary

Two stages, one goal — kill the old-school blog card and align the feed with the Mzizi design system:

1. **Modern card redesign** (first commit): dropped the glassmorphism "02 JUL" date box + dark image wash; fixed on-image badge contrast (white-on-tanzanite = 2.66:1 in dark mode → `bg-black/70` chips).
2. **Canonical brand adoption** (this commit): discovered the canonical **React** component sources in the `mzizi_db` component registry (`component_documents`, N2/N3) and wired Mukoko News onto them.

### Adopted from the mzizi registry
- **`src/lib/harness.tsx`** — `nyuchi-harness` (N1): scoped logging, motion tokens (reduced-motion safe + list stagger), LiveRegion announcer, health reporting, dev token verification, and the declarative `NyuchiHarness` section boundary (branded error card + skeleton).
- **`src/components/brand/`** — `nyuchi-listing-card` (universal listing card: row/compact/hero), `nyuchi-article-card` (news card extending it: factcheck badge, source attribution, read time), `nyuchi-source-badge` (credibility tiers), `nyuchi-verified-badge` (three-axis trust model, mineral-tiered).
- **`src/lib/icons.ts`** — icon shim preserving the canonical `@/lib/icons` import path (lucide re-exports).
- **`globals.css`** — N1 tokens the components consume: `--radius-inner`/`--radius-pill`, theme-aware `--status-*`, focus-ring vars, `nyuchi-fade-slide-up` keyframes.

### Wiring
`ArticleCard` → `NyuchiArticleCard variant="compact"`, `CompactCard` → `variant="row"` — with proxied images, the favicon `SourceBadge` in the `sourceSlot`, engagement in the `footer` slot, and feed maps passing `index` so lists stagger in.

### Documented deviations from canonical (upstreamable to mzizi)
- `role="article"` only on non-interactive wrappers — on an anchor it overrides the link role for assistive tech
- Fixed duplicate `className` on the article-card hero variant + undeclared `loading` prop; entry animation now actually applied
- Internal hrefs render through `next/link`; images lazy-load
- Hero category chips use `bg-black/60` (white-on-mineral fails AA in dark mode)

## Testing
- `npm run typecheck` ✅ · `npm run build` ✅ · `npx vitest run` — **455/455** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)