### PR TITLE
feat(pwa): hand-rolled service worker, offline page, and update flow

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Mukoko News - Pan-African News Hub",
-  "short_name": "Mukoko News",
+  "name": "mukoko news",
+  "short_name": "mukoko",
   "description": "Pan-African digital news aggregation platform. Breaking news, top stories, and in-depth coverage from Zimbabwe, South Africa, Kenya, Nigeria, and 12 more African countries.",
   "start_url": "/",
   "display": "standalone",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,257 @@
+/**
+ * Mukoko News service worker.
+ *
+ * Registered by src/components/pwa/sw-register.tsx as /sw.js?v=<build id>, so
+ * every deploy produces a new script URL → the browser installs a fresh worker
+ * and `activate` prunes the previous version's caches. The version is read
+ * from the registration URL's `v` query param (no build step needed).
+ *
+ * Strategy summary (see src/lib/pwa/sw-policy.ts for the tested policy):
+ *   /_next/static/*            cache-first (immutable hashed chunks)
+ *   navigations (all pages)    network-first → cache → /offline fallback;
+ *                              /article/{id} goes to a larger dedicated cache
+ *                              (the offline-articles promise in the /help FAQ)
+ *   assets.mukoko.com/i/*      stale-while-revalidate, capped at ~150 entries
+ *   NEVER handled              non-GET, Authorization-bearing requests,
+ *                              /api/*, /auth/*, /admin*, /sign-in, /mcp,
+ *                              other origins, subresource fetches (RSC etc.)
+ *
+ * Update flow: install does NOT call skipWaiting — the page shows an
+ * "Update available" banner and posts {type:'SKIP_WAITING'} when the user
+ * accepts; the client reloads once on controllerchange.
+ */
+
+/* eslint-env serviceworker */
+
+const VERSION = new URL(self.location.href).searchParams.get('v') || 'dev';
+const PREFIX = 'mukoko-';
+
+const CACHE_NAMES = {
+  precache: `${PREFIX}precache-${VERSION}`,
+  static: `${PREFIX}static-${VERSION}`,
+  pages: `${PREFIX}pages-${VERSION}`,
+  articles: `${PREFIX}articles-${VERSION}`,
+  images: `${PREFIX}images-${VERSION}`,
+};
+
+/** Trim-on-put caps (LRU-ish: oldest inserted entries are evicted first). */
+const MAX_ENTRIES = {
+  [CACHE_NAMES.pages]: 60,
+  [CACHE_NAMES.articles]: 150,
+  [CACHE_NAMES.images]: 150,
+};
+
+const OFFLINE_URL = '/offline';
+
+/**
+ * Small, stable-URL assets only. Next's hashed chunks are NOT precached —
+ * they are runtime-cached (cache-first) as the app requests them.
+ */
+const PRECACHE_URLS = [
+  OFFLINE_URL,
+  '/manifest.json',
+  '/favicon.svg',
+  '/icon-192.png',
+  '/icon-512.png',
+  '/icon-maskable-192.png',
+  '/icon-maskable-512.png',
+  '/mukoko-mark-full-light.svg',
+  '/mukoko-mark-full-dark.svg',
+];
+
+// ---------------------------------------------------------------------------
+// Request policy — ⚠️ duplicated from src/lib/pwa/sw-policy.ts (the tested
+// source of truth) because this file is a standalone unbundled script.
+// Keep both in sync.
+// ---------------------------------------------------------------------------
+
+const ASSETS_IMAGE_ORIGIN = 'https://assets.mukoko.com';
+const EXCLUDED_PATHS = /^\/(api|auth|admin|sign-in|mcp)(\/|$)/;
+
+/** True for article detail pages (`/article/{id}`). */
+function isArticlePath(pathname) {
+  return /^\/article\/[^/]+$/.test(pathname);
+}
+
+/**
+ * @param {{url: string, method: string, mode?: string, hasAuthorization?: boolean, swOrigin: string}} info
+ * @returns {'static-asset'|'navigation'|'image'|null}
+ */
+function classifyRequest(info) {
+  if (info.method.toUpperCase() !== 'GET') return null;
+  if (info.hasAuthorization) return null;
+
+  let url;
+  try {
+    url = new URL(info.url);
+  } catch {
+    return null;
+  }
+
+  if (url.origin === ASSETS_IMAGE_ORIGIN && url.pathname.startsWith('/i/')) {
+    return 'image';
+  }
+
+  if (url.origin !== info.swOrigin) return null;
+  if (EXCLUDED_PATHS.test(url.pathname)) return null;
+
+  if (url.pathname.startsWith('/_next/static/')) return 'static-asset';
+  if (info.mode === 'navigate') return 'navigation';
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Cache helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Evict oldest entries until the cache holds at most `max` items.
+ * Cache.keys() returns entries in insertion order, so deleting from the
+ * front is a simple FIFO/LRU-ish trim.
+ * @param {string} cacheName
+ */
+async function trimCache(cacheName) {
+  const max = MAX_ENTRIES[cacheName];
+  if (!max) return;
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+  for (let i = 0; i < keys.length - max; i++) {
+    await cache.delete(keys[i]);
+  }
+}
+
+/**
+ * @param {string} cacheName
+ * @param {Request} request
+ * @param {Response} response
+ */
+async function putAndTrim(cacheName, request, response) {
+  const cache = await caches.open(cacheName);
+  await cache.put(request, response);
+  await trimCache(cacheName);
+}
+
+// ---------------------------------------------------------------------------
+// Strategies
+// ---------------------------------------------------------------------------
+
+/**
+ * Cache-first for immutable hashed build assets.
+ * @param {Request} request
+ */
+async function handleStaticAsset(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response.ok) {
+    await putAndTrim(CACHE_NAMES.static, request, response.clone());
+  }
+  return response;
+}
+
+/**
+ * Network-first for page loads: fresh when online, cached copy when the
+ * network fails, /offline as the last resort.
+ * @param {Request} request
+ */
+async function handleNavigation(request) {
+  const url = new URL(request.url);
+  const cacheName = isArticlePath(url.pathname) ? CACHE_NAMES.articles : CACHE_NAMES.pages;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      await putAndTrim(cacheName, request, response.clone());
+    }
+    return response;
+  } catch (error) {
+    const cached = await caches.match(request);
+    if (cached) return cached;
+    const offline = await caches.match(OFFLINE_URL);
+    if (offline) return offline;
+    throw error;
+  }
+}
+
+/**
+ * Stale-while-revalidate for article images: serve the cached copy
+ * immediately and refresh it in the background.
+ * @param {FetchEvent} event
+ */
+async function handleImage(event) {
+  const cache = await caches.open(CACHE_NAMES.images);
+  const cached = await cache.match(event.request);
+
+  const refresh = fetch(event.request)
+    .then(async (response) => {
+      // <img> loads are no-cors → opaque responses (ok === false); cache those too.
+      if (response.ok || response.type === 'opaque') {
+        await putAndTrim(CACHE_NAMES.images, event.request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => undefined);
+
+  if (cached) {
+    event.waitUntil(refresh);
+    return cached;
+  }
+  const fresh = await refresh;
+  if (fresh) return fresh;
+  return Response.error();
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+self.addEventListener('install', (event) => {
+  // No skipWaiting here — activation is user-approved via the update banner.
+  event.waitUntil(
+    caches
+      .open(CACHE_NAMES.precache)
+      .then((cache) =>
+        cache.addAll(PRECACHE_URLS.map((url) => new Request(url, { cache: 'reload' })))
+      )
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  const keep = new Set(Object.values(CACHE_NAMES));
+  event.waitUntil(
+    (async () => {
+      const names = await caches.keys();
+      await Promise.all(
+        names
+          .filter((name) => name.startsWith(PREFIX) && !keep.has(name))
+          .map((name) => caches.delete(name))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+self.addEventListener('fetch', (event) => {
+  const kind = classifyRequest({
+    url: event.request.url,
+    method: event.request.method,
+    mode: event.request.mode,
+    hasAuthorization: event.request.headers.has('authorization'),
+    swOrigin: self.location.origin,
+  });
+
+  if (kind === 'static-asset') {
+    event.respondWith(handleStaticAsset(event.request));
+  } else if (kind === 'navigation') {
+    event.respondWith(handleNavigation(event.request));
+  } else if (kind === 'image') {
+    event.respondWith(handleImage(event));
+  }
+  // null → not handled; the request goes straight to the network.
+});

--- a/src/app/__tests__/offline-page.test.tsx
+++ b/src/app/__tests__/offline-page.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OfflinePage from '@/app/offline/page';
+
+describe('OfflinePage', () => {
+  it('renders the offline message and a link back to the feed', () => {
+    render(<OfflinePage />);
+
+    expect(screen.getByRole('heading', { name: /you.re offline/i })).toBeInTheDocument();
+    expect(screen.getByText(/previously read articles are still available/i)).toBeInTheDocument();
+
+    const backLink = screen.getByRole('link', { name: /back to the feed/i });
+    expect(backLink).toHaveAttribute('href', '/');
+  });
+});

--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -18,7 +18,7 @@ const faqs = [
   },
   {
     question: "Can I read news offline?",
-    answer: "Yes! Articles you've viewed are cached automatically. Open articles while online and they'll be available offline later."
+    answer: "Yes! Articles you open and pages you visit are cached automatically, so they stay readable when you lose connection. Open articles while online and they'll be available offline later — fresh stories load again once you're back online."
   },
   {
     question: "How do I change the theme?",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
 import { BottomNav } from '@/components/layout/bottom-nav';
 import { OnboardingModal } from '@/components/onboarding-modal';
+import { ServiceWorkerRegister } from '@/components/pwa/sw-register';
 import { OrganizationJsonLd, WebSiteJsonLd } from '@/components/ui/json-ld';
 import { AuthKitProvider } from '@workos-inc/authkit-nextjs/components';
 
@@ -170,6 +171,9 @@ export default function RootLayout({
 
             {/* Onboarding Modal */}
             <OnboardingModal />
+
+            {/* PWA: registers /sw.js (production only) + update banner */}
+            <ServiceWorkerRegister />
           </PreferencesProvider>
         </ThemeProvider>
         </AuthKitProvider>

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,50 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { WifiOff, Bookmark, Newspaper } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Offline',
+  robots: { index: false, follow: false },
+};
+
+// Fully static — this page is precached by the service worker (public/sw.js)
+// and served as the last-resort fallback for navigations while offline.
+export const dynamic = 'force-static';
+
+export default function OfflinePage() {
+  return (
+    <div className="max-w-[800px] mx-auto px-6 py-16 text-center">
+      <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-primary/10">
+        <WifiOff className="h-10 w-10 text-primary" aria-hidden="true" />
+      </div>
+
+      <h1 className="mb-2 text-3xl font-bold text-foreground">You&rsquo;re offline</h1>
+      <p className="mx-auto mb-10 max-w-md text-text-secondary">
+        No connection right now &mdash; previously read articles are still available. Anything you
+        opened while online stays readable in the hive.
+      </p>
+
+      <div className="mx-auto mb-10 grid max-w-md grid-cols-1 gap-4 text-left sm:grid-cols-2">
+        <div className="flex items-start gap-3 rounded-xl bg-surface p-4">
+          <Newspaper className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+          <p className="text-sm text-text-secondary">
+            Articles you opened while online are cached and stay readable.
+          </p>
+        </div>
+        <div className="flex items-start gap-3 rounded-xl bg-surface p-4">
+          <Bookmark className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+          <p className="text-sm text-text-secondary">
+            Fresh stories will load as soon as your connection returns.
+          </p>
+        </div>
+      </div>
+
+      <Link
+        href="/"
+        className="inline-block rounded-xl bg-primary px-6 py-2.5 font-medium text-on-primary transition-opacity hover:opacity-90"
+      >
+        Back to the feed
+      </Link>
+    </div>
+  );
+}

--- a/src/components/__tests__/sw-register.test.tsx
+++ b/src/components/__tests__/sw-register.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { ServiceWorkerRegister, getServiceWorkerUrl } from '@/components/pwa/sw-register';
+
+type Listener = () => void;
+
+function createEventTarget() {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    addEventListener: vi.fn((type: string, cb: Listener) => {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)?.add(cb);
+    }),
+    removeEventListener: vi.fn((type: string, cb: Listener) => {
+      listeners.get(type)?.delete(cb);
+    }),
+    emit(type: string) {
+      listeners.get(type)?.forEach((cb) => cb());
+    },
+  };
+}
+
+function createMockWorker(state = 'installing') {
+  return { state, postMessage: vi.fn(), ...createEventTarget() };
+}
+
+type MockWorker = ReturnType<typeof createMockWorker>;
+
+function createMockRegistration(
+  overrides: { waiting?: MockWorker | null; installing?: MockWorker | null } = {}
+) {
+  return { waiting: null, installing: null, ...createEventTarget(), ...overrides };
+}
+
+type MockRegistration = ReturnType<typeof createMockRegistration>;
+
+function installMockContainer(
+  registration: MockRegistration,
+  { controller = {} as object | null } = {}
+) {
+  const container = {
+    register: vi.fn().mockResolvedValue(registration),
+    controller,
+    ...createEventTarget(),
+  };
+  Object.defineProperty(window.navigator, 'serviceWorker', {
+    value: container,
+    configurable: true,
+  });
+  return container;
+}
+
+function removeMockContainer() {
+  delete (window.navigator as { serviceWorker?: unknown }).serviceWorker;
+}
+
+describe('getServiceWorkerUrl', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('uses NEXT_PUBLIC_BUILD_ID when set', () => {
+    vi.stubEnv('NEXT_PUBLIC_BUILD_ID', 'build42');
+    expect(getServiceWorkerUrl()).toBe('/sw.js?v=build42');
+  });
+
+  it('falls back to the Vercel commit SHA, then the constant', () => {
+    vi.stubEnv('NEXT_PUBLIC_BUILD_ID', '');
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA', 'abc123def');
+    expect(getServiceWorkerUrl()).toBe('/sw.js?v=abc123def');
+
+    vi.stubEnv('NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA', '');
+    expect(getServiceWorkerUrl()).toBe('/sw.js?v=v1');
+  });
+});
+
+describe('ServiceWorkerRegister', () => {
+  beforeEach(() => {
+    // The component defers registration to the window load event unless the
+    // document has already finished loading.
+    Object.defineProperty(document, 'readyState', {
+      value: 'complete',
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    removeMockContainer();
+  });
+
+  it('does not register outside production', async () => {
+    const container = installMockContainer(createMockRegistration());
+    render(<ServiceWorkerRegister />);
+    await act(async () => {});
+    expect(container.register).not.toHaveBeenCalled();
+  });
+
+  it('registers the versioned worker URL in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_BUILD_ID', 'build42');
+    const container = installMockContainer(createMockRegistration());
+    render(<ServiceWorkerRegister />);
+    await waitFor(() => expect(container.register).toHaveBeenCalledWith('/sw.js?v=build42'));
+  });
+
+  it('renders nothing and does not crash when serviceWorker is unsupported', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const { container } = render(<ServiceWorkerRegister />);
+    await act(async () => {});
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the update banner for an already-waiting worker and posts SKIP_WAITING', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const waiting = createMockWorker('installed');
+    installMockContainer(createMockRegistration({ waiting }));
+    render(<ServiceWorkerRegister />);
+
+    const refresh = await screen.findByRole('button', { name: /refresh/i });
+    expect(screen.getByText('Update available')).toBeInTheDocument();
+
+    fireEvent.click(refresh);
+    expect(waiting.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' });
+  });
+
+  it('shows the banner after updatefound → installed while controlled', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const registration = createMockRegistration();
+    const container = installMockContainer(registration);
+    render(<ServiceWorkerRegister />);
+    await waitFor(() => expect(container.register).toHaveBeenCalled());
+
+    const installing = createMockWorker('installing');
+    registration.installing = installing;
+    act(() => registration.emit('updatefound'));
+
+    installing.state = 'installed';
+    act(() => installing.emit('statechange'));
+
+    expect(await screen.findByText('Update available')).toBeInTheDocument();
+  });
+
+  it('does not prompt on the very first install (no controller yet)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const registration = createMockRegistration();
+    const container = installMockContainer(registration, { controller: null });
+    render(<ServiceWorkerRegister />);
+    await waitFor(() => expect(container.register).toHaveBeenCalled());
+
+    const installing = createMockWorker('installing');
+    registration.installing = installing;
+    act(() => registration.emit('updatefound'));
+    installing.state = 'installed';
+    act(() => installing.emit('statechange'));
+
+    expect(screen.queryByText('Update available')).not.toBeInTheDocument();
+  });
+
+  it('reloads exactly once on controllerchange', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const container = installMockContainer(createMockRegistration());
+    const reloadPage = vi.fn();
+    render(<ServiceWorkerRegister reloadPage={reloadPage} />);
+    await waitFor(() => expect(container.register).toHaveBeenCalled());
+
+    act(() => container.emit('controllerchange'));
+    act(() => container.emit('controllerchange'));
+    expect(reloadPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('can be dismissed', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const waiting = createMockWorker('installed');
+    installMockContainer(createMockRegistration({ waiting }));
+    render(<ServiceWorkerRegister />);
+
+    await screen.findByText('Update available');
+    fireEvent.click(screen.getByRole('button', { name: /dismiss update/i }));
+    expect(screen.queryByText('Update available')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/pwa/sw-register.tsx
+++ b/src/components/pwa/sw-register.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RefreshCw, X } from 'lucide-react';
+
+/**
+ * Bump this when NEXT_PUBLIC_BUILD_ID / the Vercel commit SHA are unavailable
+ * and you need to force clients onto a new service-worker cache version.
+ */
+const SW_FALLBACK_VERSION = 'v1';
+
+/**
+ * Versioned service-worker URL. The `v` param does double duty: a new value
+ * gives the browser a new script URL (triggering an update install) and the
+ * worker derives its cache-name version from it. On Vercel,
+ * NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA changes per deploy when system env vars
+ * are exposed; NEXT_PUBLIC_BUILD_ID wins if set explicitly.
+ */
+export function getServiceWorkerUrl(): string {
+  const buildId =
+    process.env.NEXT_PUBLIC_BUILD_ID ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ||
+    SW_FALLBACK_VERSION;
+  return `/sw.js?v=${encodeURIComponent(buildId)}`;
+}
+
+interface ServiceWorkerRegisterProps {
+  /** Injectable for tests — jsdom's window.location.reload is not stubbable. */
+  reloadPage?: () => void;
+}
+
+/**
+ * Registers /sw.js in production and shows a subtle "Update available" banner
+ * when a new service worker is waiting. Accepting posts {type:'SKIP_WAITING'}
+ * to the waiting worker; the page reloads once on controllerchange (guarded
+ * against double reloads). Dependency-free by design.
+ */
+export function ServiceWorkerRegister({ reloadPage }: ServiceWorkerRegisterProps) {
+  const [waitingWorker, setWaitingWorker] = useState<ServiceWorker | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const reloadingRef = useRef(false);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+    if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+
+    const container = navigator.serviceWorker;
+    let cancelled = false;
+
+    // Single-reload guard: controllerchange fires when the new worker takes
+    // over (after SKIP_WAITING); reload exactly once to pick up new assets.
+    const onControllerChange = () => {
+      if (reloadingRef.current) return;
+      reloadingRef.current = true;
+      if (reloadPage) reloadPage();
+      else window.location.reload();
+    };
+    container.addEventListener('controllerchange', onControllerChange);
+
+    const register = async () => {
+      try {
+        const registration = await container.register(getServiceWorkerUrl());
+        if (cancelled) return;
+
+        // A worker may already be waiting from a previous visit.
+        if (registration.waiting && container.controller) {
+          setWaitingWorker(registration.waiting);
+        }
+
+        registration.addEventListener('updatefound', () => {
+          const installing = registration.installing;
+          if (!installing) return;
+          installing.addEventListener('statechange', () => {
+            // 'installed' + an existing controller ⇒ an update is waiting
+            // (no controller means this is the very first install — nothing
+            // to prompt about).
+            if (!cancelled && installing.state === 'installed' && container.controller) {
+              setWaitingWorker(installing);
+            }
+          });
+        });
+      } catch {
+        // Registration failed (unsupported / blocked) — the app still works,
+        // just without offline support.
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      void register();
+    } else {
+      window.addEventListener('load', register, { once: true });
+    }
+
+    return () => {
+      cancelled = true;
+      container.removeEventListener('controllerchange', onControllerChange);
+      window.removeEventListener('load', register);
+    };
+  }, [reloadPage]);
+
+  const applyUpdate = useCallback(() => {
+    // The worker's message handler calls self.skipWaiting(); the resulting
+    // controllerchange triggers the guarded reload above.
+    waitingWorker?.postMessage({ type: 'SKIP_WAITING' });
+  }, [waitingWorker]);
+
+  if (!waitingWorker || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className="fixed left-4 right-4 z-50 mx-auto flex max-w-md items-center gap-3 rounded-2xl border border-border bg-background/95 p-3 pl-4 shadow-lg backdrop-blur-xl bottom-[calc(env(safe-area-inset-bottom,0px)_+_5.75rem)] md:bottom-6"
+    >
+      <p className="flex-1 text-sm text-foreground">Update available</p>
+      <button
+        type="button"
+        onClick={applyUpdate}
+        className="flex items-center gap-1.5 rounded-xl bg-primary px-3 py-2 text-sm font-medium text-on-primary transition-opacity hover:opacity-90"
+      >
+        <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        Refresh
+      </button>
+      <button
+        type="button"
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss update notification"
+        className="rounded-xl p-2 text-text-tertiary transition-colors hover:text-foreground"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/__tests__/sw-policy.test.ts
+++ b/src/lib/__tests__/sw-policy.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { classifyRequest, isArticlePath, ASSETS_IMAGE_ORIGIN } from '@/lib/pwa/sw-policy';
+
+const ORIGIN = 'https://news.mukoko.com';
+
+function classify(
+  url: string,
+  overrides: Partial<Parameters<typeof classifyRequest>[0]> = {}
+) {
+  return classifyRequest({
+    url,
+    method: 'GET',
+    swOrigin: ORIGIN,
+    ...overrides,
+  });
+}
+
+describe('classifyRequest', () => {
+  describe('never-handle exclusions', () => {
+    it('ignores non-GET methods', () => {
+      expect(classify(`${ORIGIN}/article/abc`, { method: 'POST', mode: 'navigate' })).toBeNull();
+      expect(classify(`${ORIGIN}/_next/static/chunk.js`, { method: 'PUT' })).toBeNull();
+      expect(classify(`${ORIGIN}/_next/static/chunk.js`, { method: 'HEAD' })).toBeNull();
+    });
+
+    it('ignores requests carrying an Authorization header', () => {
+      expect(
+        classify(`${ORIGIN}/article/abc`, { mode: 'navigate', hasAuthorization: true })
+      ).toBeNull();
+    });
+
+    it('ignores /api/*, /auth/*, /admin*, /sign-in, and /mcp', () => {
+      for (const path of [
+        '/api/articles/1/like',
+        '/api/health',
+        '/auth/callback',
+        '/admin',
+        '/admin/sources',
+        '/sign-in',
+        '/mcp',
+      ]) {
+        expect(classify(`${ORIGIN}${path}`, { mode: 'navigate' })).toBeNull();
+      }
+    });
+
+    it('does not over-match excluded prefixes on longer path segments', () => {
+      // /administrator etc. is a normal (404) navigation, not an exclusion
+      expect(classify(`${ORIGIN}/apiary`, { mode: 'navigate' })).toBe('navigation');
+      expect(classify(`${ORIGIN}/administrator`, { mode: 'navigate' })).toBe('navigation');
+    });
+
+    it('ignores cross-origin requests that are not article images', () => {
+      expect(classify('https://example.com/page', { mode: 'navigate' })).toBeNull();
+      expect(classify('https://assets.example.com/i/photo.jpg')).toBeNull();
+      // assets.mukoko.com but outside /i/
+      expect(classify(`${ASSETS_IMAGE_ORIGIN}/other/photo.jpg`)).toBeNull();
+    });
+
+    it('ignores same-origin subresource fetches (e.g. RSC payloads, /_next/image)', () => {
+      expect(classify(`${ORIGIN}/discover?_rsc=abc`)).toBeNull();
+      expect(classify(`${ORIGIN}/_next/image?url=%2Ffoo.png&w=640&q=75`)).toBeNull();
+    });
+
+    it('ignores unparseable URLs', () => {
+      expect(classify('not a url', { mode: 'navigate' })).toBeNull();
+    });
+  });
+
+  describe('static assets', () => {
+    it('classifies /_next/static/* as static-asset', () => {
+      expect(classify(`${ORIGIN}/_next/static/chunks/main-abc123.js`)).toBe('static-asset');
+      expect(classify(`${ORIGIN}/_next/static/css/app.css`)).toBe('static-asset');
+    });
+  });
+
+  describe('navigations', () => {
+    it('classifies top-level page loads as navigation', () => {
+      for (const path of ['/', '/discover', '/insights', '/search?q=harare', '/article/abc123']) {
+        expect(classify(`${ORIGIN}${path}`, { mode: 'navigate' })).toBe('navigation');
+      }
+    });
+
+    it('requires navigate mode for pages', () => {
+      expect(classify(`${ORIGIN}/article/abc123`)).toBeNull();
+      expect(classify(`${ORIGIN}/article/abc123`, { mode: 'cors' })).toBeNull();
+    });
+  });
+
+  describe('article images', () => {
+    it('classifies assets.mukoko.com/i/* as image', () => {
+      expect(classify(`${ASSETS_IMAGE_ORIGIN}/i/abc/photo.jpg`)).toBe('image');
+    });
+
+    it('still excludes non-GET image requests', () => {
+      expect(classify(`${ASSETS_IMAGE_ORIGIN}/i/abc/photo.jpg`, { method: 'POST' })).toBeNull();
+    });
+  });
+});
+
+describe('isArticlePath', () => {
+  it('matches exactly /article/{id}', () => {
+    expect(isArticlePath('/article/abc123')).toBe(true);
+    expect(isArticlePath('/article/65f0c9')).toBe(true);
+  });
+
+  it('rejects sub-routes, the bare prefix, and other pages', () => {
+    expect(isArticlePath('/article')).toBe(false);
+    expect(isArticlePath('/article/')).toBe(false);
+    expect(isArticlePath('/article/abc/comments')).toBe(false);
+    expect(isArticlePath('/discover')).toBe(false);
+  });
+});

--- a/src/lib/pwa/sw-policy.ts
+++ b/src/lib/pwa/sw-policy.ts
@@ -1,0 +1,78 @@
+/**
+ * Request-classification policy for the Mukoko News service worker.
+ *
+ * ⚠️ DUPLICATION NOTE: `public/sw.js` is a standalone, unbundled script served
+ * from the public dir, so it cannot import this module. The `classifyRequest`
+ * and `isArticlePath` functions are duplicated there (kept intentionally tiny).
+ * If you change the policy here, update `public/sw.js` to match — and vice
+ * versa. This module is the tested source of truth for the policy.
+ */
+
+/** Origin that serves pipeline-proxied article images (image-worker). */
+export const ASSETS_IMAGE_ORIGIN = 'https://assets.mukoko.com';
+
+/**
+ * Path prefixes the service worker must NEVER handle: authenticated or
+ * mutating surfaces (engagement APIs, WorkOS auth flows, the admin app,
+ * sign-in, and the gateway MCP path). Matches `/api`, `/api/...`, etc.
+ */
+const EXCLUDED_PATHS = /^\/(api|auth|admin|sign-in|mcp)(\/|$)/;
+
+export type SwRequestKind =
+  | 'static-asset' // /_next/static/* — immutable hashed chunks, cache-first
+  | 'navigation' // document loads — network-first, cache fallback, /offline last
+  | 'image' // assets.mukoko.com/i/* — stale-while-revalidate, capped cache
+  | null; // not handled by the service worker (falls through to the network)
+
+export interface SwRequestInfo {
+  /** Full request URL. */
+  url: string;
+  /** HTTP method — anything other than GET is never handled. */
+  method: string;
+  /** `Request.mode` — 'navigate' for top-level document loads. */
+  mode?: string;
+  /** True when the request carries an Authorization header. */
+  hasAuthorization?: boolean;
+  /** Origin the service worker is running on (`self.location.origin`). */
+  swOrigin: string;
+}
+
+/** True for article detail pages (`/article/{id}`) — the offline-reading promise. */
+export function isArticlePath(pathname: string): boolean {
+  return /^\/article\/[^/]+$/.test(pathname);
+}
+
+/**
+ * Decide whether (and how) the service worker handles a request.
+ * Returns `null` for everything that must fall through to the network
+ * untouched: non-GET, Authorization-bearing, excluded paths, foreign
+ * origins, and same-origin subresource fetches (e.g. RSC payloads).
+ */
+export function classifyRequest(info: SwRequestInfo): SwRequestKind {
+  if (info.method.toUpperCase() !== 'GET') return null;
+  if (info.hasAuthorization) return null;
+
+  let url: URL;
+  try {
+    url = new URL(info.url);
+  } catch {
+    return null;
+  }
+
+  // Article images from the image worker (cross-origin, GET only).
+  if (url.origin === ASSETS_IMAGE_ORIGIN && url.pathname.startsWith('/i/')) {
+    return 'image';
+  }
+
+  // Everything else must be same-origin.
+  if (url.origin !== info.swOrigin) return null;
+  if (EXCLUDED_PATHS.test(url.pathname)) return null;
+
+  // Hashed, immutable Next.js build assets.
+  if (url.pathname.startsWith('/_next/static/')) return 'static-asset';
+
+  // Top-level page loads (articles, feed pages, everything public).
+  if (info.mode === 'navigate') return 'navigation';
+
+  return null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,9 @@ export default authkitMiddleware({
 
 export const config = {
   matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|embed|robots.txt|sitemap.xml).*)',
+    // sw.js and manifest.json are static public assets fetched by the browser
+    // itself (service-worker update checks / install prompts) — no session to
+    // refresh, so they are excluded like the other static files.
+    '/((?!_next/static|_next/image|favicon.ico|embed|robots.txt|sitemap.xml|sw.js|manifest.json).*)',
   ],
 }


### PR DESCRIPTION
Ships the PWA properly on top of #139 (server-first-paint + ISR, floating bottom nav, next/font, corrected icons + manifest, viewportFit cover — all kept intact): a real service worker so viewed articles are readable offline (the `/help` FAQ promise), installability, and graceful degradation on flaky connections.

## What's in here

- **`public/sw.js`** — hand-rolled, dependency-free service worker (plain JS + JSDoc; no next-pwa/Serwist — neither was installed, and the runtime logic is ~250 lines).
- **`src/lib/pwa/sw-policy.ts`** — the tested source of truth for the request-classification policy. `sw.js` is a standalone unbundled script, so the tiny predicate is intentionally duplicated there; both files carry a keep-in-sync note.
- **`src/components/pwa/sw-register.tsx`** — production-only, feature-detected registration mounted in `layout.tsx`, plus the update banner.
- **`src/app/offline/page.tsx`** — static, branded (mineral tokens) fallback: "You're offline — previously read articles are still available", link back to `/`. Prerendered `○ (Static)` in the build.
- **`public/manifest.json`** — name/short_name now `mukoko news` / `mukoko` (lowercase wordmark doctrine). start_url, `standalone`, `#1A0033` background, `#4B0082` theme, and the #139 `any`+`maskable` icon sets were already correct and are unchanged. Already linked via `metadata.manifest`.
- **`src/middleware.ts`** — `/sw.js` and `/manifest.json` added to the AuthKit matcher exclusions (browser-initiated static fetches; no session to refresh). Verified: both return 200 without touching the middleware.
- **`src/app/help/page.tsx`** — offline FAQ wording updated to exactly match behaviour (articles you open **and pages you visit** are cached; fresh stories need a connection).

## Caching strategy

| Request | Strategy | Cache | Cap |
| --- | --- | --- | --- |
| `/offline`, `/manifest.json`, core icons + marks | Precache at `install` (`cache: 'reload'`) | `mukoko-precache-<v>` | — |
| `/_next/static/*` | Cache-first (immutable hashed chunks — runtime-cached, never precached by hand) | `mukoko-static-<v>` | — (pruned per version) |
| `/article/{id}` navigations | Network-first → cache fallback → `/offline`; successful responses cached | `mukoko-articles-<v>` | 150 (trim-on-put) |
| All other navigations (`/`, `/discover`, `/insights`, `/search`, …) | Network-first → cache fallback → `/offline` | `mukoko-pages-<v>` | 60 (trim-on-put) |
| `https://assets.mukoko.com/i/*` images | Stale-while-revalidate (opaque responses cached too) | `mukoko-images-<v>` | 150 (trim-on-put) |

**Never handled** (fall straight through to the network): non-GET, anything with an `Authorization` header, `/api/*`, `/auth/*`, `/admin*`, `/sign-in`, `/mcp`, foreign origins, and same-origin subresource fetches (RSC payloads, `/_next/image`) — so App Router client navigation and auth flows are untouched.

## Versioning & update flow

- Registration URL is `/sw.js?v=<NEXT_PUBLIC_BUILD_ID || NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA || 'v1'>`. A new build id → new script URL → the browser installs a fresh worker, and the worker derives its cache-name version from the `v` param — versioned caches with zero build tooling. (On Vercel, expose system env vars so `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` rotates per deploy; otherwise set `NEXT_PUBLIC_BUILD_ID`, or bump the `v1` fallback in `sw-register.tsx`.)
- `install` precaches but does **not** `skipWaiting`. When a new worker reaches `waiting`, a subtle "Update available — Refresh" banner appears (dismissible); accepting posts `{type:'SKIP_WAITING'}`, the worker calls `self.skipWaiting()`, and the page reloads exactly once on `controllerchange` (guarded).
- `activate` deletes every `mukoko-*` cache from previous versions and calls `clients.claim()`.

## Vercel note

`public/sw.js` is served from the site root by Vercel (verified locally with `next start`: `200 application/javascript`, `Cache-Control: public, max-age=0`), so the worker registers at scope `/` — no `Service-Worker-Allowed` header needed.

## Tests

- 25 new tests: `sw-policy` (exclusions, static/navigation/image classification, `isArticlePath`), `sw-register` (prod-only gate, versioned URL, already-waiting + `updatefound` banner paths, first-install no-prompt, SKIP_WAITING post, single-reload guard, dismiss), and the offline page.
- Full suite: **609 passed (36 files)**; `typecheck`, `lint`, and `build` all green (pre-commit hook ran vitest related → typecheck → build).

## Deviations / notes

- The offline fallback HTML references hashed CSS/JS chunks that are runtime-cached; on a first-ever visit that goes offline immediately, `/offline` may render unstyled. Standard limitation of not precaching hashed chunks (which the task explicitly rules out).
- Manifest `name`/`short_name` changed from "Mukoko News …" to lowercase per the task + wordmark doctrine — flagging since #139 touched this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_