### PR TITLE
fix(a11y,reader): on-primary tokens, quiet harness logs, reader dedupe + blank-image fix

### DIFF
--- a/src/app/admin/system/page.tsx
+++ b/src/app/admin/system/page.tsx
@@ -122,7 +122,7 @@ export default function AdminSystemPage() {
       <section>
         <h2 className="text-lg font-semibold text-foreground mb-4">Actions</h2>
         <div className="flex flex-wrap gap-3">
-          <button className="flex items-center gap-2 px-4 py-2.5 bg-primary text-white rounded-xl font-medium hover:opacity-90">
+          <button className="flex items-center gap-2 px-4 py-2.5 bg-primary text-on-primary rounded-xl font-medium hover:opacity-90">
             <RefreshCw className="w-4 h-4" />
             Clear Cache
           </button>

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -215,7 +215,7 @@ export default function AnalyticsPage() {
                 <div className="flex justify-between items-start mb-2">
                   <span className="text-2xl">{getEmoji(t.name)}</span>
                   {i < 3 && (
-                    <span className="w-6 h-6 rounded-full bg-primary text-white text-xs font-bold flex items-center justify-center">
+                    <span className="w-6 h-6 rounded-full bg-primary text-on-primary text-xs font-bold flex items-center justify-center">
                       {i + 1}
                     </span>
                   )}

--- a/src/app/article/[id]/article-detail-client.tsx
+++ b/src/app/article/[id]/article-detail-client.tsx
@@ -15,7 +15,7 @@ import {
   Check,
   ExternalLink,
 } from "lucide-react";
-import { Markdown } from "@/components/ui/markdown";
+import { Markdown, decodeHtmlEntities } from "@/components/ui/markdown";
 import { type Article } from "@/lib/api";
 import { getArticleAction } from "@/lib/actions/feed";
 import { getArticleUrl } from "@/lib/constants";
@@ -25,6 +25,28 @@ import { ArticlePageSkeleton } from "@/components/ui/skeleton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { ArticleJsonLd } from "@/components/ui/json-ld";
 import { Breadcrumb } from "@/components/ui/breadcrumb";
+
+/**
+ * True when the article body is just the description again — excerpt-only RSS
+ * sources (e.g. Zimpapers feeds) store the same ~30-word teaser in both
+ * fields, and showing it twice reads like a bug. Compared on a normalized
+ * prefix so trailing ellipses / entity differences don't defeat the check.
+ */
+function bodyRepeatsDescription(article: Article): boolean {
+  const body = article.content_markdown || article.content;
+  if (!body || !article.description) return false;
+  const normalize = (s: string) =>
+    decodeHtmlEntities(s)
+      .toLowerCase()
+      .replace(/[\s…]+/g, " ")
+      .replace(/\.{3,}/g, " ")
+      .trim();
+  const desc = normalize(article.description);
+  const bodyNorm = normalize(body);
+  if (!desc || !bodyNorm) return false;
+  const prefix = desc.slice(0, Math.min(desc.length, 120));
+  return bodyNorm.startsWith(prefix) || bodyNorm.includes(prefix);
+}
 
 export default function ArticleDetailClient({
   articleId,
@@ -41,6 +63,7 @@ export default function ArticleDetailClient({
   const [isLiked, setIsLiked] = useState(initialArticle?.isLiked || false);
   const [isSaved, setIsSaved] = useState(initialArticle?.isSaved || false);
   const [likesCount, setLikesCount] = useState(initialArticle?.likesCount || 0);
+  const [heroImageFailed, setHeroImageFailed] = useState(false);
 
   const loadArticle = useCallback(async () => {
     setLoading(true);
@@ -222,7 +245,7 @@ export default function ArticleDetailClient({
             </button>
             <button
               onClick={handleForceRefresh}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
             >
               <RefreshCw className="w-4 h-4" />
               Try Again
@@ -250,7 +273,7 @@ export default function ArticleDetailClient({
         </div>
 
         {/* Hero Section */}
-        <div className="bg-primary text-white px-6 py-12 relative">
+        <div className="bg-primary text-on-primary px-6 py-12 relative">
         {/* Back Button */}
         <button
           onClick={() => router.back()}
@@ -284,7 +307,7 @@ export default function ArticleDetailClient({
           </h1>
 
           {/* Source and Date */}
-          <div className="flex items-center gap-4 text-white/80">
+          <div className="flex items-center gap-4 text-on-primary/80">
             <span className="font-medium">{article.source}</span>
             <span className="flex items-center gap-1">
               <Clock className="w-4 h-4" />
@@ -294,14 +317,16 @@ export default function ArticleDetailClient({
         </div>
       </div>
 
-      {/* Article Image */}
-      {article.image_url && isValidImageUrl(article.image_url) && (
+      {/* Article Image — hidden entirely if the proxy can't fetch it (some
+          publisher WAFs block server-side fetches); no empty placeholder box. */}
+      {article.image_url && isValidImageUrl(article.image_url) && !heroImageFailed && (
         <div className="max-w-[900px] mx-auto px-6 -mt-6">
           <div className="rounded-2xl overflow-hidden shadow-xl">
             <img
               src={imageProxyUrl(article.image_url, { width: 900 })}
               alt={article.title}
               className="w-full aspect-video object-cover"
+              onError={() => setHeroImageFailed(true)}
             />
           </div>
         </div>
@@ -309,8 +334,9 @@ export default function ArticleDetailClient({
 
       {/* Article Content */}
       <div className="max-w-[800px] mx-auto px-6 py-8">
-        {/* Description */}
-        {article.description && (
+        {/* Description — skipped when the body just repeats it (excerpt-only
+            RSS sources store the same text in both fields). */}
+        {article.description && !bodyRepeatsDescription(article) && (
           <p className="text-lg text-text-secondary leading-relaxed mb-8">
             {article.description}
           </p>
@@ -345,7 +371,7 @@ export default function ArticleDetailClient({
             href={article.original_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-primary text-white font-semibold hover:opacity-90 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             <ExternalLink className="w-5 h-5" aria-hidden="true" />
             Read full article{article.source ? ` at ${article.source}` : ""}
@@ -386,7 +412,7 @@ export default function ArticleDetailClient({
             className={`flex items-center gap-2 px-4 py-2.5 rounded-xl transition-all ml-auto ${
               copySuccess
                 ? "bg-success text-white"
-                : "bg-primary text-white hover:opacity-90"
+                : "bg-primary text-on-primary hover:opacity-90"
             }`}
           >
             {copySuccess ? <Check className="w-5 h-5" /> : <Share2 className="w-5 h-5" />}

--- a/src/app/embed/iframe/page.tsx
+++ b/src/app/embed/iframe/page.tsx
@@ -433,7 +433,7 @@ export default function EmbedIframePage() {
           <p className="text-sm text-text-secondary mb-3">{error}</p>
           <button
             onClick={() => { setLoading(true); loadArticles(); }}
-            className="text-xs px-3 py-1.5 bg-primary text-white rounded-lg hover:opacity-90 transition-opacity"
+            className="text-xs px-3 py-1.5 bg-primary text-on-primary rounded-lg hover:opacity-90 transition-opacity"
           >
             Try Again
           </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,8 @@
   /* Semantic */
   --primary: var(--tanzanite);
   --secondary: var(--cobalt);
+  --on-primary: #1A0033;   /* deep tanzanite ink on light-lavender primary — 7.2:1 */
+  --on-secondary: #002966; /* deep cobalt ink on light-cyan secondary — 5.7:1 */
   --success: #64FFDA;   /* Malachite (dark) */
   --warning: #E1B07E;   /* Terracotta (dark) */
   --accent: var(--gold);
@@ -92,6 +94,8 @@
 
   --primary: var(--tanzanite);
   --secondary: var(--cobalt);
+  --on-primary: #1A0033;   /* deep tanzanite ink on light-lavender primary — 7.2:1 */
+  --on-secondary: #002966; /* deep cobalt ink on light-cyan secondary — 5.7:1 */
   --success: #64FFDA;   /* Malachite (dark) */
   --warning: #E1B07E;   /* Terracotta (dark) */
   --accent: var(--gold);
@@ -150,6 +154,8 @@
 
   --primary: var(--tanzanite);
   --secondary: var(--cobalt);
+  --on-primary: #FFFFFF;   /* white on deep tanzanite — 12.9:1 */
+  --on-secondary: #FFFFFF; /* white on deep cobalt — 7.6:1 */
   --success: #004D40;   /* Malachite (light) */
   --warning: #A0522D;   /* Terracotta (light) */
   --accent: var(--gold);
@@ -197,6 +203,8 @@
   --color-elevated: var(--elevated);
   --color-primary: var(--primary);
   --color-secondary: var(--secondary);
+  --color-on-primary: var(--on-primary);
+  --color-on-secondary: var(--on-secondary);
   --color-success: var(--success);
   --color-warning: var(--warning);
   --color-accent: var(--accent);

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -94,7 +94,7 @@ export default function HelpPage() {
         </p>
         <Link
           href="mailto:support@mukoko.com"
-          className="inline-block px-6 py-2.5 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+          className="inline-block px-6 py-2.5 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
         >
           Contact Support
         </Link>

--- a/src/app/newsbytes/page.tsx
+++ b/src/app/newsbytes/page.tsx
@@ -210,7 +210,7 @@ export default function NewsBytesPage() {
             <p className="text-white/60 mb-6">{error}</p>
             <button
               onClick={handleForceRefresh}
-              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
             >
               <RefreshCw className="w-4 h-4" />
               Try Again

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -334,7 +334,7 @@ export default function FeedPage() {
       {/* Refreshing indicator */}
       {refreshing && (
         <div className="fixed top-[80px] left-0 right-0 flex justify-center z-50" role="status" aria-live="polite">
-          <div className="bg-primary text-white px-4 py-2 rounded-full text-sm font-medium flex items-center gap-2 shadow-lg">
+          <div className="bg-primary text-on-primary px-4 py-2 rounded-full text-sm font-medium flex items-center gap-2 shadow-lg">
             <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
             Refreshing...
           </div>
@@ -411,7 +411,7 @@ export default function FeedPage() {
             <p className="text-sm text-text-tertiary mb-6 max-w-md">{error}</p>
             <button
               onClick={() => fetchData()}
-              className="flex items-center gap-2 px-6 py-3 bg-primary text-white rounded-full font-medium hover:opacity-90 transition-opacity"
+              className="flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-full font-medium hover:opacity-90 transition-opacity"
             >
               <RefreshCw className="w-4 h-4" aria-hidden="true" />
               Try Again

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -83,7 +83,7 @@ function ProfileContent() {
             <div className="flex gap-3 justify-center">
               <button
                 onClick={() => setShowSignIn(true)}
-                className="px-6 py-3 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+                className="px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
               >
                 Sign In
               </button>

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -68,7 +68,7 @@ function SavedContent() {
           </p>
           <Link
             href="/"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
           >
             Discover Articles
           </Link>
@@ -92,7 +92,7 @@ export default function SavedPage() {
           </p>
           <Link
             href="/"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-white font-medium rounded-xl hover:opacity-90 transition-opacity"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
           >
             Back to Home
           </Link>

--- a/src/components/admin/articles-moderator.tsx
+++ b/src/components/admin/articles-moderator.tsx
@@ -50,7 +50,7 @@ export function ArticlesModerator({ initialArticles, activeFilter }: ArticlesMod
             href={`/admin/articles?moderationStatus=${f.key}`}
             className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
               activeFilter === f.key
-                ? 'bg-primary text-white'
+                ? 'bg-primary text-on-primary'
                 : 'bg-surface border border-elevated text-text-secondary hover:bg-elevated'
             }`}
           >

--- a/src/components/onboarding-modal.tsx
+++ b/src/components/onboarding-modal.tsx
@@ -100,7 +100,7 @@ export function OnboardingModal() {
                   onClick={() => toggleCountry(country.code)}
                   className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                     isSelected
-                      ? "bg-secondary text-white"
+                      ? "bg-secondary text-on-secondary"
                       : "bg-elevated text-foreground hover:bg-muted"
                   }`}
                   aria-pressed={isSelected}
@@ -129,7 +129,7 @@ export function OnboardingModal() {
                     onClick={() => toggleCategory(category.id)}
                     className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
                       isSelected
-                        ? "bg-primary text-white"
+                        ? "bg-primary text-on-primary"
                         : "bg-elevated text-foreground hover:bg-muted"
                     }`}
                     aria-pressed={isSelected}
@@ -146,7 +146,7 @@ export function OnboardingModal() {
         <div className="p-6 pt-2">
           <button
             onClick={handleGetStarted}
-            className="w-full py-3 px-6 rounded-xl bg-primary text-white font-semibold hover:opacity-90 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+            className="w-full py-3 px-6 rounded-xl bg-primary text-on-primary font-semibold hover:opacity-90 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
           >
             {selectedCategories.length > 0 || selectedCountries.length > 0
               ? "Start Reading"

--- a/src/components/share-modal.tsx
+++ b/src/components/share-modal.tsx
@@ -161,7 +161,7 @@ export function ShareModal({ article, isOpen, onClose }: ShareModalProps) {
           {typeof navigator !== "undefined" && typeof navigator.share === "function" && (
             <button
               onClick={handleNativeShare}
-              className="w-full flex items-center justify-center gap-2 p-3 mt-3 bg-primary text-white rounded-xl font-medium transition-opacity hover:opacity-90"
+              className="w-full flex items-center justify-center gap-2 p-3 mt-3 bg-primary text-on-primary rounded-xl font-medium transition-opacity hover:opacity-90"
             >
               <Share2 className="w-5 h-5" />
               <span>More Options</span>

--- a/src/components/ui/category-chip.tsx
+++ b/src/components/ui/category-chip.tsx
@@ -15,7 +15,7 @@ export function CategoryChip({ label, active = false, onClick, icon }: CategoryC
       onClick={onClick}
       className={`px-3 py-1.5 rounded-full text-xs font-medium cursor-pointer transition-all duration-200 whitespace-nowrap flex items-center gap-1.5 ${
         active
-          ? "bg-primary text-white"
+          ? "bg-primary text-on-primary"
           : "bg-surface text-foreground border border-elevated hover:border-primary hover:text-primary"
       }`}
     >

--- a/src/components/ui/markdown.tsx
+++ b/src/components/ui/markdown.tsx
@@ -18,6 +18,32 @@ import { isValidImageUrl } from "@/lib/utils";
  * cross-origin fetch is slow, hotlink-blocked, or dropped by OpaqueResponseBlocking.
  * Unsafe/relative srcs are skipped (`isValidImageUrl`) rather than rendered raw.
  */
+/**
+ * Decode HTML entities that survive the pipeline's HTML→Markdown rendition
+ * (e.g. `&#8230;` in WordPress excerpts). Safe: react-markdown escapes its
+ * output, so decoded characters render as text, never as live HTML.
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  hellip: "…",
+  mdash: "—",
+  ndash: "–",
+  lsquo: "‘",
+  rsquo: "’",
+  ldquo: "“",
+  rdquo: "”",
+};
+
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&([a-zA-Z]+);/g, (m, name: string) => NAMED_ENTITIES[name] ?? m);
+}
+
 export function Markdown({ children }: { children: string }) {
   return (
     <div className="prose prose-lg dark:prose-invert max-w-none">
@@ -42,7 +68,7 @@ export function Markdown({ children }: { children: string }) {
           },
         }}
       >
-        {children}
+        {decodeHtmlEntities(children)}
       </ReactMarkdown>
     </div>
   );

--- a/src/lib/harness.tsx
+++ b/src/lib/harness.tsx
@@ -42,11 +42,18 @@ interface ScopedLogger {
   error: (message: string, error?: Error, data?: Record<string, unknown>) => void;
 }
 
+// debug/info are development-only: lifecycle chatter (mounted / status:
+// healthy) must never reach production consoles — with dozens of cards per
+// feed it floods them. warn/error always emit (real signals). NODE_ENV is
+// statically inlined by the bundler, so the prod branch compiles away.
+const IS_DEV = process.env.NODE_ENV === "development";
+const noop = () => {};
+
 function createScopedLogger(componentName: string): ScopedLogger {
   const prefix = `[nyuchi:${componentName}]`;
   return {
-    debug: (msg, data) => console.debug(`${prefix} ${msg}`, data || ""),
-    info: (msg, data) => console.info(`${prefix} ${msg}`, data || ""),
+    debug: IS_DEV ? (msg, data) => console.debug(`${prefix} ${msg}`, data || "") : noop,
+    info: IS_DEV ? (msg, data) => console.info(`${prefix} ${msg}`, data || "") : noop,
     warn: (msg, data) => console.warn(`${prefix} ${msg}`, data || ""),
     error: (msg, err, data) => console.error(`${prefix} ${msg}`, err || "", data || ""),
   };


### PR DESCRIPTION
## Summary

Follow-ups from the production a11y report + the Herald article screenshots.

### Accessibility — the systemic `--on-primary` fix (top P0 from the audit)
In dark mode `--primary` is light lavender (`#B388FF`), so **every** `bg-primary text-white` button in the app was ~2.66:1. Added theme-aware paired tokens and swept all 13 affected files:

| token | light | dark |
|---|---|---|
| `--on-primary` | `#FFFFFF` (12.9:1 on `#4B0082`) | `#1A0033` (7.2:1 on `#B388FF`) |
| `--on-secondary` | `#FFFFFF` (7.6:1 on `#0047AB`) | `#002966` (5.7:1 on `#00B0FF`) |

All `bg-primary text-white` → `bg-primary text-on-primary` (and secondary equivalents), including the article hero band + its source/date row. Contrast values verified via the Mzizi contrast tool.

### Harness — no more console spam
`[nyuchi:article-card] mounted / status: healthy` was flooding production consoles (one pair per card). `debug`/`info` are now dev-only no-ops (statically compiled away); `warn`/`error` still always emit.

### Reader — excerpt-only articles (Herald et al.)
Root cause data: Herald's RSS is excerpt-only (**every** recent article stores exactly ~30 words) and their Cloudflare WAF 403s datacenter fetches, so:
- **Duplicate text**: the body repeats the description → the standalone description paragraph is now skipped when the body starts with/contains it (normalized).
- **`&#8230;` artifacts**: HTML entities are decoded before Markdown rendering (safe — react-markdown escapes output; `lt`/`gt` deliberately not decoded).
- **Giant blank image box**: the hero image card now hides entirely on proxy error instead of reserving an empty 16:9 area.

The *content* fix (full text via the WordPress REST API + Photon image fallback) is landing separately in `mukoko-news-pipeline`.

## Testing
- `npm run typecheck` ✅ · `npm run build` ✅ · `npx vitest run` — **455/455** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_