### PR TITLE
fix(api): enforce rate limiting on engagement route handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ All news data reads go through Server Actions → MongoDB Atlas (`news` database
 
 ### Data Flow (writes / mutations)
 
-- **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit`, `getRequestIp`). `src/app/api/health/route.ts` is the health probe.
+- **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit`, `getRequestIp`). Note the limiter is in-memory per Vercel instance, so limits apply per-instance rather than globally — a shared store (e.g. Redis/Upstash) is the durable upgrade. `src/app/api/health/route.ts` is the health probe.
 - **Admin mutations** — `src/lib/admin/gateway.ts` proxies to the gateway Worker's WorkOS-gated `/api/admin/*` endpoints, forwarding the WorkOS access token as a Bearer header so the Worker re-verifies the same RBAC. **This is the only place the frontend touches the gateway.**
 - **Pipeline refresh** — `src/lib/actions/refresh.ts` `triggerFeedCollection()` fire-and-forget `POST`s to `FLY_WORKER_URL/trigger/collect` with `FLY_TRIGGER_TOKEN`.
 

--- a/auth.md
+++ b/auth.md
@@ -53,4 +53,4 @@ const { user } = await withAuth()
 
 ## Engagement & rate limiting
 
-Engagement Route Handlers (`src/app/api/articles/[id]/{like,view,save}/route.ts`, `runtime = 'nodejs'`) are rate-limited via `checkRateLimit()` + `getRequestIp()` (`src/lib/rate-limit.ts`). Keep new public write endpoints behind the same rate-limit guard.
+Engagement Route Handlers (`src/app/api/articles/[id]/{like,view,save}/route.ts`, `runtime = 'nodejs'`) are rate-limited via `checkRateLimit()` + `getRequestIp()` (`src/lib/rate-limit.ts`). The limiter is in-memory per Vercel instance, so limits are enforced per-instance rather than globally — a shared store is the durable upgrade. Keep new public write endpoints behind the same rate-limit guard.

--- a/src/app/api/articles/[id]/like/route.ts
+++ b/src/app/api/articles/[id]/like/route.ts
@@ -1,8 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/mongodb/client'
+import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
+
+const RATE_LIMIT_MAX = 10
+const RATE_LIMIT_WINDOW_MS = 60_000
 
 // Session cookie + unique {articleId, sessionId} index prevents double-likes.
 // Replace sessionId with OIDC personId when auth is wired.
