### PR TITLE
fix(resilience): fail fast on unreachable Atlas, bound refresh trigger, add root error pages

### DIFF
--- a/src/app/__tests__/error-pages.test.tsx
+++ b/src/app/__tests__/error-pages.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorPage from '../error';
+import GlobalError from '../global-error';
+
+describe('root error pages', () => {
+  // Suppress React DOM-nesting warnings (global-error renders <html>/<body>)
+  // and the components' own console.error reporting during tests.
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('error.tsx', () => {
+    it('renders the branded fallback copy', () => {
+      render(<ErrorPage error={new Error('boom')} reset={() => {}} />);
+      expect(screen.getByText('Something went wrong loading Mukoko News')).toBeInTheDocument();
+    });
+
+    it('calls reset() when "Try again" is clicked', () => {
+      const reset = vi.fn();
+      render(<ErrorPage error={new Error('boom')} reset={reset} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+      expect(reset).toHaveBeenCalledOnce();
+    });
+
+    it('logs the error for observability', () => {
+      const error = new Error('boom');
+      render(<ErrorPage error={error} reset={() => {}} />);
+      expect(console.error).toHaveBeenCalledWith('[RootError]', error);
+    });
+  });
+
+  describe('global-error.tsx', () => {
+    it('renders the branded fallback copy', () => {
+      render(<GlobalError error={new Error('boom')} reset={() => {}} />);
+      expect(screen.getByText('Something went wrong loading Mukoko News')).toBeInTheDocument();
+    });
+
+    it('calls reset() when "Try again" is clicked', () => {
+      const reset = vi.fn();
+      render(<GlobalError error={new Error('boom')} reset={reset} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+      expect(reset).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[RootError]', error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <div className="w-full max-w-md rounded-card border border-border bg-surface p-8 text-center">
+        <h2 className="font-serif text-xl font-semibold text-foreground">
+          Something went wrong loading Mukoko News
+        </h2>
+        <p className="mt-2 text-sm text-text-secondary">
+          Please try again — the hive is buzzing back to life.
+        </p>
+        <button
+          type="button"
+          onClick={() => reset()}
+          // TODO(on-primary): switch to text-on-primary when tokens land
+          className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary/90"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect } from 'react';
+// global-error replaces the root layout when active, so the global styles
+// imported there must be re-imported here for the mineral tokens to apply.
+import './globals.css';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('[GlobalError]', error);
+  }, [error]);
+
+  // global-error must render its own <html> and <body> — it replaces the root layout.
+  return (
+    <html lang="en" className="dark">
+      <body className="font-sans antialiased">
+        <div className="flex min-h-screen items-center justify-center p-6">
+          <div className="w-full max-w-md rounded-card border border-border bg-surface p-8 text-center">
+            <h2 className="font-serif text-xl font-semibold text-foreground">
+              Something went wrong loading Mukoko News
+            </h2>
+            <p className="mt-2 text-sm text-text-secondary">
+              Please try again — the hive is buzzing back to life.
+            </p>
+            <button
+              type="button"
+              onClick={() => reset()}
+              // TODO(on-primary): switch to text-on-primary when tokens land
+              className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary/90"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/lib/__tests__/mongodb-client.test.ts
+++ b/src/lib/__tests__/mongodb-client.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { MongoClientMock, connectMock, dbMock } = vi.hoisted(() => {
+  const dbMock = vi.fn(() => ({ collection: vi.fn() }));
+  const connectMock = vi.fn();
+  const clientInstance = { connect: connectMock, db: dbMock };
+  connectMock.mockResolvedValue(clientInstance);
+  // Regular function so it is constructible via `new MongoClient(...)`
+  const MongoClientMock = vi.fn(function MongoClient() {
+    return clientInstance;
+  });
+  return { MongoClientMock, connectMock, dbMock };
+});
+
+vi.mock('mongodb', () => ({ MongoClient: MongoClientMock }));
+
+const EXPECTED_TIMEOUTS = {
+  serverSelectionTimeoutMS: 8000,
+  connectTimeoutMS: 8000,
+  socketTimeoutMS: 20000,
+};
+
+function clearDevGlobalCache() {
+  const g = global as typeof globalThis & { _mongoClientPromise?: unknown };
+  delete g._mongoClientPromise;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  clearDevGlobalCache();
+  vi.stubEnv('MONGODB_URI', 'mongodb://unit-test.example/');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  clearDevGlobalCache();
+});
+
+describe('mongodb client fail-fast options', () => {
+  it('exports the fail-fast timeout options', async () => {
+    const { MONGO_CLIENT_OPTIONS } = await import('../mongodb/client');
+    expect(MONGO_CLIENT_OPTIONS).toMatchObject(EXPECTED_TIMEOUTS);
+  });
+
+  it('constructs the MongoClient with the timeout options (production branch)', async () => {
+    const { getDb } = await import('../mongodb/client');
+    await getDb();
+
+    expect(MongoClientMock).toHaveBeenCalledOnce();
+    expect(MongoClientMock).toHaveBeenCalledWith(
+      'mongodb://unit-test.example/',
+      expect.objectContaining(EXPECTED_TIMEOUTS)
+    );
+    expect(connectMock).toHaveBeenCalledOnce();
+  });
+
+  it('constructs the MongoClient with the timeout options (development global-cache branch)', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const { getDb } = await import('../mongodb/client');
+    await getDb();
+
+    expect(MongoClientMock).toHaveBeenCalledOnce();
+    expect(MongoClientMock).toHaveBeenCalledWith(
+      'mongodb://unit-test.example/',
+      expect.objectContaining(EXPECTED_TIMEOUTS)
+    );
+  });
+
+  it('reuses the cached client on subsequent getDb calls', async () => {
+    const { getDb } = await import('../mongodb/client');
+    await getDb();
+    await getDb();
+
+    expect(MongoClientMock).toHaveBeenCalledOnce();
+    expect(dbMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when MONGODB_URI is not set', async () => {
+    vi.stubEnv('MONGODB_URI', '');
+    const { getDb } = await import('../mongodb/client');
+    await expect(getDb()).rejects.toThrow('MONGODB_URI environment variable is not set');
+    expect(MongoClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/refresh.test.ts
+++ b/src/lib/__tests__/refresh.test.ts
@@ -46,8 +46,22 @@ describe('triggerFeedCollection', () => {
       {
         method: 'POST',
         headers: { Authorization: 'Bearer bf61a6184dbe6da192ffa0706e7666ec' },
+        signal: expect.any(AbortSignal),
       }
     );
+  });
+
+  it('bounds the request with an abort timeout signal', async () => {
+    vi.stubEnv('FLY_WORKER_URL', 'https://news-ingestion.fly-worker.nyuchi.dev');
+    vi.stubEnv('FLY_TRIGGER_TOKEN', 'tok');
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValueOnce(new Response('{}', { status: 202 }));
+
+    await triggerFeedCollection();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    const { signal } = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(signal).toBe(timeoutSpy.mock.results[0].value);
   });
 
   it('swallows network errors silently (fire-and-forget)', async () => {

--- a/src/lib/actions/refresh.ts
+++ b/src/lib/actions/refresh.ts
@@ -9,6 +9,8 @@ export async function triggerFeedCollection(): Promise<void> {
     await fetch(`${url}/trigger/collect`, {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
+      // Bound the fire-and-forget trigger so a stalled worker can't hold the action open.
+      signal: AbortSignal.timeout(5000),
     });
   } catch {
     // fire-and-forget — don't block the UI refresh

--- a/src/lib/mongodb/client.ts
+++ b/src/lib/mongodb/client.ts
@@ -1,6 +1,15 @@
-import { MongoClient } from 'mongodb'
+import { MongoClient, type MongoClientOptions } from 'mongodb'
 
 const dbName = process.env.MONGODB_DATABASE || 'news'
+
+// Fail fast when Atlas is unreachable instead of hanging Server-Action reads
+// for the driver-default 30s. 8s absorbs Atlas failover jitter without
+// blocking every page render behind a dead cluster.
+export const MONGO_CLIENT_OPTIONS: MongoClientOptions = {
+  serverSelectionTimeoutMS: 8000,
+  connectTimeoutMS: 8000,
+  socketTimeoutMS: 20000,
+}
 
 // Lazily initialised so next build can collect page data without a live DB.
 let clientPromise: Promise<MongoClient> | null = null
@@ -14,11 +23,11 @@ function getClientPromise(): Promise<MongoClient> {
   if (process.env.NODE_ENV === 'development') {
     const g = global as typeof globalThis & { _mongoClientPromise?: Promise<MongoClient> }
     if (!g._mongoClientPromise) {
-      g._mongoClientPromise = new MongoClient(uri).connect()
+      g._mongoClientPromise = new MongoClient(uri, MONGO_CLIENT_OPTIONS).connect()
     }
     clientPromise = g._mongoClientPromise
   } else {
-    clientPromise = new MongoClient(uri).connect()
+    clientPromise = new MongoClient(uri, MONGO_CLIENT_OPTIONS).connect()
   }
 
   return clientPromise


### PR DESCRIPTION
## Summary

Three resilience fixes so an unreachable backend degrades in seconds with a branded fallback instead of hanging renders:

- **MongoDB fail-fast** — `src/lib/mongodb/client.ts` now passes `{ serverSelectionTimeoutMS: 8000, connectTimeoutMS: 8000, socketTimeoutMS: 20000 }` to **both** `new MongoClient(uri)` call sites (the dev global-cache branch and the prod branch). Previously the driver-default 30s `serverSelectionTimeoutMS` hung every Server-Action read when Atlas was unreachable. 8s absorbs Atlas failover jitter; no retry logic added.
- **Root error pages** — new `src/app/error.tsx` and `src/app/global-error.tsx` (`'use client'`), branded with the mineral tokens (`bg-surface` card, `rounded-card`, `text-foreground`, `bg-primary` "Try again" button calling `reset()`). `global-error` renders its own `<html><body>` and re-imports `globals.css`, since it replaces the root layout. The button uses `text-white` with a `// TODO(on-primary)` marker — `--on-primary` is not in `globals.css` in this branch yet; the token sweep PR can flip it.
- **Bounded refresh trigger** — `src/lib/actions/refresh.ts` adds `signal: AbortSignal.timeout(5000)` to the fire-and-forget `/trigger/collect` POST; the existing swallow-errors behavior is unchanged.

## Tests

- `src/lib/__tests__/mongodb-client.test.ts` (new) — mocks the `mongodb` driver and asserts the constructor receives the timeout options in both the production and development branches, plus client-caching and missing-URI behavior.
- `src/app/__tests__/error-pages.test.tsx` (new) — RTL render tests for both error pages: branded copy renders, "Try again" calls `reset()`, error is logged.
- `src/lib/__tests__/refresh.test.ts` (updated) — exact-args assertion now includes the abort signal, plus a new test that `AbortSignal.timeout(5000)` backs the request.

## Verification

- `npx vitest run` — **466 tests, 23 files, all pass** (10 new)
- `npm run typecheck` — clean
- `npm run lint` — no warnings or errors
- `npm run build` — production build succeeds

No dependency or lockfile changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_