### PR TITLE
feat(admin,analytics): replace fabricated dashboards with real MongoDB reads

### DIFF
--- a/src/app/admin/__tests__/admin-analytics-page.test.tsx
+++ b/src/app/admin/__tests__/admin-analytics-page.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminAnalyticsPage from '../analytics/page';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Admin reads go directly through src/lib/mongodb/admin.ts — mock that module.
+const mockGetAdminStats = vi.fn();
+const mockGetAdminEngagementTotals = vi.fn();
+const mockGetAdminCategoryCounts = vi.fn();
+vi.mock('@/lib/mongodb/admin', () => ({
+  getAdminStats: (...args: unknown[]) => mockGetAdminStats(...args),
+  getAdminEngagementTotals: (...args: unknown[]) => mockGetAdminEngagementTotals(...args),
+  getAdminCategoryCounts: (...args: unknown[]) => mockGetAdminCategoryCounts(...args),
+}));
+
+const defaultStats = {
+  totalArticles: 9876,
+  activeSources: 42,
+  categories: 12,
+  todayArticles: 55,
+  pendingArticles: 3,
+};
+
+const defaultEngagement = { likes: 120, saves: 45, viewEvents: 3200 };
+
+const defaultCategories = [
+  { slug: 'politics', name: 'Politics', count: 400 },
+  { slug: 'business', name: 'Business', count: 250 },
+];
+
+describe('AdminAnalyticsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAdminStats.mockResolvedValue(defaultStats);
+    mockGetAdminEngagementTotals.mockResolvedValue(defaultEngagement);
+    mockGetAdminCategoryCounts.mockResolvedValue(defaultCategories);
+  });
+
+  it('renders real article and source counts from MongoDB reads', async () => {
+    render(await AdminAnalyticsPage());
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+    expect(screen.getByText('9,876')).toBeInTheDocument();
+    expect(screen.getByText('Total Articles')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('Active Sources')).toBeInTheDocument();
+    expect(screen.getByText('55')).toBeInTheDocument();
+    expect(screen.getByText('Published Today')).toBeInTheDocument();
+  });
+
+  it('renders engagement totals from the event collections', async () => {
+    render(await AdminAnalyticsPage());
+    expect(screen.getByText('120')).toBeInTheDocument();
+    expect(screen.getByText('Likes')).toBeInTheDocument();
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText('Saves')).toBeInTheDocument();
+    expect(screen.getByText('3,200')).toBeInTheDocument();
+    expect(screen.getByText('Tracked View Events')).toBeInTheDocument();
+  });
+
+  it('renders real per-category counts', async () => {
+    render(await AdminAnalyticsPage());
+    expect(screen.getByText('Top Categories by Article Count')).toBeInTheDocument();
+    expect(screen.getByText('Politics')).toBeInTheDocument();
+    expect(screen.getByText('400')).toBeInTheDocument();
+    expect(screen.getByText('Business')).toBeInTheDocument();
+    expect(screen.getByText('250')).toBeInTheDocument();
+  });
+
+  it('states untracked metrics honestly instead of fabricating them', async () => {
+    render(await AdminAnalyticsPage());
+    expect(screen.getByText('Not tracked yet')).toBeInTheDocument();
+    // No fabricated KPIs from the old mock page
+    expect(screen.queryByText('24.5K')).not.toBeInTheDocument();
+    expect(screen.queryByText('68%')).not.toBeInTheDocument();
+    expect(screen.queryByText('Engagement Rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Avg. Session')).not.toBeInTheDocument();
+  });
+
+  it('shows an error banner when the database is unreachable', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetAdminStats.mockRejectedValue(new Error('down'));
+    render(await AdminAnalyticsPage());
+    expect(
+      screen.getByText('Could not reach the database. Analytics are unavailable right now.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Total Articles')).not.toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/admin/__tests__/admin-system-page.test.tsx
+++ b/src/app/admin/__tests__/admin-system-page.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminSystemPage from '../system/page';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockPingDatabase = vi.fn();
+vi.mock('@/lib/mongodb/admin', () => ({
+  pingDatabase: (...args: unknown[]) => mockPingDatabase(...args),
+}));
+
+describe('AdminSystemPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a real connected status with ping latency', async () => {
+    mockPingDatabase.mockResolvedValue({ ok: true, latencyMs: 23 });
+    render(await AdminSystemPage());
+    expect(screen.getByText('MongoDB Atlas')).toBeInTheDocument();
+    expect(screen.getByText('Connected — ping 23 ms')).toBeInTheDocument();
+  });
+
+  it('shows unreachable when the ping fails', async () => {
+    mockPingDatabase.mockResolvedValue({ ok: false, latencyMs: null });
+    render(await AdminSystemPage());
+    expect(screen.getByText('Unreachable')).toBeInTheDocument();
+  });
+
+  it('links to the real health probe', async () => {
+    mockPingDatabase.mockResolvedValue({ ok: true, latencyMs: 5 });
+    render(await AdminSystemPage());
+    const link = screen.getByText('/api/health');
+    expect(link.closest('a')).toHaveAttribute('href', '/api/health');
+  });
+
+  it('has no fabricated statuses or dead config controls', async () => {
+    mockPingDatabase.mockResolvedValue({ ok: true, latencyMs: 5 });
+    render(await AdminSystemPage());
+    // Old fake statuses
+    expect(screen.queryByText('Operational')).not.toBeInTheDocument();
+    expect(screen.queryByText('Running')).not.toBeInTheDocument();
+    expect(screen.queryByText('RSS Scheduler')).not.toBeInTheDocument();
+    // Old dead controls
+    expect(screen.queryByText('RSS Sync Interval')).not.toBeInTheDocument();
+    expect(screen.queryByText('Clear Cache')).not.toBeInTheDocument();
+    expect(screen.queryByText('Rebuild Indexes')).not.toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('describes the pipeline boundary honestly', async () => {
+    mockPingDatabase.mockResolvedValue({ ok: true, latencyMs: 5 });
+    render(await AdminSystemPage());
+    expect(screen.getByText(/not monitored from this frontend/)).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/__tests__/admin-users-page.test.tsx
+++ b/src/app/admin/__tests__/admin-users-page.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AdminUsersPage from '../users/page';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('AdminUsersPage', () => {
+  it('renders an honest coming-soon empty state', () => {
+    render(<AdminUsersPage />);
+    expect(screen.getByText('Users')).toBeInTheDocument();
+    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    expect(
+      screen.getByText(/User management arrives with the WorkOS directory sync/)
+    ).toBeInTheDocument();
+  });
+
+  it('does not render fabricated users', () => {
+    render(<AdminUsersPage />);
+    expect(screen.queryByText('Admin User')).not.toBeInTheDocument();
+    expect(screen.queryByText('John Doe')).not.toBeInTheDocument();
+    expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Search users...')).not.toBeInTheDocument();
+  });
+
+  it('links back to the admin dashboard', () => {
+    render(<AdminUsersPage />);
+    const backLinks = screen.getAllByRole('link');
+    expect(backLinks.some((l) => l.getAttribute('href') === '/admin')).toBe(true);
+  });
+});

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -1,23 +1,68 @@
-"use client";
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  AlertCircle,
+  BarChart3,
+  Bookmark,
+  Eye,
+  Heart,
+  Layers,
+  Newspaper,
+  Radio,
+  TrendingUp,
+} from 'lucide-react'
+import {
+  getAdminStats,
+  getAdminEngagementTotals,
+  getAdminCategoryCounts,
+  type AdminStats,
+  type AdminEngagementTotals,
+  type AdminCategoryCount,
+} from '@/lib/mongodb/admin'
 
-import { useState, useEffect } from "react";
-import Link from "next/link";
-import { ArrowLeft, BarChart3, TrendingUp, Users, Eye, Clock, Loader2 } from "lucide-react";
+export const metadata = { title: 'Analytics' }
 
-export default function AdminAnalyticsPage() {
-  const [loading, setLoading] = useState(true);
+// Server Component — every number on this page is read live from MongoDB.
+export const dynamic = 'force-dynamic'
 
-  useEffect(() => {
-    setTimeout(() => setLoading(false), 500);
-  }, []);
+function StatCard({
+  icon: Icon,
+  value,
+  label,
+  tint,
+}: {
+  icon: typeof Newspaper
+  value: number
+  label: string
+  tint: string
+}) {
+  return (
+    <div className="bg-surface rounded-xl p-5 border border-elevated">
+      <Icon className={`w-6 h-6 mb-3 ${tint}`} />
+      <div className="text-2xl font-bold text-foreground">{value.toLocaleString()}</div>
+      <p className="text-sm text-text-secondary">{label}</p>
+    </div>
+  )
+}
 
-  if (loading) {
-    return (
-      <div className="min-h-[60vh] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
-      </div>
-    );
+export default async function AdminAnalyticsPage() {
+  let stats: AdminStats | null = null
+  let engagement: AdminEngagementTotals | null = null
+  let categories: AdminCategoryCount[] = []
+  let dbError = false
+
+  try {
+    ;[stats, engagement, categories] = await Promise.all([
+      getAdminStats(),
+      getAdminEngagementTotals(),
+      getAdminCategoryCounts(8),
+    ])
+  } catch (err) {
+    console.error('[ADMIN] analytics read failed', err)
+    dbError = true
   }
+
+  const maxCategory = categories[0]?.count ?? 1
 
   return (
     <div className="max-w-[1200px] mx-auto px-6 py-8">
@@ -31,76 +76,103 @@ export default function AdminAnalyticsPage() {
         </Link>
         <div>
           <h1 className="text-2xl font-bold text-foreground">Analytics</h1>
-          <p className="text-text-secondary">Platform metrics and insights</p>
+          <p className="text-text-secondary">Live platform metrics from the news database</p>
         </div>
       </div>
 
-      {/* Stats Grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div className="bg-surface rounded-xl p-5 border border-elevated">
-          <Eye className="w-6 h-6 text-blue-500 mb-3" />
-          <div className="text-2xl font-bold text-foreground">24.5K</div>
-          <p className="text-sm text-text-secondary">Page Views Today</p>
-          <div className="flex items-center gap-1 mt-2 text-green-600">
-            <TrendingUp className="w-3 h-3" />
-            <span className="text-xs font-medium">+12%</span>
+      {dbError && (
+        <div className="mb-8 flex items-center gap-3 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-warning">
+          <AlertCircle className="w-5 h-5 shrink-0" />
+          Could not reach the database. Analytics are unavailable right now.
+        </div>
+      )}
+
+      {stats && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          <StatCard
+            icon={Newspaper}
+            value={stats.totalArticles}
+            label="Total Articles"
+            tint="text-secondary"
+          />
+          <StatCard
+            icon={Radio}
+            value={stats.activeSources}
+            label="Active Sources"
+            tint="text-success"
+          />
+          <StatCard
+            icon={TrendingUp}
+            value={stats.todayArticles}
+            label="Published Today"
+            tint="text-primary"
+          />
+          <StatCard
+            icon={Layers}
+            value={stats.categories}
+            label="Curated Categories"
+            tint="text-accent"
+          />
+        </div>
+      )}
+
+      {engagement && (
+        <section className="mb-8">
+          <h2 className="text-lg font-semibold text-foreground mb-4">Engagement</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <StatCard icon={Heart} value={engagement.likes} label="Likes" tint="text-primary" />
+            <StatCard icon={Bookmark} value={engagement.saves} label="Saves" tint="text-secondary" />
+            <StatCard
+              icon={Eye}
+              value={engagement.viewEvents}
+              label="Tracked View Events"
+              tint="text-success"
+            />
           </div>
-        </div>
+          <p className="text-xs text-text-tertiary mt-2">
+            View events are deduplicated per session per day — this is not a raw page-view count.
+          </p>
+        </section>
+      )}
 
-        <div className="bg-surface rounded-xl p-5 border border-elevated">
-          <Users className="w-6 h-6 text-purple-500 mb-3" />
-          <div className="text-2xl font-bold text-foreground">1,234</div>
-          <p className="text-sm text-text-secondary">Active Users</p>
-          <div className="flex items-center gap-1 mt-2 text-green-600">
-            <TrendingUp className="w-3 h-3" />
-            <span className="text-xs font-medium">+5%</span>
-          </div>
-        </div>
-
-        <div className="bg-surface rounded-xl p-5 border border-elevated">
-          <Clock className="w-6 h-6 text-orange-500 mb-3" />
-          <div className="text-2xl font-bold text-foreground">4:32</div>
-          <p className="text-sm text-text-secondary">Avg. Session</p>
-        </div>
-
-        <div className="bg-surface rounded-xl p-5 border border-elevated">
-          <BarChart3 className="w-6 h-6 text-green-500 mb-3" />
-          <div className="text-2xl font-bold text-foreground">68%</div>
-          <p className="text-sm text-text-secondary">Engagement Rate</p>
-        </div>
-      </div>
-
-      {/* Charts Placeholder */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="bg-surface rounded-xl border border-elevated p-6">
-          <h3 className="font-semibold text-foreground mb-4">Traffic Over Time</h3>
-          <div className="h-48 flex items-center justify-center text-text-tertiary">
-            <BarChart3 className="w-12 h-12" />
-          </div>
-        </div>
-
-        <div className="bg-surface rounded-xl border border-elevated p-6">
-          <h3 className="font-semibold text-foreground mb-4">Top Categories</h3>
-          <div className="space-y-3">
-            {["Politics", "Business", "Sports", "Technology", "Entertainment"].map((cat, i) => (
-              <div key={cat} className="flex items-center gap-3">
-                <div className="flex-1">
+      {/* Top categories — live article counts */}
+      {categories.length > 0 && (
+        <section className="mb-8">
+          <div className="bg-surface rounded-xl border border-elevated p-6">
+            <h3 className="font-semibold text-foreground mb-4">Top Categories by Article Count</h3>
+            <div className="space-y-3">
+              {categories.map((cat) => (
+                <div key={cat.slug}>
                   <div className="flex justify-between text-sm mb-1">
-                    <span className="text-foreground">{cat}</span>
-                    <span className="text-text-secondary">{100 - i * 15}%</span>
+                    <span className="text-foreground">{cat.name}</span>
+                    <span className="text-text-secondary">{cat.count.toLocaleString()}</span>
                   </div>
                   <div className="h-2 bg-elevated rounded-full overflow-hidden">
                     <div
                       className="h-full bg-primary rounded-full"
-                      style={{ width: `${100 - i * 15}%` }}
+                      style={{ width: `${Math.round((cat.count / maxCategory) * 100)}%` }}
                     />
                   </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Honest placeholder for metrics with no backing data yet */}
+      <section>
+        <div className="bg-surface rounded-xl border border-elevated p-6 flex items-start gap-4">
+          <BarChart3 className="w-6 h-6 text-text-tertiary shrink-0 mt-0.5" />
+          <div>
+            <h3 className="font-semibold text-foreground mb-1">Not tracked yet</h3>
+            <p className="text-sm text-text-secondary">
+              Page views, active users, session duration, and traffic-over-time analytics are not
+              collected by the frontend yet. They will appear here once real tracking lands.
+            </p>
           </div>
         </div>
-      </div>
+      </section>
     </div>
-  );
+  )
 }

--- a/src/app/admin/system/page.tsx
+++ b/src/app/admin/system/page.tsx
@@ -1,23 +1,14 @@
-"use client";
+import Link from 'next/link'
+import { ArrowLeft, Activity, Database, Workflow } from 'lucide-react'
+import { pingDatabase } from '@/lib/mongodb/admin'
 
-import { useState, useEffect } from "react";
-import Link from "next/link";
-import { ArrowLeft, Settings, Server, Database, Clock, RefreshCw, Check, Loader2 } from "lucide-react";
+export const metadata = { title: 'System' }
 
-export default function AdminSystemPage() {
-  const [loading, setLoading] = useState(true);
+// Server Component — the database status is a real ping, checked on every load.
+export const dynamic = 'force-dynamic'
 
-  useEffect(() => {
-    setTimeout(() => setLoading(false), 500);
-  }, []);
-
-  if (loading) {
-    return (
-      <div className="min-h-[60vh] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
-      </div>
-    );
-  }
+export default async function AdminSystemPage() {
+  const dbPing = await pingDatabase()
 
   return (
     <div className="max-w-[1200px] mx-auto px-6 py-8">
@@ -30,108 +21,70 @@ export default function AdminSystemPage() {
           <ArrowLeft className="w-5 h-5" />
         </Link>
         <div>
-          <h1 className="text-2xl font-bold text-foreground">System Settings</h1>
-          <p className="text-text-secondary">Platform configuration and status</p>
+          <h1 className="text-2xl font-bold text-foreground">System</h1>
+          <p className="text-text-secondary">Live status — checked on page load</p>
         </div>
       </div>
 
       {/* System Status */}
       <section className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4">System Status</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <h2 className="text-lg font-semibold text-foreground mb-4">Status</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="bg-surface rounded-xl border border-elevated p-5">
             <div className="flex items-center gap-3 mb-3">
-              <Server className="w-6 h-6 text-green-500" />
-              <span className="font-medium text-foreground">API Server</span>
+              <Database
+                className={`w-6 h-6 ${dbPing.ok ? 'text-success' : 'text-warning'}`}
+              />
+              <span className="font-medium text-foreground">MongoDB Atlas</span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              <span className="text-sm text-text-secondary">Operational</span>
+              <div
+                className={`w-2 h-2 rounded-full ${dbPing.ok ? 'bg-success' : 'bg-warning'}`}
+              />
+              <span className="text-sm text-text-secondary">
+                {dbPing.ok
+                  ? `Connected${dbPing.latencyMs !== null ? ` — ping ${dbPing.latencyMs} ms` : ''}`
+                  : 'Unreachable'}
+              </span>
             </div>
           </div>
 
           <div className="bg-surface rounded-xl border border-elevated p-5">
             <div className="flex items-center gap-3 mb-3">
-              <Database className="w-6 h-6 text-green-500" />
-              <span className="font-medium text-foreground">Database</span>
+              <Activity className="w-6 h-6 text-secondary" />
+              <span className="font-medium text-foreground">Health Probe</span>
             </div>
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              <span className="text-sm text-text-secondary">Connected</span>
-            </div>
-          </div>
-
-          <div className="bg-surface rounded-xl border border-elevated p-5">
-            <div className="flex items-center gap-3 mb-3">
-              <Clock className="w-6 h-6 text-blue-500" />
-              <span className="font-medium text-foreground">RSS Scheduler</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-              <span className="text-sm text-text-secondary">Running</span>
-            </div>
+            <p className="text-sm text-text-secondary">
+              <a
+                href="/api/health"
+                className="text-secondary underline underline-offset-2"
+                target="_blank"
+                rel="noreferrer"
+              >
+                /api/health
+              </a>{' '}
+              returns this app&apos;s live status (database ping + article stats) as JSON.
+            </p>
           </div>
         </div>
       </section>
 
-      {/* Configuration */}
-      <section className="mb-8">
-        <h2 className="text-lg font-semibold text-foreground mb-4">Configuration</h2>
-        <div className="bg-surface rounded-xl border border-elevated divide-y divide-elevated">
-          <div className="flex items-center justify-between p-5">
-            <div>
-              <p className="font-medium text-foreground">RSS Sync Interval</p>
-              <p className="text-sm text-text-secondary">How often to fetch new articles</p>
-            </div>
-            <select className="px-4 py-2 bg-elevated rounded-lg text-foreground border-none outline-none">
-              <option>Every 5 minutes</option>
-              <option>Every 15 minutes</option>
-              <option>Every 30 minutes</option>
-              <option>Every hour</option>
-            </select>
-          </div>
-
-          <div className="flex items-center justify-between p-5">
-            <div>
-              <p className="font-medium text-foreground">Article Retention</p>
-              <p className="text-sm text-text-secondary">How long to keep old articles</p>
-            </div>
-            <select className="px-4 py-2 bg-elevated rounded-lg text-foreground border-none outline-none">
-              <option>30 days</option>
-              <option>60 days</option>
-              <option>90 days</option>
-              <option>Forever</option>
-            </select>
-          </div>
-
-          <div className="flex items-center justify-between p-5">
-            <div>
-              <p className="font-medium text-foreground">Cache TTL</p>
-              <p className="text-sm text-text-secondary">API response cache duration</p>
-            </div>
-            <select className="px-4 py-2 bg-elevated rounded-lg text-foreground border-none outline-none">
-              <option>5 minutes</option>
-              <option>15 minutes</option>
-              <option>30 minutes</option>
-            </select>
-          </div>
-        </div>
-      </section>
-
-      {/* Actions */}
+      {/* Pipeline — honest boundary note, no fabricated status */}
       <section>
-        <h2 className="text-lg font-semibold text-foreground mb-4">Actions</h2>
-        <div className="flex flex-wrap gap-3">
-          <button className="flex items-center gap-2 px-4 py-2.5 bg-primary text-on-primary rounded-xl font-medium hover:opacity-90">
-            <RefreshCw className="w-4 h-4" />
-            Clear Cache
-          </button>
-          <button className="flex items-center gap-2 px-4 py-2.5 bg-surface border border-elevated text-foreground rounded-xl font-medium hover:bg-elevated">
-            <Database className="w-4 h-4" />
-            Rebuild Indexes
-          </button>
+        <h2 className="text-lg font-semibold text-foreground mb-4">Pipeline</h2>
+        <div className="bg-surface rounded-xl border border-elevated p-5 flex items-start gap-4">
+          <Workflow className="w-6 h-6 text-text-tertiary shrink-0 mt-0.5" />
+          <div>
+            <p className="font-medium text-foreground mb-1">Ingestion &amp; enrichment</p>
+            <p className="text-sm text-text-secondary">
+              RSS collection and AI enrichment run in the <code>mukoko-news-pipeline</code> repo
+              (Fly.io + Cloudflare Workers). Their status is not monitored from this frontend, so
+              no status is shown here. Sync intervals and retention are configured in the
+              pipeline repo, not here.
+            </p>
+          </div>
         </div>
       </section>
     </div>
-  );
+  )
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,59 +1,12 @@
-"use client";
+import Link from 'next/link'
+import { ArrowLeft, Users } from 'lucide-react'
 
-import { useState, useEffect } from "react";
-import Link from "next/link";
-import { ArrowLeft, Users, Search, MoreVertical, Shield, Loader2 } from "lucide-react";
+export const metadata = { title: 'Users' }
 
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: "admin" | "user" | "moderator";
-  status: "active" | "inactive";
-  joinedAt: string;
-}
-
-const mockUsers: User[] = [
-  { id: "1", name: "Admin User", email: "admin@mukoko.com", role: "admin", status: "active", joinedAt: "Jan 2024" },
-  { id: "2", name: "John Doe", email: "john@example.com", role: "user", status: "active", joinedAt: "Mar 2024" },
-  { id: "3", name: "Jane Smith", email: "jane@example.com", role: "moderator", status: "active", joinedAt: "Feb 2024" },
-  { id: "4", name: "Bob Wilson", email: "bob@example.com", role: "user", status: "inactive", joinedAt: "Dec 2023" },
-];
-
+// Server Component — there is no user directory wired up yet, so this page
+// shows an honest empty state instead of fabricated users. RBAC gating lives
+// in src/app/admin/layout.tsx and is unchanged.
 export default function AdminUsersPage() {
-  const [users, setUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [search, setSearch] = useState("");
-
-  useEffect(() => {
-    setTimeout(() => {
-      setUsers(mockUsers);
-      setLoading(false);
-    }, 500);
-  }, []);
-
-  const getRoleBadgeColor = (role: User["role"]) => {
-    switch (role) {
-      case "admin": return "bg-red-500/10 text-red-500";
-      case "moderator": return "bg-blue-500/10 text-blue-500";
-      default: return "bg-gray-500/10 text-gray-500";
-    }
-  };
-
-  const filteredUsers = users.filter(
-    (u) =>
-      u.name.toLowerCase().includes(search.toLowerCase()) ||
-      u.email.toLowerCase().includes(search.toLowerCase())
-  );
-
-  if (loading) {
-    return (
-      <div className="min-h-[60vh] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
-      </div>
-    );
-  }
-
   return (
     <div className="max-w-[1200px] mx-auto px-6 py-8">
       {/* Header */}
@@ -64,74 +17,23 @@ export default function AdminUsersPage() {
         >
           <ArrowLeft className="w-5 h-5" />
         </Link>
-        <div className="flex-1">
+        <div>
           <h1 className="text-2xl font-bold text-foreground">Users</h1>
-          <p className="text-text-secondary">{users.length} registered users</p>
+          <p className="text-text-secondary">Platform user management</p>
         </div>
       </div>
 
-      {/* Search */}
-      <div className="relative mb-6">
-        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-tertiary" />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search users..."
-          className="w-full pl-12 pr-4 py-3 bg-surface rounded-xl border border-elevated text-foreground placeholder:text-text-tertiary focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none"
-        />
-      </div>
-
-      {/* Users Table */}
-      <div className="bg-surface rounded-xl border border-elevated overflow-hidden">
-        <table className="w-full">
-          <thead className="bg-elevated/50">
-            <tr>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-text-secondary">User</th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-text-secondary">Role</th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-text-secondary">Status</th>
-              <th className="text-left px-4 py-3 text-sm font-semibold text-text-secondary">Joined</th>
-              <th className="text-right px-4 py-3 text-sm font-semibold text-text-secondary">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-elevated">
-            {filteredUsers.map((user) => (
-              <tr key={user.id} className="hover:bg-elevated/30 transition-colors">
-                <td className="px-4 py-4">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
-                      <span className="font-semibold text-primary">
-                        {user.name.charAt(0)}
-                      </span>
-                    </div>
-                    <div>
-                      <p className="font-medium text-foreground">{user.name}</p>
-                      <p className="text-xs text-text-tertiary">{user.email}</p>
-                    </div>
-                  </div>
-                </td>
-                <td className="px-4 py-4">
-                  <span className={`px-2.5 py-1 rounded-full text-xs font-medium capitalize ${getRoleBadgeColor(user.role)}`}>
-                    {user.role}
-                  </span>
-                </td>
-                <td className="px-4 py-4">
-                  <div className="flex items-center gap-2">
-                    <div className={`w-2 h-2 rounded-full ${user.status === "active" ? "bg-green-500" : "bg-gray-400"}`} />
-                    <span className="text-sm capitalize">{user.status}</span>
-                  </div>
-                </td>
-                <td className="px-4 py-4 text-sm text-text-secondary">{user.joinedAt}</td>
-                <td className="px-4 py-4 text-right">
-                  <button className="p-2 hover:bg-elevated rounded-lg transition-colors">
-                    <MoreVertical className="w-4 h-4 text-text-secondary" />
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {/* Honest empty state — no user data source is wired up yet */}
+      <div className="bg-surface rounded-xl border border-elevated p-12 flex flex-col items-center text-center">
+        <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center mb-4">
+          <Users className="w-7 h-7 text-primary" />
+        </div>
+        <h2 className="text-lg font-semibold text-foreground mb-2">Coming soon</h2>
+        <p className="text-sm text-text-secondary max-w-md">
+          User management arrives with the WorkOS directory sync — coming soon. Until then, roles
+          and org membership are managed directly in the WorkOS dashboard.
+        </p>
       </div>
     </div>
-  );
+  )
 }

--- a/src/app/analytics/__tests__/analytics-page.test.tsx
+++ b/src/app/analytics/__tests__/analytics-page.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AnalyticsPage from '../page';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Pages read via Server Actions — mock @/lib/actions/feed (NOT @/lib/api).
+const mockGetStatsAction = vi.fn();
+const mockGetTrendingCategoriesAction = vi.fn();
+const mockGetSourcesAction = vi.fn();
+vi.mock('@/lib/actions/feed', () => ({
+  getStatsAction: (...args: unknown[]) => mockGetStatsAction(...args),
+  getTrendingCategoriesAction: (...args: unknown[]) => mockGetTrendingCategoriesAction(...args),
+  getSourcesAction: (...args: unknown[]) => mockGetSourcesAction(...args),
+}));
+
+const defaultStats = {
+  database: {
+    total_articles: 12345,
+    active_sources: 87,
+    categories: 14,
+    today_articles: 231,
+  },
+};
+
+const defaultTrending = [
+  { id: 'politics', name: 'Politics', slug: 'politics', article_count: 420 },
+  { id: 'business', name: 'Business', slug: 'business', article_count: 300 },
+  { id: 'sports', name: 'Sports', slug: 'sports', article_count: 150 },
+];
+
+const defaultSources = [
+  { id: 's1', name: 'The Herald', url: 'https://herald.co.zw/feed', country_id: 'ZW', article_count: 500 },
+  { id: 's2', name: 'Chronicle', url: 'https://chronicle.co.zw/feed', country_id: 'ZW', article_count: 250 },
+  { id: 's3', name: 'Daily Maverick', url: 'https://dailymaverick.co.za/rss', country_id: 'ZA', article_count: 600 },
+  { id: 's4', name: 'Dead Source', url: 'https://dead.example.com/rss', country_id: 'KE', article_count: 0 },
+];
+
+describe('AnalyticsPage (public)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetStatsAction.mockResolvedValue(defaultStats);
+    mockGetTrendingCategoriesAction.mockResolvedValue(defaultTrending);
+    mockGetSourcesAction.mockResolvedValue(defaultSources);
+  });
+
+  it('renders header and real stats from getStatsAction', async () => {
+    render(await AnalyticsPage());
+    expect(screen.getByText('Open Analytics')).toBeInTheDocument();
+    expect(screen.getByText('12,345')).toBeInTheDocument(); // articles
+    expect(screen.getByText('87')).toBeInTheDocument(); // active sources
+    expect(screen.getByText('14')).toBeInTheDocument(); // categories
+    expect(screen.getByText('231')).toBeInTheDocument(); // published today
+  });
+
+  it('renders trending categories from getTrendingCategoriesAction', async () => {
+    render(await AnalyticsPage());
+    expect(screen.getByText('Trending Categories')).toBeInTheDocument();
+    // Politics appears in the trending grid and the category breakdown
+    expect(screen.getAllByText('Politics').length).toBeGreaterThan(0);
+    expect(screen.getByText('420 articles')).toBeInTheDocument();
+  });
+
+  it('links trending categories to search', async () => {
+    render(await AnalyticsPage());
+    const link = screen.getByText('420 articles').closest('a');
+    expect(link).toHaveAttribute('href', '/search?q=Politics');
+  });
+
+  it('aggregates the country breakdown from source article counts', async () => {
+    render(await AnalyticsPage());
+    expect(screen.getByText('By Country')).toBeInTheDocument();
+    expect(screen.getByText('Zimbabwe')).toBeInTheDocument(); // 500 + 250
+    expect(screen.getByText('750')).toBeInTheDocument();
+    expect(screen.getByText('South Africa')).toBeInTheDocument();
+    // Zero-count countries are omitted
+    expect(screen.queryByText('Kenya')).not.toBeInTheDocument();
+  });
+
+  it('renders an error state instead of fabricated data when actions fail', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetStatsAction.mockRejectedValue(new Error('db down'));
+    render(await AnalyticsPage());
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Unable to load analytics right now. Please try again later.'
+    );
+    expect(screen.queryByText('Trending Categories')).not.toBeInTheDocument();
+    expect(screen.queryByText('By Country')).not.toBeInTheDocument();
+    consoleSpy.mockRestore();
+  });
+
+  it('does not reference the removed /api/analytics endpoint', async () => {
+    const { container } = render(await AnalyticsPage());
+    expect(container.textContent).not.toContain('/api/analytics');
+  });
+});

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,160 +1,110 @@
-"use client";
-
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import Link from 'next/link'
+import { AlertCircle, Globe, Layers, Newspaper, Radio, TrendingUp } from 'lucide-react'
 import {
-  TrendingUp,
-  Zap,
-  Globe,
-  Layers,
-  Newspaper,
-  Radio,
-  RefreshCw,
-  Loader2,
-} from "lucide-react";
+  getStatsAction,
+  getTrendingCategoriesAction,
+  getSourcesAction,
+} from '@/lib/actions/feed'
+import { COUNTRIES, getCategoryEmoji } from '@/lib/constants'
 
-const COUNTRY_NAMES: Record<string, string> = {
-  ZW: "Zimbabwe",
-  KE: "Kenya",
-  ZA: "South Africa",
-  NG: "Nigeria",
-  GH: "Ghana",
-  EG: "Egypt",
-  ET: "Ethiopia",
-  TZ: "Tanzania",
-  UG: "Uganda",
-  RW: "Rwanda",
-  SN: "Senegal",
-  CI: "Côte d'Ivoire",
-  CM: "Cameroon",
-  MA: "Morocco",
-  TN: "Tunisia",
-  AO: "Angola",
-};
+export const metadata = { title: 'Open Analytics' }
 
-const CATEGORY_EMOJIS: Record<string, string> = {
-  politics: "🏛️",
-  business: "💼",
-  sports: "⚽",
-  entertainment: "🎬",
-  technology: "💻",
-  health: "🏥",
-  world: "🌍",
-  local: "📍",
-  opinion: "💭",
-  breaking: "⚡",
-  crime: "🚨",
-  education: "📚",
-  environment: "🌱",
-  lifestyle: "✨",
-  agriculture: "🌾",
-  mining: "⛏️",
-  tourism: "✈️",
-  finance: "💰",
-  culture: "🎭",
-};
+// Server Component — reads via Server Actions → MongoDB (news DB), the same
+// path every other page uses. No client fetch, no phantom API route.
+export const dynamic = 'force-dynamic'
 
-const getEmoji = (cat: string) => CATEGORY_EMOJIS[cat?.toLowerCase()] ?? "📰";
-
-interface TrendingTopic {
-  tag_id: string;
-  name: string;
-  slug: string;
-  count: number;
+interface TrendingCategory {
+  id: string
+  name: string
+  slug: string
+  article_count: number
 }
 
-interface SurgeAlert {
-  tag: string;
-  recent_24h: number;
-  daily_avg: number;
-  multiplier: number;
+interface CountryCount {
+  country: string
+  count: number
 }
 
-interface CountryItem {
-  country: string;
-  count: number;
-}
+const COUNTRY_NAMES = new Map<string, string>(COUNTRIES.map((c) => [c.code, c.name]))
 
-interface CategoryItem {
-  category: string;
-  count: number;
-}
+export default async function AnalyticsPage() {
+  let stats: Awaited<ReturnType<typeof getStatsAction>> | null = null
+  let trending: TrendingCategory[] = []
+  let countryBreakdown: CountryCount[] = []
+  let loadError = false
 
-interface AnalyticsData {
-  meta: { generated_at: string; total_articles: number; active_sources: number };
-  trending_topics: TrendingTopic[];
-  surge_alerts: SurgeAlert[];
-  country_breakdown: CountryItem[];
-  category_breakdown: CategoryItem[];
-}
+  try {
+    const [statsResult, trendingResult, sources] = await Promise.all([
+      getStatsAction(),
+      getTrendingCategoriesAction(12),
+      getSourcesAction(),
+    ])
+    stats = statsResult
+    trending = trendingResult
 
-export default function AnalyticsPage() {
-  const [data, setData] = useState<AnalyticsData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-
-  const load = useCallback(async (isRefresh = false) => {
-    if (isRefresh) setRefreshing(true);
-    else setLoading(true);
-    try {
-      const res = await fetch("/api/analytics");
-      if (res.ok) setData(await res.json());
-    } catch {
-      // analytics are best-effort
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
+    // Articles per country, aggregated from each active source's article count.
+    const byCountry = new Map<string, number>()
+    for (const source of sources) {
+      if (!source.country_id) continue
+      byCountry.set(source.country_id, (byCountry.get(source.country_id) ?? 0) + (source.article_count ?? 0))
     }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  if (loading) {
-    return (
-      <div className="min-h-[60vh] flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
-      </div>
-    );
+    countryBreakdown = [...byCountry.entries()]
+      .map(([country, count]) => ({ country, count }))
+      .filter(({ count }) => count > 0)
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 12)
+  } catch (err) {
+    console.error('[/analytics] load failed', err)
+    loadError = true
   }
 
-  const maxCountry = data?.country_breakdown[0]?.count ?? 1;
-  const maxCategory = data?.category_breakdown[0]?.count ?? 1;
+  const maxCountry = countryBreakdown[0]?.count ?? 1
+  const maxCategory = trending[0]?.article_count ?? 1
 
   return (
     <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-8 space-y-10">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold text-foreground mb-1">Open Analytics</h1>
-          <p className="text-text-secondary text-sm">
-            Real-time data across African news — no paywall, no account required.
-          </p>
-          {data && (
-            <p className="text-xs text-text-tertiary mt-1">
-              Updated {new Date(data.meta.generated_at).toLocaleTimeString()}
-            </p>
-          )}
-        </div>
-        <button
-          onClick={() => load(true)}
-          disabled={refreshing}
-          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-surface border border-elevated text-sm text-foreground hover:border-primary/50 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} />
-          Refresh
-        </button>
+      <div>
+        <h1 className="text-3xl font-bold text-foreground mb-1">Open Analytics</h1>
+        <p className="text-text-secondary text-sm">
+          Live data across African news — no paywall, no account required.
+        </p>
       </div>
 
+      {loadError && (
+        <div
+          role="alert"
+          className="flex items-center gap-3 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3 text-sm text-warning"
+        >
+          <AlertCircle className="w-5 h-5 shrink-0" />
+          Unable to load analytics right now. Please try again later.
+        </div>
+      )}
+
       {/* Stats row */}
-      {data && (
+      {stats && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           {[
-            { icon: <Newspaper className="w-5 h-5" />, label: "Articles", value: data.meta.total_articles.toLocaleString() },
-            { icon: <Radio className="w-5 h-5" />, label: "Active Sources", value: data.meta.active_sources.toLocaleString() },
-            { icon: <TrendingUp className="w-5 h-5" />, label: "Trending Topics", value: data.trending_topics.length },
-            { icon: <Zap className="w-5 h-5" />, label: "Surge Alerts", value: data.surge_alerts.length },
+            {
+              icon: <Newspaper className="w-5 h-5" />,
+              label: 'Articles',
+              value: stats.database.total_articles.toLocaleString(),
+            },
+            {
+              icon: <Radio className="w-5 h-5" />,
+              label: 'Active Sources',
+              value: stats.database.active_sources.toLocaleString(),
+            },
+            {
+              icon: <Layers className="w-5 h-5" />,
+              label: 'Categories',
+              value: stats.database.categories.toLocaleString(),
+            },
+            {
+              icon: <TrendingUp className="w-5 h-5" />,
+              label: 'Published Today',
+              value: stats.database.today_articles.toLocaleString(),
+            },
           ].map(({ icon, label, value }) => (
             <div key={label} className="bg-surface rounded-2xl p-5 border border-elevated">
               <div className="text-primary mb-2">{icon}</div>
@@ -165,55 +115,21 @@ export default function AnalyticsPage() {
         </div>
       )}
 
-      {/* Surge Alerts */}
-      {data && data.surge_alerts.length > 0 && (
+      {/* Trending categories */}
+      {trending.length > 0 && (
         <section>
           <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2">
-            <Zap className="w-5 h-5 text-amber-500" /> Surge Alerts
-            <span className="ml-2 text-xs font-normal text-text-secondary">
-              Topics with 2× higher volume in the last 24 h
-            </span>
-          </h2>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {data.surge_alerts.map((s) => (
-              <div
-                key={s.tag}
-                className="flex items-center gap-4 bg-surface rounded-xl p-4 border border-elevated"
-              >
-                <div className="w-10 h-10 rounded-full bg-amber-500/10 flex items-center justify-center flex-shrink-0">
-                  <Zap className="w-5 h-5 text-amber-500" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <p className="font-semibold text-foreground truncate">{s.tag}</p>
-                  <p className="text-xs text-text-secondary">
-                    {s.recent_24h} articles in 24 h · avg {s.daily_avg}/day
-                  </p>
-                </div>
-                <div className="text-right flex-shrink-0">
-                  <span className="text-lg font-bold text-amber-500">{s.multiplier}×</span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Trending Topics */}
-      {data && data.trending_topics.length > 0 && (
-        <section>
-          <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2">
-            <TrendingUp className="w-5 h-5 text-primary" /> Trending Topics
-            <span className="ml-2 text-xs font-normal text-text-secondary">Last 7 days</span>
+            <TrendingUp className="w-5 h-5 text-primary" /> Trending Categories
           </h2>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            {data.trending_topics.slice(0, 12).map((t, i) => (
+            {trending.map((t, i) => (
               <Link
-                key={t.tag_id}
+                key={t.id}
                 href={`/search?q=${encodeURIComponent(t.name)}`}
                 className="bg-surface rounded-xl p-4 border border-elevated hover:border-primary/50 transition-colors"
               >
                 <div className="flex justify-between items-start mb-2">
-                  <span className="text-2xl">{getEmoji(t.name)}</span>
+                  <span className="text-2xl">{getCategoryEmoji(t.slug)}</span>
                   {i < 3 && (
                     <span className="w-6 h-6 rounded-full bg-primary text-on-primary text-xs font-bold flex items-center justify-center">
                       {i + 1}
@@ -221,7 +137,9 @@ export default function AnalyticsPage() {
                   )}
                 </div>
                 <p className="font-semibold text-foreground truncate text-sm">{t.name}</p>
-                <p className="text-xs text-text-secondary mt-1">{t.count} articles</p>
+                <p className="text-xs text-text-secondary mt-1">
+                  {t.article_count.toLocaleString()} articles
+                </p>
               </Link>
             ))}
           </div>
@@ -231,18 +149,20 @@ export default function AnalyticsPage() {
       {/* Two-column: Country + Category */}
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Country breakdown */}
-        {data && data.country_breakdown.length > 0 && (
+        {countryBreakdown.length > 0 && (
           <section className="bg-surface rounded-2xl border border-elevated p-6">
-            <h2 className="text-lg font-bold text-foreground mb-5 flex items-center gap-2">
+            <h2 className="text-lg font-bold text-foreground mb-1 flex items-center gap-2">
               <Globe className="w-5 h-5 text-primary" /> By Country
-              <span className="ml-2 text-xs font-normal text-text-secondary">30 days</span>
             </h2>
+            <p className="text-xs text-text-tertiary mb-5">
+              Articles aggregated per source country
+            </p>
             <div className="space-y-3">
-              {data.country_breakdown.map(({ country, count }) => (
+              {countryBreakdown.map(({ country, count }) => (
                 <div key={country}>
                   <div className="flex justify-between text-sm mb-1">
                     <span className="text-foreground font-medium">
-                      {COUNTRY_NAMES[country] ?? country}
+                      {COUNTRY_NAMES.get(country) ?? country}
                     </span>
                     <span className="text-text-secondary">{count.toLocaleString()}</span>
                   </div>
@@ -259,25 +179,25 @@ export default function AnalyticsPage() {
         )}
 
         {/* Category breakdown */}
-        {data && data.category_breakdown.length > 0 && (
+        {trending.length > 0 && (
           <section className="bg-surface rounded-2xl border border-elevated p-6">
-            <h2 className="text-lg font-bold text-foreground mb-5 flex items-center gap-2">
+            <h2 className="text-lg font-bold text-foreground mb-1 flex items-center gap-2">
               <Layers className="w-5 h-5 text-primary" /> By Category
-              <span className="ml-2 text-xs font-normal text-text-secondary">30 days</span>
             </h2>
+            <p className="text-xs text-text-tertiary mb-5">Article counts per category</p>
             <div className="space-y-3">
-              {data.category_breakdown.map(({ category, count }) => (
-                <div key={category}>
+              {trending.slice(0, 8).map(({ slug, name, article_count }) => (
+                <div key={slug}>
                   <div className="flex justify-between text-sm mb-1">
                     <span className="text-foreground font-medium flex items-center gap-1">
-                      {getEmoji(category)} {category}
+                      {getCategoryEmoji(slug)} {name}
                     </span>
-                    <span className="text-text-secondary">{count.toLocaleString()}</span>
+                    <span className="text-text-secondary">{article_count.toLocaleString()}</span>
                   </div>
                   <div className="h-2 bg-elevated rounded-full overflow-hidden">
                     <div
                       className="h-full bg-secondary rounded-full transition-all"
-                      style={{ width: `${Math.round((count / maxCategory) * 100)}%` }}
+                      style={{ width: `${Math.round((article_count / maxCategory) * 100)}%` }}
                     />
                   </div>
                 </div>
@@ -290,20 +210,19 @@ export default function AnalyticsPage() {
       {/* Open data notice */}
       <div className="bg-primary/5 border border-primary/20 rounded-2xl p-6 text-center">
         <p className="text-sm text-text-secondary">
-          Mukoko News operates under an{" "}
-          <strong className="text-foreground">open data policy</strong> — these analytics
-          are freely available to journalists, researchers, and the public.
-          Access programmatically at{" "}
-          <code className="bg-surface px-1.5 py-0.5 rounded text-xs font-mono">
-            /api/analytics
-          </code>{" "}
-          or via our{" "}
-          <Link href="https://news.mukoko.dev/mcp" className="text-primary underline underline-offset-2">
+          Mukoko News operates under an{' '}
+          <strong className="text-foreground">open data policy</strong> — these analytics are
+          freely available to journalists, researchers, and the public. Access programmatically
+          via our{' '}
+          <Link
+            href="https://news.mukoko.dev/mcp"
+            className="text-primary underline underline-offset-2"
+          >
             MCP server
           </Link>
           .
         </p>
       </div>
     </div>
-  );
+  )
 }

--- a/src/lib/mongodb/admin.ts
+++ b/src/lib/mongodb/admin.ts
@@ -69,6 +69,23 @@ interface MongoArticle {
   datePublished?: Date
 }
 
+export interface AdminEngagementTotals {
+  likes: number
+  saves: number
+  viewEvents: number
+}
+
+export interface AdminCategoryCount {
+  slug: string
+  name: string
+  count: number
+}
+
+export interface AdminDbPing {
+  ok: boolean
+  latencyMs: number | null
+}
+
 /** Aggregate counts for the dashboard. */
 export async function getAdminStats(): Promise<AdminStats> {
   const db = await getDb()
@@ -89,6 +106,69 @@ export async function getAdminStats(): Promise<AdminStats> {
     ])
 
   return { totalArticles, activeSources, categories, todayArticles, pendingArticles }
+}
+
+/**
+ * Totals from the engagement event collections the like/view/save
+ * Route Handlers write (`articleLikes`, `articleSaves`, `articleViews`).
+ * Views are deduplicated per session per day by the Route Handler, so
+ * `viewEvents` counts tracked view events — not raw page loads.
+ */
+export async function getAdminEngagementTotals(): Promise<AdminEngagementTotals> {
+  const db = await getDb()
+  const [likes, saves, viewEvents] = await Promise.all([
+    db.collection('articleLikes').countDocuments({}),
+    db.collection('articleSaves').countDocuments({}),
+    db.collection('articleViews').countDocuments({}),
+  ])
+  return { likes, saves, viewEvents }
+}
+
+/** Title-case a category slug for display ("arts-culture" → "Arts Culture"). */
+function slugToName(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+/**
+ * Live per-category article counts from the AI-classified
+ * `engagement.interest_categories` slugs — the same field the public feed reads.
+ */
+export async function getAdminCategoryCounts(limit = 8): Promise<AdminCategoryCount[]> {
+  const db = await getDb()
+  const rows = await db
+    .collection('articles')
+    .aggregate<{ _id: string; count: number }>([
+      { $match: { status: { $ne: 'rejected' }, moderationStatus: { $ne: 'removed' } } },
+      { $unwind: '$engagement.interest_categories' },
+      { $group: { _id: '$engagement.interest_categories', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+      { $limit: limit },
+    ])
+    .toArray()
+
+  return rows
+    .filter((r) => typeof r._id === 'string' && r._id.trim().length > 0)
+    .map((r) => {
+      const slug = r._id.trim()
+      return { slug, name: slugToName(slug), count: r.count }
+    })
+}
+
+/** Cheap MongoDB reachability probe for the system page. Never throws. */
+export async function pingDatabase(): Promise<AdminDbPing> {
+  try {
+    const db = await getDb()
+    const start = Date.now()
+    await db.command({ ping: 1 })
+    return { ok: true, latencyMs: Date.now() - start }
+  } catch (err) {
+    console.error('[ADMIN] db ping failed', err)
+    return { ok: false, latencyMs: null }
+  }
 }
 
 /** All feed sources, most-productive first. */


### PR DESCRIPTION
## Summary

Audit found four pages rendering fabricated data (hardcoded KPIs, mock users, fake statuses) or silently-blank data (a fetch to a nonexistent `/api/analytics` with an empty catch). Every number is now a real read from the `news` DB or an honest empty state — no invented values anywhere.

> **Note:** this branch is based on `claude/harness-quiet-prod` (#132). Until #132 merges, its commits appear in this diff; after it merges, this PR shows only its own commit.

## Changes

### `src/lib/mongodb/admin.ts` — new read helpers (news DB, existing collections only)
- `getAdminEngagementTotals()` — counts from `articleLikes` / `articleSaves` / `articleViews` (the collections the engagement Route Handlers already write)
- `getAdminCategoryCounts(limit)` — live per-category article counts from `engagement.interest_categories` (the same field the public feed reads)
- `pingDatabase()` — cheap `{ ping: 1 }` reachability probe with latency, never throws

### `/admin/analytics` — was hardcoded 24.5K views / 1,234 users / 68% engagement
Now an async server component (no `'use client'`, no fake `setTimeout` loading): real total articles, active sources, published today, curated categories, likes/saves/tracked-view-event totals, and a real top-categories bar list. Page views / active users / session duration are **not tracked** — they get an explicit "Not tracked yet" card instead of numbers.

### `/admin/system` — was fake "Operational/Connected/Running" + dead selects
Now a server component showing a **real MongoDB ping** (Connected + latency, or Unreachable) and a link to the real `/api/health` probe. The fabricated API-server/RSS-scheduler badges, dead config selects (sync interval, retention, cache TTL), and dead "Clear Cache"/"Rebuild Indexes" buttons are removed; pipeline status is honestly described as not monitored from this frontend (it lives in `mukoko-news-pipeline`).

### `/admin/users` — was `mockUsers` behind the RBAC gate
Mock users, fake search, and fake table stripped. Honest empty state: "User management arrives with the WorkOS directory sync — coming soon." No gateway users endpoint built (separate repo, pending decision). RBAC gating in `src/app/admin/layout.tsx` untouched.

### Public `/analytics` — fetched nonexistent `/api/analytics`, swallowed the 404
Repointed to Server Actions per the repo's data-flow rules (`getStatsAction`, `getTrendingCategoriesAction`, `getSourcesAction` → `news` DB) as an async server component. The silent empty catch is gone — failures render a visible `role="alert"` error state. Surge alerts (no backing data) removed; country breakdown is aggregated from real per-source article counts; the footer no longer advertises the nonexistent `/api/analytics` endpoint.

## Tests

- 4 new test files, 19 new tests: real-data rendering, error states, and explicit assertions that the old fabricated values (24.5K, 68%, mock users, "Operational") are gone
- Admin pages mock `@/lib/mongodb/admin`; the public page mocks `@/lib/actions/feed` per the established pattern
- `vitest run`: **474 passed (25 files)** · `typecheck` ✅ · `lint` ✅ · `build` ✅ · no lockfile changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_