@@ -10,8 +14,22 @@ export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const ip = getRequestIp(request)
+  if (!checkRateLimit(`like:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
+    )
+  }
+
   try {
     const { id: articleId } = await params
+    if (typeof articleId !== 'string' || articleId.length === 0 || articleId.length > 128) {
+      return NextResponse.json(
+        { success: false, message: 'Invalid article id' },
+        { status: 400 }
+      )
+    }
     const sessionId = request.cookies.get('mukoko_session')?.value || randomUUID()
 
     const db = await getDb()

--- a/src/app/api/articles/[id]/save/route.ts
+++ b/src/app/api/articles/[id]/save/route.ts
@@ -1,15 +1,33 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/mongodb/client'
+import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
+
+const RATE_LIMIT_MAX = 10
+const RATE_LIMIT_WINDOW_MS = 60_000
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const ip = getRequestIp(request)
+  if (!checkRateLimit(`save:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
+    )
+  }
+
   try {
     const { id: articleId } = await params
+    if (typeof articleId !== 'string' || articleId.length === 0 || articleId.length > 128) {
+      return NextResponse.json(
+        { success: false, message: 'Invalid article id' },
+        { status: 400 }
+      )
+    }
     const sessionId = request.cookies.get('mukoko_session')?.value || randomUUID()
 
     const db = await getDb()

--- a/src/app/api/articles/[id]/view/route.ts
+++ b/src/app/api/articles/[id]/view/route.ts
@@ -1,15 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/mongodb/client'
+import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
+
+// Views fire on every article page load, so the ceiling is higher than like/save.
+const RATE_LIMIT_MAX = 60
+const RATE_LIMIT_WINDOW_MS = 60_000
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const ip = getRequestIp(request)
+  if (!checkRateLimit(`view:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
+    )
+  }
+
   try {
     const { id: articleId } = await params
+    if (typeof articleId !== 'string' || articleId.length === 0 || articleId.length > 128) {
+      return NextResponse.json({ success: false, views: 0 }, { status: 400 })
+    }
     const sessionId = request.cookies.get('mukoko_session')?.value || randomUUID()
 
     // Day bucket prevents a single session from inflating counts across the day

--- a/src/app/api/articles/__tests__/engagement-routes.test.ts
+++ b/src/app/api/articles/__tests__/engagement-routes.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as likePost } from '@/app/api/articles/[id]/like/route';
+import { POST as viewPost } from '@/app/api/articles/[id]/view/route';
+import { POST as savePost } from '@/app/api/articles/[id]/save/route';
+import { getDb } from '@/lib/mongodb/client';
+
+// The routes hit MongoDB through getDb() — mock the client module so no
+// connection is attempted. Rate limiting is exercised for real (the in-memory
+// limiter from src/lib/rate-limit.ts), isolated per test via unique IPs.
+vi.mock('@/lib/mongodb/client', () => ({
+  getDb: vi.fn(),
+}));
+
+type MockCollection = {
+  findOne: ReturnType<typeof vi.fn>;
+  insertOne: ReturnType<typeof vi.fn>;
+  deleteOne: ReturnType<typeof vi.fn>;
+  updateOne: ReturnType<typeof vi.fn>;
+  countDocuments: ReturnType<typeof vi.fn>;
+};
+
+function makeCollection(overrides: Partial<MockCollection> = {}): MockCollection {
+  return {
+    findOne: vi.fn().mockResolvedValue(null),
+    insertOne: vi.fn().mockResolvedValue({ acknowledged: true }),
+    deleteOne: vi.fn().mockResolvedValue({ deletedCount: 1 }),
+    updateOne: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+function makeDb(collections: Record<string, MockCollection>) {
+  return {
+    collection: vi.fn((name: string) => {
+      if (!collections[name]) collections[name] = makeCollection();
+      return collections[name];
+    }),
+  };
+}
+
+function useDb(collections: Record<string, MockCollection>) {
+  vi.mocked(getDb).mockResolvedValue(makeDb(collections) as unknown as never);
+  return collections;
+}
+
+// The rate limiter's window map is module-global and shared across tests in
+// this file — every test uses a fresh IP so windows never interfere.
+let ipCounter = 0;
+function nextIp(): string {
+  ipCounter += 1;
+  return `10.${Math.floor(ipCounter / 65536) % 256}.${Math.floor(ipCounter / 256) % 256}.${ipCounter % 256}`;
+}
+
+function makeRequest(path: string, ip: string, cookie?: string): NextRequest {
+  return new NextRequest(`http://localhost${path}`, {
+    method: 'POST',
+    headers: {
+      'x-forwarded-for': ip,
+      ...(cookie ? { cookie } : {}),
+    },
+  });
+}
+
+function withParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.mocked(getDb).mockReset();
+});
+
+describe('POST /api/articles/[id]/like', () => {
+  it('likes an article and sets the session cookie', async () => {
+    const cols = useDb({
+      articles: makeCollection({ findOne: vi.fn().mockResolvedValue({ _id: 'a-1' }) }),
+      articleLikes: makeCollection({ countDocuments: vi.fn().mockResolvedValue(5) }),
+    });
+
+    const res = await likePost(makeRequest('/api/articles/a-1/like', nextIp()), withParams('a-1'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, liked: true, count: 5 });
+    expect(cols.articleLikes.insertOne).toHaveBeenCalledOnce();
+    expect(res.cookies.get('mukoko_session')?.value).toBeTruthy();
+  });
+
+  it('toggles the like off when the unique index reports a duplicate', async () => {
+    const cols = useDb({
+      articles: makeCollection({ findOne: vi.fn().mockResolvedValue({ _id: 'a-1' }) }),
+      articleLikes: makeCollection({
+        insertOne: vi.fn().mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 })),
+        countDocuments: vi.fn().mockResolvedValue(4),
+      }),
+    });
+
+    const res = await likePost(
+      makeRequest('/api/articles/a-1/like', nextIp(), 'mukoko_session=sess-1'),
+      withParams('a-1')
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ success: true, liked: false, count: 4 });
+    expect(cols.articleLikes.deleteOne).toHaveBeenCalledWith({
+      articleId: 'a-1',
+      sessionId: 'sess-1',
+    });
+  });
+
+  it('returns 404 when the article does not exist', async () => {
+    useDb({ articles: makeCollection() }); // findOne resolves null
+
+    const res = await likePost(
+      makeRequest('/api/articles/missing/like', nextIp()),
+      withParams('missing')
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects an empty article id with 400 before touching Mongo', async () => {
+    const res = await likePost(makeRequest('/api/articles//like', nextIp()), withParams(''));
+
+    expect(res.status).toBe(400);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('rejects an article id longer than 128 chars with 400 before touching Mongo', async () => {
+    const res = await likePost(
+      makeRequest('/api/articles/x/like', nextIp()),
+      withParams('x'.repeat(129))
+    );
+
+    expect(res.status).toBe(400);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('rate limits after 10 requests/minute per IP with a Retry-After header', async () => {
+    useDb({
+      articles: makeCollection({ findOne: vi.fn().mockResolvedValue({ _id: 'a-1' }) }),
+    });
+    const ip = nextIp();
+
+    for (let i = 0; i < 10; i++) {
+      const res = await likePost(makeRequest('/api/articles/a-1/like', ip), withParams('a-1'));
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await likePost(makeRequest('/api/articles/a-1/like', ip), withParams('a-1'));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('retry-after')).toBe('60');
+    expect(await blocked.json()).toEqual({ error: 'Too many requests' });
+    expect(getDb).toHaveBeenCalledTimes(10); // the blocked request never reached Mongo
+  });
+
+  it('tracks the rate limit per IP', async () => {
+    useDb({
+      articles: makeCollection({ findOne: vi.fn().mockResolvedValue({ _id: 'a-1' }) }),
+    });
+    const ipA = nextIp();
+    const ipB = nextIp();
+
+    for (let i = 0; i < 10; i++) {
+      await likePost(makeRequest('/api/articles/a-1/like', ipA), withParams('a-1'));
+    }
+    const blockedA = await likePost(makeRequest('/api/articles/a-1/like', ipA), withParams('a-1'));
+    expect(blockedA.status).toBe(429);
+
+    const allowedB = await likePost(makeRequest('/api/articles/a-1/like', ipB), withParams('a-1'));
+    expect(allowedB.status).toBe(200);
+  });
+});
+
+describe('POST /api/articles/[id]/view', () => {
+  it('records a view and returns the updated count', async () => {
+    const articles = makeCollection({
+      findOne: vi
+        .fn()
+        .mockResolvedValueOnce({ _id: 'a-2', viewsCount: 7 }) // existence check
+        .mockResolvedValueOnce({ viewsCount: 8 }), // post-increment read
+    });
+    const cols = useDb({ articles, articleViews: makeCollection() });
+
+    const res = await viewPost(makeRequest('/api/articles/a-2/view', nextIp()), withParams('a-2'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, views: 8 });
+    expect(cols.articleViews.insertOne).toHaveBeenCalledOnce();
+    expect(articles.updateOne).toHaveBeenCalledOnce();
+  });
+
+  it('does not increment on a duplicate same-day view', async () => {
+    const articles = makeCollection({
+      findOne: vi
+        .fn()
+        .mockResolvedValueOnce({ _id: 'a-2', viewsCount: 7 })
+        .mockResolvedValueOnce({ viewsCount: 7 }),
+    });
+    useDb({
+      articles,
+      articleViews: makeCollection({
+        insertOne: vi.fn().mockRejectedValue(Object.assign(new Error('dup'), { code: 11000 })),
+      }),
+    });
+
+    const res = await viewPost(
+      makeRequest('/api/articles/a-2/view', nextIp(), 'mukoko_session=sess-2'),
+      withParams('a-2')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, views: 7 });
+    expect(articles.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the article does not exist', async () => {
+    useDb({ articles: makeCollection() });
+
+    const res = await viewPost(
+      makeRequest('/api/articles/missing/view', nextIp()),
+      withParams('missing')
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects an invalid article id with 400 before touching Mongo', async () => {
+    const empty = await viewPost(makeRequest('/api/articles//view', nextIp()), withParams(''));
+    expect(empty.status).toBe(400);
+
+    const tooLong = await viewPost(
+      makeRequest('/api/articles/x/view', nextIp()),
+      withParams('x'.repeat(129))
+    );
+    expect(tooLong.status).toBe(400);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('rate limits after 60 requests/minute per IP with a Retry-After header', async () => {
+    useDb({
+      articles: makeCollection({
+        findOne: vi.fn().mockResolvedValue({ _id: 'a-2', viewsCount: 1 }),
+      }),
+      articleViews: makeCollection(),
+    });
+    const ip = nextIp();
+
+    for (let i = 0; i < 60; i++) {
+      const res = await viewPost(makeRequest('/api/articles/a-2/view', ip), withParams('a-2'));
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await viewPost(makeRequest('/api/articles/a-2/view', ip), withParams('a-2'));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('retry-after')).toBe('60');
+    expect(await blocked.json()).toEqual({ error: 'Too many requests' });
+  });
+});
+
+describe('POST /api/articles/[id]/save', () => {
+  it('saves an article when no prior save exists', async () => {
+    const cols = useDb({ articleSaves: makeCollection() }); // findOne resolves null
+
+    const res = await savePost(makeRequest('/api/articles/a-3/save', nextIp()), withParams('a-3'));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, saved: true });
+    expect(cols.articleSaves.insertOne).toHaveBeenCalledOnce();
+  });
+
+  it('unsaves when a prior save exists', async () => {
+    const cols = useDb({
+      articleSaves: makeCollection({
+        findOne: vi.fn().mockResolvedValue({ articleId: 'a-3', sessionId: 'sess-3' }),
+      }),
+    });
+
+    const res = await savePost(
+      makeRequest('/api/articles/a-3/save', nextIp(), 'mukoko_session=sess-3'),
+      withParams('a-3')
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, saved: false });
+    expect(cols.articleSaves.deleteOne).toHaveBeenCalledWith({
+      articleId: 'a-3',
+      sessionId: 'sess-3',
+    });
+  });
+
+  it('rejects an invalid article id with 400 before touching Mongo', async () => {
+    const empty = await savePost(makeRequest('/api/articles//save', nextIp()), withParams(''));
+    expect(empty.status).toBe(400);
+
+    const tooLong = await savePost(
+      makeRequest('/api/articles/x/save', nextIp()),
+      withParams('x'.repeat(129))
+    );
+    expect(tooLong.status).toBe(400);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it('rate limits after 10 requests/minute per IP with a Retry-After header', async () => {
+    useDb({ articleSaves: makeCollection() });
+    const ip = nextIp();
+
+    for (let i = 0; i < 10; i++) {
+      const res = await savePost(makeRequest('/api/articles/a-3/save', ip), withParams('a-3'));
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await savePost(makeRequest('/api/articles/a-3/save', ip), withParams('a-3'));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('retry-after')).toBe('60');
+    expect(await blocked.json()).toEqual({ error: 'Too many requests' });
+  });
+
+  it('keeps rate-limit buckets separate per endpoint for the same IP', async () => {
+    useDb({
+      articles: makeCollection({ findOne: vi.fn().mockResolvedValue({ _id: 'a-4' }) }),
+      articleSaves: makeCollection(),
+      articleLikes: makeCollection({ countDocuments: vi.fn().mockResolvedValue(1) }),
+    });
+    const ip = nextIp();
+
+    // Exhaust the save bucket for this IP…
+    for (let i = 0; i < 10; i++) {
+      await savePost(makeRequest('/api/articles/a-4/save', ip), withParams('a-4'));
+    }
+    expect(
+      (await savePost(makeRequest('/api/articles/a-4/save', ip), withParams('a-4'))).status
+    ).toBe(429);
+
+    // …like from the same IP is still allowed (its own bucket).
+    expect(
+      (await likePost(makeRequest('/api/articles/a-4/like', ip), withParams('a-4'))).status
+    ).toBe(200);
+  });
+});


### PR DESCRIPTION
## Problem

`src/lib/rate-limit.ts` exports `checkRateLimit` + `getRequestIp` (unit-tested), but **no route handler imported them** — the public, unauthenticated engagement writes `POST /api/articles/[id]/{like,view,save}` ran with zero throttling, while CLAUDE.md, auth.md, agents.md (Rule 5) and review.md all claim they are rate-limited. This makes the code match the docs.

## Changes

### Route handlers (`src/app/api/articles/[id]/{like,view,save}/route.ts`)

- **Rate limiting first, before any Mongo call** — resolve the client IP via `getRequestIp(request)` and check `checkRateLimit()` with a per-endpoint key (`like:<ip>`, `view:<ip>`, `save:<ip>`). When exceeded, return `429 { "error": "Too many requests" }` with a `Retry-After: 60` header.
  - `like`: 10 req / 60 s per IP
  - `save`: 10 req / 60 s per IP
  - `view`: 60 req / 60 s per IP (views fire on every article page load)
- **articleId validation before any Mongo call** — must be a non-empty string of ≤ 128 chars, otherwise `400` (no regex format pinning; ids are UUID-ish strings but not hard-asserted).

### Docs

- `CLAUDE.md` (Data Flow → writes) and `auth.md` (Engagement & rate limiting): added the honest caveat that the limiter is **in-memory per Vercel instance** — limits are per-instance, not global; a shared store is the durable upgrade.
- `review.md` checklist item "Engagement Route Handlers rate-limited (`checkRateLimit` + `getRequestIp`)" now matches reality — no wording change needed.

### Tests

New `src/app/api/articles/__tests__/engagement-routes.test.ts` (17 tests): mocks `@/lib/mongodb/client` and exercises the real in-memory limiter (unique IP per test) — happy paths, like toggle-off / save-unsave, 404s, 400 id validation (Mongo never called), 429 + `Retry-After` after the limit, per-IP isolation, and per-endpoint bucket isolation.

## Verification

- `npx vitest run` — **472 tests, 22 files, all passing** (455 pre-existing + 17 new)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build` — clean
- No dependency changes; both lockfiles untouched (agents.md Rule 2)

## Known limitation

The limiter remains in-memory sliding-window per instance (as designed in `src/lib/rate-limit.ts`). On Vercel Fluid Compute, an attacker spread across instances gets `limit × instances`; a shared store (e.g. Redis/Upstash) is the durable upgrade and is now documented as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_