### PR TITLE
feat(insights): rebuild /insights as a public open-data analytics dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,11 +113,14 @@ All news data reads go through Server Actions → MongoDB Atlas (`news` database
 
 `mongodb/client.ts` owns the singleton `MongoClient` (reads `MONGODB_URI` / `MONGODB_DATABASE`). `mongodb/admin.ts` powers admin **reads**; admin **writes** go through the gateway (below).
 
+**Public Insights / open-data analytics** — `src/lib/mongodb/insights.ts` holds read-only aggregation pipelines over `news.articles` (+ `feedSources` / `newsMediaOrganizations`) for the flagship open-data dashboard: `getCorpusSummary`, `getPublishingVolume`, `getSourceLeaderboard`, `getCategoryDistribution`, `getCountryCoverage`, `getSentimentBreakdown`, `getTopTopics`. **Every function is wrapped so a failure returns an empty-but-typed result — it never throws to the page.** `src/lib/actions/insights.ts` exposes them as Server Actions (incl. the aggregate `getInsightsBundleAction`), which back the server-rendered, ISR-cached (`revalidate = 600`) `/insights` page. Metrics computed over an enriched subset (sentiment, quality) carry an explicit **coverage %** so nothing is misrepresented.
+
 ### Data Flow (writes / mutations)
 
 - **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit`, `getRequestIp`). Note the limiter is in-memory per Vercel instance, so limits apply per-instance rather than globally — a shared store (e.g. Redis/Upstash) is the durable upgrade. `src/app/api/health/route.ts` is the health probe.
 - **Admin mutations** — `src/lib/admin/gateway.ts` proxies to the gateway Worker's WorkOS-gated `/api/admin/*` endpoints, forwarding the WorkOS access token as a Bearer header so the Worker re-verifies the same RBAC. **This is the only place the frontend touches the gateway.**
 - **Pipeline refresh** — `src/lib/actions/refresh.ts` `triggerFeedCollection()` fire-and-forget `POST`s to `FLY_WORKER_URL/trigger/collect` with `FLY_TRIGGER_TOKEN`.
+- **Open-data export** (read-only, public) — `src/app/api/insights/export/route.ts` (`GET`, `runtime = 'nodejs'`, `revalidate = 600`) returns the aggregated Insights bundle. `?format=json` (default) emits the full `InsightsBundle`; `?format=csv` emits one CSV with three labelled tables — `## media_organizations`, `## topic_distribution`, `## country_coverage` (RFC-4180 quoted). Rate-limited via `checkRateLimit`/`getRequestIp` (20 req/min/IP → `429` + `Retry-After`); edge-cached (`Cache-Control: public, s-maxage=600, stale-while-revalidate=1800`). Linked from the `/insights` page ("Download open data"). This is a plain Route Handler → MongoDB, not a gateway call.
 
 ### API Client (`src/lib/api.ts`)
 

--- a/src/app/api/insights/__tests__/export-route.test.ts
+++ b/src/app/api/insights/__tests__/export-route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/insights/export/route'
+import { getInsightsBundleAction } from '@/lib/actions/insights'
+
+vi.mock('@/lib/actions/insights', () => ({
+  getInsightsBundleAction: vi.fn(),
+}))
+
+const bundle = {
+  summary: {
+    totalArticles: 1000,
+    sources: 42,
+    organizations: 30,
+    countries: 3,
+    aiEnrichedPct: 75,
+    avgQualityScore: 0.73,
+    earliest: '2025-01-01T00:00:00.000Z',
+    latest: '2026-06-30T00:00:00.000Z',
+  },
+  volume: { days: 30, from: '2026-06-01', to: '2026-06-30', total: 500, series: [], topSources: [] },
+  leaderboard: [
+    {
+      sourceId: 'src-1',
+      name: 'The Herald, ZW',
+      organization: 'Zimpapers',
+      verified: true,
+      articleCount: 120,
+      avgQualityScore: 0.81,
+      avgWordCount: 640,
+      countries: ['ZW', 'ZA'],
+      lastPublished: '2026-06-01T00:00:00.000Z',
+    },
+  ],
+  categories: {
+    totalAssignments: 200,
+    coverage: 50,
+    categories: [{ slug: 'politics', count: 60, share: 30 }],
+  },
+  countries: { total: 100, countries: [{ code: 'ZW', name: 'Zimbabwe', count: 75, share: 75 }] },
+  sentiment: { total: 100, coverage: 25, breakdown: [{ sentiment: 'positive', count: 30, share: 30 }] },
+  topics: [{ tag: 'elections', count: 12 }],
+  generatedAt: '2026-07-02T00:00:00.000Z',
+}
+
+// Unique IP per test so the module-global rate-limit windows never collide.
+let ipCounter = 0
+function nextIp(): string {
+  ipCounter += 1
+  return `172.16.${Math.floor(ipCounter / 256) % 256}.${ipCounter % 256}`
+}
+
+function makeRequest(ip: string, query = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/insights/export${query}`, {
+    method: 'GET',
+    headers: { 'x-forwarded-for': ip },
+  })
+}
+
+beforeEach(() => {
+  vi.mocked(getInsightsBundleAction).mockReset()
+  vi.mocked(getInsightsBundleAction).mockResolvedValue(bundle as never)
+})
+
+describe('GET /api/insights/export', () => {
+  it('returns the full bundle as JSON with a public cache header by default', async () => {
+    const res = await GET(makeRequest(nextIp()))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    expect(res.headers.get('cache-control')).toContain('s-maxage=600')
+    const body = await res.json()
+    expect(body).toEqual(bundle)
+  })
+
+  it('returns CSV with the three labelled tables when format=csv', async () => {
+    const res = await GET(makeRequest(nextIp(), '?format=csv'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/csv')
+    expect(res.headers.get('content-disposition')).toContain('mukoko-insights.csv')
+
+    const text = await res.text()
+    expect(text).toContain('## media_organizations')
+    expect(text).toContain('## topic_distribution')
+    expect(text).toContain('## country_coverage')
+    // Header rows
+    expect(text).toContain('source_id,name,organization,verified,article_count')
+    expect(text).toContain('slug,article_count,share_pct')
+    expect(text).toContain('country_code,country_name,article_count,share_pct')
+    // Data rows — a comma inside a field is RFC-4180 quoted.
+    expect(text).toContain('"The Herald, ZW"')
+    expect(text).toContain('ZW|ZA')
+    expect(text).toContain('politics,60,30')
+    expect(text).toContain('ZW,Zimbabwe,75,75')
+  })
+
+  it('rate limits after 20 requests/minute per IP with a Retry-After header', async () => {
+    const ip = nextIp()
+    for (let i = 0; i < 20; i++) {
+      const ok = await GET(makeRequest(ip))
+      expect(ok.status).toBe(200)
+    }
+    const blocked = await GET(makeRequest(ip))
+    expect(blocked.status).toBe(429)
+    expect(blocked.headers.get('retry-after')).toBe('60')
+    expect(await blocked.json()).toEqual({ error: 'Too many requests' })
+  })
+
+  it('returns 500 when the aggregate build fails', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(getInsightsBundleAction).mockRejectedValue(new Error('boom'))
+    const res = await GET(makeRequest(nextIp()))
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to build export' })
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/app/api/insights/export/route.ts
+++ b/src/app/api/insights/export/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getInsightsBundleAction } from '@/lib/actions/insights'
+import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
+
+// Public, read-only open-data endpoint. Node runtime (MongoDB driver via the
+// Server Action) and edge-cached: a fresh aggregate every 10 minutes matches
+// the /insights page's ISR window.
+export const runtime = 'nodejs'
+export const revalidate = 600
+
+const RATE_LIMIT_MAX = 20
+const RATE_LIMIT_WINDOW_MS = 60_000
+
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, s-maxage=600, stale-while-revalidate=1800',
+} as const
+
+/** Quote a CSV cell per RFC 4180 (wrap + double embedded quotes when needed). */
+function csvCell(value: unknown): string {
+  const s = value === null || value === undefined ? '' : String(value)
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+}
+
+function csvRow(cells: unknown[]): string {
+  return cells.map(csvCell).join(',')
+}
+
+type Bundle = Awaited<ReturnType<typeof getInsightsBundleAction>>
+
+/**
+ * Build a single CSV document with three labelled sections — the source
+ * leaderboard, topic distribution and country coverage tables.
+ */
+function toCsv(data: Bundle): string {
+  const lines: string[] = []
+
+  lines.push('# Mukoko News — Open Data export')
+  lines.push(`# generated,${data.generatedAt}`)
+  lines.push('')
+
+  lines.push('## media_organizations')
+  lines.push(
+    csvRow([
+      'source_id',
+      'name',
+      'organization',
+      'verified',
+      'article_count',
+      'avg_quality_score',
+      'avg_word_count',
+      'countries',
+      'last_published',
+    ])
+  )
+  for (const r of data.leaderboard) {
+    lines.push(
+      csvRow([
+        r.sourceId,
+        r.name,
+        r.organization ?? '',
+        r.verified,
+        r.articleCount,
+        r.avgQualityScore,
+        r.avgWordCount,
+        r.countries.join('|'),
+        r.lastPublished ?? '',
+      ])
+    )
+  }
+  lines.push('')
+
+  lines.push('## topic_distribution')
+  lines.push(csvRow(['slug', 'article_count', 'share_pct']))
+  for (const c of data.categories.categories) {
+    lines.push(csvRow([c.slug, c.count, c.share]))
+  }
+  lines.push('')
+
+  lines.push('## country_coverage')
+  lines.push(csvRow(['country_code', 'country_name', 'article_count', 'share_pct']))
+  for (const c of data.countries.countries) {
+    lines.push(csvRow([c.code, c.name, c.count, c.share]))
+  }
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+export async function GET(request: NextRequest) {
+  const ip = getRequestIp(request)
+  if (!checkRateLimit(`insights-export:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+    return NextResponse.json(
+      { error: 'Too many requests' },
+      { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
+    )
+  }
+
+  const format = (request.nextUrl.searchParams.get('format') || 'json').toLowerCase()
+
+  try {
+    const data = await getInsightsBundleAction()
+
+    if (format === 'csv') {
+      return new NextResponse(toCsv(data), {
+        status: 200,
+        headers: {
+          ...CACHE_HEADERS,
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="mukoko-insights.csv"',
+        },
+      })
+    }
+
+    return NextResponse.json(data, { status: 200, headers: CACHE_HEADERS })
+  } catch (error) {
+    console.error('[/api/insights/export]', error)
+    return NextResponse.json({ error: 'Failed to build export' }, { status: 500 })
+  }
+}

--- a/src/app/insights/__tests__/insights-client.test.tsx
+++ b/src/app/insights/__tests__/insights-client.test.tsx
@@ -1,120 +1,164 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import InsightsClient, { normalizeAuthors } from "../insights-client";
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import InsightsClient, { formatNumber, humanize, formatDay } from '../insights-client'
+import type { InsightsBundle } from '@/lib/actions/insights'
 
-vi.mock("next/link", () => ({
+vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
     <a href={href} {...props}>
       {children}
     </a>
   ),
-}));
+}))
 
-// Mock server actions (pages read via Server Actions — Rule 4)
-const mockGetStats = vi.fn();
-const mockGetTrendingCategories = vi.fn();
-const mockGetTrendingAuthors = vi.fn();
+vi.mock('@/components/ui/error-boundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
 
-vi.mock("@/lib/actions/feed", () => ({
-  getStatsAction: (...args: unknown[]) => mockGetStats(...args),
-  getTrendingCategoriesAction: (...args: unknown[]) => mockGetTrendingCategories(...args),
-  getTrendingAuthorsAction: (...args: unknown[]) => mockGetTrendingAuthors(...args),
-}));
+const bundle: InsightsBundle = {
+  summary: {
+    totalArticles: 18081,
+    sources: 42,
+    organizations: 30,
+    countries: 12,
+    aiEnrichedPct: 75,
+    avgQualityScore: 0.73,
+    earliest: '2025-01-01T00:00:00.000Z',
+    latest: '2026-06-30T00:00:00.000Z',
+  },
+  volume: {
+    days: 30,
+    from: '2026-06-01',
+    to: '2026-06-30',
+    total: 500,
+    series: [
+      { date: '2026-06-29', count: 10 },
+      { date: '2026-06-30', count: 20 },
+    ],
+    topSources: [{ sourceId: 'src-1', name: 'The Herald', count: 120 }],
+  },
+  leaderboard: [
+    {
+      sourceId: 'src-1',
+      name: 'The Herald',
+      organization: 'Zimpapers',
+      verified: true,
+      articleCount: 120,
+      avgQualityScore: 0.81,
+      avgWordCount: 640,
+      countries: ['ZW'],
+      lastPublished: '2026-06-01T00:00:00.000Z',
+    },
+    {
+      sourceId: 'src-2',
+      name: 'Daily Maverick',
+      verified: false,
+      articleCount: 300,
+      avgQualityScore: 0.7,
+      avgWordCount: 800,
+      countries: ['ZA'],
+      lastPublished: '2026-06-15T00:00:00.000Z',
+    },
+  ],
+  categories: {
+    totalAssignments: 200,
+    coverage: 50,
+    categories: [{ slug: 'politics', count: 60, share: 30 }],
+  },
+  countries: {
+    total: 100,
+    countries: [{ code: 'ZW', name: 'Zimbabwe', count: 75, share: 75 }],
+  },
+  sentiment: {
+    total: 100,
+    coverage: 25,
+    breakdown: [{ sentiment: 'positive', count: 30, share: 30 }],
+  },
+  topics: [{ tag: 'elections', count: 12 }],
+  generatedAt: '2026-07-02T00:00:00.000Z',
+}
 
-const stats = { total_articles: 18081, active_sources: 42, categories: 12 };
-const trending = [
-  { id: "politics", name: "Politics", slug: "politics", article_count: 3219 },
-  { id: "economy", name: "Economy", slug: "economy", article_count: 1589 },
-];
+const emptyBundle: InsightsBundle = {
+  summary: {
+    totalArticles: 0,
+    sources: 0,
+    organizations: 0,
+    countries: 0,
+    aiEnrichedPct: 0,
+    avgQualityScore: 0,
+    earliest: null,
+    latest: null,
+  },
+  volume: { days: 30, from: '2026-06-01', to: '2026-06-30', total: 0, series: [], topSources: [] },
+  leaderboard: [],
+  categories: { totalAssignments: 0, coverage: 0, categories: [] },
+  countries: { total: 0, countries: [] },
+  sentiment: { total: 0, coverage: 0, breakdown: [] },
+  topics: [],
+  generatedAt: '2026-07-02T00:00:00.000Z',
+}
 
-describe("normalizeAuthors", () => {
-  it("keeps plain string author names", () => {
-    expect(normalizeAuthors([{ id: "jane doe", name: "jane doe", article_count: 4 }])).toEqual([
-      { id: "Jane Doe", name: "Jane Doe", article_count: 4 },
-    ]);
-  });
+describe('pure helpers', () => {
+  it('formatNumber groups thousands and guards non-finite input', () => {
+    expect(formatNumber(18081)).toBe('18,081')
+    expect(formatNumber(NaN)).toBe('0')
+  })
+  it('humanize title-cases slugs', () => {
+    expect(humanize('arts-culture')).toBe('Arts Culture')
+  })
+  it('formatDay renders a friendly date and handles null', () => {
+    expect(formatDay(null)).toBe('—')
+    expect(formatDay('2026-06-30T00:00:00.000Z')).toMatch(/2026/)
+  })
+})
 
-  it("unwraps schema.org Person objects (the crash regression)", () => {
-    const raw = [
-      {
-        id: { "@type": "Person", name: "faty ba" },
-        name: { "@type": "Person", name: "faty ba" },
-        article_count: 2,
-      },
-    ];
-    expect(normalizeAuthors(raw)).toEqual([{ id: "Faty Ba", name: "Faty Ba", article_count: 2 }]);
-  });
+describe('InsightsClient', () => {
+  it('renders the corpus summary, sections and open-data links', () => {
+    render(<InsightsClient data={bundle} />)
 
-  it("drops entries without a usable name and merges duplicates", () => {
-    const raw = [
-      { name: "jane doe", article_count: 2 },
-      { name: { "@type": "Person", name: "jane doe" }, article_count: 3 },
-      { name: null, article_count: 9 },
-      { name: { "@type": "Person" }, article_count: 9 },
-    ];
-    expect(normalizeAuthors(raw)).toEqual([{ id: "Jane Doe", name: "Jane Doe", article_count: 5 }]);
-  });
+    expect(screen.getByRole('heading', { name: /Open Data/i })).toBeInTheDocument()
+    expect(screen.getByText('18,081')).toBeInTheDocument()
+    expect(screen.getByText('Media organizations')).toBeInTheDocument()
+    expect(screen.getByText('Topic distribution')).toBeInTheDocument()
+    expect(screen.getByText('Country coverage')).toBeInTheDocument()
+    expect(screen.getByText('Sentiment')).toBeInTheDocument()
 
-  it("returns empty for non-array input", () => {
-    expect(normalizeAuthors(null)).toEqual([]);
-    expect(normalizeAuthors(undefined)).toEqual([]);
-  });
-});
+    const jsonLink = screen.getByRole('link', { name: /Download open data \(JSON\)/i })
+    expect(jsonLink).toHaveAttribute('href', '/api/insights/export?format=json')
+    const csvLink = screen.getByRole('link', { name: /Download tables \(CSV\)/i })
+    expect(csvLink).toHaveAttribute('href', '/api/insights/export?format=csv')
+  })
 
-describe("InsightsClient", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  it('labels sentiment with its coverage percentage (honest thin-data caveat)', () => {
+    render(<InsightsClient data={bundle} />)
+    expect(screen.getByText(/Coverage: 25% of the corpus/i)).toBeInTheDocument()
+  })
 
-  it("renders server-provided initial data without fetching", async () => {
-    render(
-      <InsightsClient
-        initialStats={stats}
-        initialTrending={trending}
-        initialAuthors={[{ name: { "@type": "Person", name: "faty ba" }, article_count: 2 }]}
-      />
-    );
+  it('sorts the leaderboard when a column header is clicked', () => {
+    render(<InsightsClient data={bundle} />)
+    const table = screen.getByRole('table')
+    const rowNames = () =>
+      within(table)
+        .getAllByRole('row')
+        .slice(1)
+        .map((r) => within(r).getAllByRole('cell')[0].textContent)
 
-    expect(screen.getByText("Insights")).toBeInTheDocument();
-    expect(screen.getByText("18,081")).toBeInTheDocument();
-    expect(screen.getByText("Politics")).toBeInTheDocument();
-    // Object-authors render as normalised strings, not "[object Object]"
-    expect(screen.getByText("Faty Ba")).toBeInTheDocument();
+    // Default sort is by article count desc → Daily Maverick (300) first.
+    expect(rowNames()[0]).toContain('Daily Maverick')
 
-    expect(mockGetStats).not.toHaveBeenCalled();
-    expect(mockGetTrendingCategories).not.toHaveBeenCalled();
-    expect(mockGetTrendingAuthors).not.toHaveBeenCalled();
-  });
+    // Sort by source name asc → Daily Maverick before The Herald.
+    fireEvent.click(screen.getByRole('button', { name: /Sort by Source/i }))
+    expect(rowNames()[0]).toContain('Daily Maverick')
 
-  it("fetches on mount when the server provided no data", async () => {
-    mockGetStats.mockResolvedValue({ database: stats });
-    mockGetTrendingCategories.mockResolvedValue(trending);
-    mockGetTrendingAuthors.mockResolvedValue({
-      trending_authors: [{ id: "john smith", name: "john smith", article_count: 7 }],
-    });
+    // Sort by average words desc → Daily Maverick (800) first.
+    fireEvent.click(screen.getByRole('button', { name: /Sort by Avg words/i }))
+    expect(rowNames()[0]).toContain('Daily Maverick')
+  })
 
-    render(<InsightsClient />);
-
-    await waitFor(() => {
-      expect(screen.getByText("18,081")).toBeInTheDocument();
-    });
-    expect(screen.getByText("John Smith")).toBeInTheDocument();
-    expect(mockGetStats).toHaveBeenCalled();
-  });
-
-  it("shows an error state with retry when every fetch fails", async () => {
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    mockGetStats.mockRejectedValue(new Error("mongo down"));
-    mockGetTrendingCategories.mockRejectedValue(new Error("mongo down"));
-    mockGetTrendingAuthors.mockRejectedValue(new Error("mongo down"));
-
-    render(<InsightsClient />);
-
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByText("Unable to load insights")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
-    consoleSpy.mockRestore();
-  });
-});
+  it('renders the empty state when the corpus has no data', () => {
+    render(<InsightsClient data={emptyBundle} />)
+    expect(screen.getByText('No data available yet')).toBeInTheDocument()
+    // Download affordances remain available even when empty.
+    expect(screen.getByRole('link', { name: /Download open data \(JSON\)/i })).toBeInTheDocument()
+  })
+})

--- a/src/app/insights/__tests__/insights-page.test.tsx
+++ b/src/app/insights/__tests__/insights-page.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import InsightsPage from '../page'
+import type { InsightsBundle } from '@/lib/actions/insights'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/components/ui/error-boundary', () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+// Pages read via Server Actions — mock the insights action module (Rule 4).
+const mockBundle = vi.fn()
+vi.mock('@/lib/actions/insights', () => ({
+  getInsightsBundleAction: () => mockBundle(),
+}))
+
+const bundle: InsightsBundle = {
+  summary: {
+    totalArticles: 1234,
+    sources: 10,
+    organizations: 8,
+    countries: 5,
+    aiEnrichedPct: 60,
+    avgQualityScore: 0.65,
+    earliest: '2025-01-01T00:00:00.000Z',
+    latest: '2026-06-30T00:00:00.000Z',
+  },
+  volume: { days: 30, from: '2026-06-01', to: '2026-06-30', total: 200, series: [], topSources: [] },
+  leaderboard: [],
+  categories: { totalAssignments: 0, coverage: 0, categories: [] },
+  countries: { total: 0, countries: [] },
+  sentiment: { total: 0, coverage: 0, breakdown: [] },
+  topics: [],
+  generatedAt: '2026-07-02T00:00:00.000Z',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('InsightsPage (server component)', () => {
+  it('awaits the bundle action and renders the dashboard', async () => {
+    mockBundle.mockResolvedValue(bundle)
+    render(await InsightsPage())
+    expect(screen.getByRole('heading', { name: /Open Data/i })).toBeInTheDocument()
+    expect(screen.getByText('1,234')).toBeInTheDocument()
+    expect(mockBundle).toHaveBeenCalledOnce()
+  })
+
+  it('is configured for ISR with a 10-minute revalidate window', async () => {
+    const mod = await import('../page')
+    expect(mod.revalidate).toBe(600)
+  })
+})

--- a/src/app/insights/insights-client.tsx
+++ b/src/app/insights/insights-client.tsx
@@ -1,180 +1,327 @@
-"use client";
+'use client'
 
-import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
 import {
-  TrendingUp,
-  ChevronRight,
   BarChart3,
-  Users,
   Newspaper,
-  Layers,
-  RefreshCw,
-  WifiOff,
-} from "lucide-react";
-import {
-  getStatsAction,
-  getTrendingCategoriesAction,
-  getTrendingAuthorsAction,
-} from "@/lib/actions/feed";
-import { ErrorBoundary } from "@/components/ui/error-boundary";
-import { InsightsPageSkeleton } from "@/components/ui/skeleton";
+  Radio,
+  Building2,
+  Globe2,
+  Sparkles,
+  Gauge,
+  CalendarRange,
+  Download,
+  ArrowUpDown,
+  BadgeCheck,
+  TrendingUp,
+} from 'lucide-react'
+import { ErrorBoundary } from '@/components/ui/error-boundary'
+import { getCategoryEmoji } from '@/lib/constants'
+import type { InsightsBundle } from '@/lib/actions/insights'
 
-// Category emojis
-const CATEGORY_EMOJIS: Record<string, string> = {
-  politics: "🏛️",
-  business: "💼",
-  sports: "⚽",
-  entertainment: "🎬",
-  technology: "💻",
-  health: "🏥",
-  world: "🌍",
-  local: "📍",
-  opinion: "💭",
-  breaking: "⚡",
-  crime: "🚨",
-  education: "📚",
-  environment: "🌱",
-  lifestyle: "✨",
-  agriculture: "🌾",
-  mining: "⛏️",
-  tourism: "✈️",
-  finance: "💰",
-  culture: "🎭",
-};
+// ---------------------------------------------------------------------------
+// Formatting helpers (pure — unit-testable)
+// ---------------------------------------------------------------------------
 
-const getEmoji = (name: string) => CATEGORY_EMOJIS[name?.toLowerCase()] || "📰";
-
-export interface Stats {
-  total_articles: number;
-  active_sources: number;
-  categories: number;
+export function formatNumber(n: number): string {
+  return (Number.isFinite(n) ? n : 0).toLocaleString('en-US')
 }
 
-export interface TrendingCategory {
-  id: string;
-  name: string;
-  slug: string;
-  article_count: number;
-  growth_rate?: number;
+/** Title-case a lowercase slug/tag for display: "arts-culture" → "Arts Culture". */
+export function humanize(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
 }
 
-export interface Author {
-  id: string;
-  name: string;
-  article_count: number;
+export function formatDay(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
 }
 
-/**
- * Some ingested articles store `author` as a schema.org object
- * (`{"@type": "Person", "name": "…"}`) rather than a string, so the
- * trending-authors aggregation can return objects in `id`/`name`. Rendering
- * those crashed the page ("Objects are not valid as a React child").
- * Normalise every entry to a plain display string, merge duplicates, and
- * title-case the lowercase pipeline names.
- */
-export function normalizeAuthors(raw: unknown): Author[] {
-  if (!Array.isArray(raw)) return [];
-  const merged = new Map<string, number>();
-  for (const entry of raw) {
-    const e = entry as { name?: unknown; article_count?: unknown };
-    const rawName =
-      typeof e.name === "string" ? e.name : (e.name as { name?: unknown } | null)?.name;
-    if (typeof rawName !== "string" || rawName.trim().length === 0) continue;
-    const name = rawName
-      .trim()
-      .split(/\s+/)
-      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-      .join(" ");
-    const count = typeof e.article_count === "number" ? e.article_count : 0;
-    merged.set(name, (merged.get(name) ?? 0) + count);
-  }
-  return [...merged.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([name, article_count]) => ({ id: name, name, article_count }));
+// Fixed diverging semantics for sentiment — never color-alone, always labelled.
+const SENTIMENT_STYLE: Record<string, { bar: string; label: string }> = {
+  positive: { bar: 'bg-malachite', label: 'Positive' },
+  negative: { bar: 'bg-destructive', label: 'Negative' },
+  neutral: { bar: 'bg-text-tertiary', label: 'Neutral' },
+  mixed: { bar: 'bg-gold', label: 'Mixed' },
 }
 
-interface InsightsClientProps {
-  /** Data prefetched by the server page — null members mean that fetch failed. */
-  initialStats?: Stats | null;
-  initialTrending?: TrendingCategory[] | null;
-  /** Raw trending_authors payload (normalised client-side). */
-  initialAuthors?: unknown[] | null;
+// ---------------------------------------------------------------------------
+// Small presentational pieces
+// ---------------------------------------------------------------------------
+
+function StatTile({
+  icon: Icon,
+  label,
+  value,
+  caption,
+}: {
+  icon: typeof Newspaper
+  label: string
+  value: string
+  caption?: string
+}) {
+  return (
+    <div className="bg-surface rounded-2xl p-5 border border-elevated">
+      <Icon className="w-6 h-6 text-primary mb-3" aria-hidden="true" />
+      <div className="text-2xl font-bold text-foreground font-mono">{value}</div>
+      <div className="text-sm text-text-secondary">{label}</div>
+      {caption && <div className="text-xs text-text-tertiary mt-1">{caption}</div>}
+    </div>
+  )
 }
 
-export default function InsightsClient({
-  initialStats = null,
-  initialTrending = null,
-  initialAuthors = null,
-}: InsightsClientProps) {
-  const hasInitialData =
-    initialStats !== null || initialTrending !== null || initialAuthors !== null;
+/** A single-hue horizontal magnitude bar list (category / country / topics). */
+function BarList({
+  items,
+  colorClass = 'bg-primary',
+  href,
+}: {
+  items: Array<{ key: string; label: string; value: number; share?: number; emoji?: string }>
+  colorClass?: string
+  href?: (key: string) => string
+}) {
+  const max = Math.max(1, ...items.map((i) => i.value))
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => {
+        const pct = Math.max(2, Math.round((item.value / max) * 100))
+        const row = (
+          <div className="flex items-center gap-3">
+            <div className="w-40 shrink-0 truncate text-sm text-foreground flex items-center gap-1.5">
+              {item.emoji && <span aria-hidden="true">{item.emoji}</span>}
+              <span className="truncate">{item.label}</span>
+            </div>
+            <div className="flex-1 h-3 rounded-full bg-elevated overflow-hidden">
+              <div
+                className={`h-full rounded-full ${colorClass}`}
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="w-24 shrink-0 text-right text-xs text-text-secondary font-mono">
+              {formatNumber(item.value)}
+              {typeof item.share === 'number' && (
+                <span className="text-text-tertiary"> · {item.share}%</span>
+              )}
+            </div>
+          </div>
+        )
+        return (
+          <li key={item.key}>
+            {href ? (
+              <Link
+                href={href(item.key)}
+                className="block rounded-lg hover:bg-elevated/50 transition-colors py-1"
+              >
+                {row}
+              </Link>
+            ) : (
+              <div className="py-1">{row}</div>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
 
-  const [loading, setLoading] = useState(!hasInitialData);
-  const [error, setError] = useState<string | null>(null);
-  const [stats, setStats] = useState<Stats | null>(initialStats);
-  const [trending, setTrending] = useState<TrendingCategory[]>(initialTrending ?? []);
-  const [authors, setAuthors] = useState<Author[]>(normalizeAuthors(initialAuthors ?? []));
-
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    const results = await Promise.allSettled([
-      getStatsAction(),
-      getTrendingCategoriesAction(8),
-      getTrendingAuthorsAction(5),
-    ]);
-
-    if (results[0].status === "fulfilled" && results[0].value.database) {
-      setStats(results[0].value.database);
-    }
-    if (results[1].status === "fulfilled") {
-      setTrending(results[1].value as TrendingCategory[]);
-    }
-    if (results[2].status === "fulfilled" && results[2].value.trending_authors) {
-      setAuthors(normalizeAuthors(results[2].value.trending_authors));
-    }
-
-    // Surface an explicit error (with retry) when nothing loaded, instead of
-    // silently rendering the "No data available" empty state.
-    if (results.every((r) => r.status === "rejected")) {
-      const reason = (results[0] as PromiseRejectedResult).reason;
-      console.error("Failed to load insights:", reason);
-      setError(reason instanceof Error ? reason.message : "Failed to load insights");
-    }
-    setLoading(false);
-  }, []);
-
-  // Fetch on mount only when the server page couldn't provide initial data.
-  useEffect(() => {
-    if (!hasInitialData) {
-      loadData();
-    }
-  }, [hasInitialData, loadData]);
-
-  if (loading) {
-    return <InsightsPageSkeleton />;
-  }
-
-  if (error) {
-    return (
-      <div
-        className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center"
-        role="alert"
+/** Inline SVG bar chart for the daily publishing volume (single-hue, tanzanite). */
+function VolumeChart({ series }: { series: InsightsBundle['volume']['series'] }) {
+  if (series.length === 0) return null
+  const max = Math.max(1, ...series.map((p) => p.count))
+  const n = series.length
+  const gap = 0.25
+  const barW = (100 - gap * (n - 1)) / n
+  return (
+    <div className="text-primary">
+      <svg
+        viewBox="0 0 100 40"
+        preserveAspectRatio="none"
+        className="w-full h-40"
+        role="img"
+        aria-label={`Daily publishing volume over ${n} days, peaking at ${formatNumber(max)} articles`}
       >
-        <WifiOff className="w-12 h-12 text-text-tertiary mb-4" aria-hidden="true" />
-        <p className="text-lg text-text-secondary mb-2">Unable to load insights</p>
-        <p className="text-sm text-text-tertiary mb-6 max-w-md">{error}</p>
-        <button
-          onClick={() => loadData()}
-          className="flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-full font-medium hover:opacity-90 transition-opacity"
-        >
-          <RefreshCw className="w-4 h-4" aria-hidden="true" />
-          Try Again
-        </button>
-      </div>
-    );
+        {series.map((p, i) => {
+          const h = (p.count / max) * 38
+          const x = i * (barW + gap)
+          const y = 40 - h
+          return (
+            <rect
+              key={p.date}
+              x={x}
+              y={y}
+              width={barW}
+              height={Math.max(h, 0.4)}
+              rx={0.4}
+              fill="currentColor"
+            >
+              <title>{`${p.date}: ${formatNumber(p.count)} articles`}</title>
+            </rect>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Leaderboard (client-sortable table)
+// ---------------------------------------------------------------------------
+
+type LeaderRow = InsightsBundle['leaderboard'][number]
+type SortKey = 'name' | 'articleCount' | 'avgQualityScore' | 'avgWordCount' | 'countries' | 'lastPublished'
+
+function SourceLeaderboard({ rows }: { rows: LeaderRow[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>('articleCount')
+  const [asc, setAsc] = useState(false)
+
+  const sorted = useMemo(() => {
+    const copy = [...rows]
+    copy.sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'name':
+          cmp = a.name.localeCompare(b.name)
+          break
+        case 'countries':
+          cmp = a.countries.length - b.countries.length
+          break
+        case 'lastPublished':
+          cmp = (a.lastPublished ?? '').localeCompare(b.lastPublished ?? '')
+          break
+        default:
+          cmp = (a[sortKey] as number) - (b[sortKey] as number)
+      }
+      return asc ? cmp : -cmp
+    })
+    return copy
+  }, [rows, sortKey, asc])
+
+  const toggle = (key: SortKey) => {
+    if (key === sortKey) setAsc((v) => !v)
+    else {
+      setSortKey(key)
+      setAsc(key === 'name')
+    }
   }
+
+  const header = (key: SortKey, label: string, align = 'text-left') => (
+    <th className={`px-3 py-2 ${align}`}>
+      <button
+        type="button"
+        onClick={() => toggle(key)}
+        className="inline-flex items-center gap-1 font-semibold text-text-secondary hover:text-foreground transition-colors"
+        aria-label={`Sort by ${label}`}
+      >
+        {label}
+        <ArrowUpDown
+          className={`w-3 h-3 ${sortKey === key ? 'text-primary' : 'text-text-tertiary'}`}
+          aria-hidden="true"
+        />
+      </button>
+    </th>
+  )
+
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-elevated">
+      <table className="w-full text-sm border-collapse">
+        <thead className="bg-elevated/40">
+          <tr>
+            {header('name', 'Source')}
+            {header('articleCount', 'Articles', 'text-right')}
+            {header('avgQualityScore', 'Avg quality', 'text-right')}
+            {header('avgWordCount', 'Avg words', 'text-right')}
+            {header('countries', 'Countries', 'text-right')}
+            {header('lastPublished', 'Last published', 'text-right')}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((r) => (
+            <tr key={r.sourceId} className="border-t border-elevated hover:bg-elevated/30">
+              <td className="px-3 py-2">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-foreground truncate max-w-[220px]">
+                    {r.name}
+                  </span>
+                  {r.verified && (
+                    <BadgeCheck
+                      className="w-4 h-4 text-secondary shrink-0"
+                      aria-label="Verified publisher"
+                    />
+                  )}
+                </div>
+                {r.organization && r.organization !== r.name && (
+                  <div className="text-xs text-text-tertiary truncate max-w-[220px]">
+                    {r.organization}
+                  </div>
+                )}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-foreground">
+                {formatNumber(r.articleCount)}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                {r.avgQualityScore > 0 ? r.avgQualityScore.toFixed(2) : '—'}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                {r.avgWordCount > 0 ? formatNumber(r.avgWordCount) : '—'}
+              </td>
+              <td className="px-3 py-2 text-right font-mono text-text-secondary">
+                {r.countries.length > 0 ? r.countries.join(', ') : '—'}
+              </td>
+              <td className="px-3 py-2 text-right text-text-secondary whitespace-nowrap">
+                {formatDay(r.lastPublished)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Section wrapper
+// ---------------------------------------------------------------------------
+
+function Section({
+  title,
+  caption,
+  children,
+}: {
+  title: string
+  caption?: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="mb-10">
+      <div className="mb-4">
+        <h2 className="text-xl font-bold text-foreground">{title}</h2>
+        {caption && <p className="text-sm text-text-secondary mt-1">{caption}</p>}
+      </div>
+      {children}
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export default function InsightsClient({ data }: { data: InsightsBundle }) {
+  const { summary, volume, leaderboard, categories, countries, sentiment, topics } = data
+
+  const isEmpty =
+    summary.totalArticles === 0 &&
+    volume.total === 0 &&
+    leaderboard.length === 0 &&
+    categories.categories.length === 0 &&
+    countries.countries.length === 0
 
   return (
     <ErrorBoundary
@@ -184,136 +331,229 @@ export default function InsightsClient({
     >
       <div className="max-w-[1200px] mx-auto px-6 py-8">
         {/* Header */}
-        <div className="mb-8">
+        <header className="mb-8">
           <div className="flex items-center gap-3 mb-2">
-            <BarChart3 className="w-8 h-8 text-primary" />
-            <h1 className="text-3xl font-bold text-foreground">Insights</h1>
+            <BarChart3 className="w-8 h-8 text-primary" aria-hidden="true" />
+            <h1 className="text-3xl font-bold text-foreground">Open Data &amp; Insights</h1>
           </div>
-          <p className="text-text-secondary">
-            Analytics and trending topics across African news
+          <p className="text-text-secondary max-w-2xl">
+            A live, public analytics view of the Mukoko News corpus — every figure is computed
+            directly from the articles we aggregate across African newsrooms. Open data, free to
+            download.
           </p>
-        </div>
-
-        {/* Stats Grid */}
-        {stats && (
-          <div className="grid grid-cols-3 gap-4 mb-8">
-            <div className="bg-surface rounded-2xl p-6 text-center border border-elevated">
-              <Newspaper className="w-8 h-8 text-primary mx-auto mb-3" />
-              <div className="text-3xl font-bold text-foreground mb-1">
-                {stats.total_articles.toLocaleString()}
-              </div>
-              <div className="text-sm text-text-secondary">Articles</div>
-            </div>
-            <div className="bg-surface rounded-2xl p-6 text-center border border-elevated">
-              <Users className="w-8 h-8 text-primary mx-auto mb-3" />
-              <div className="text-3xl font-bold text-foreground mb-1">
-                {stats.active_sources}
-              </div>
-              <div className="text-sm text-text-secondary">Sources</div>
-            </div>
-            <div className="bg-surface rounded-2xl p-6 text-center border border-elevated">
-              <Layers className="w-8 h-8 text-primary mx-auto mb-3" />
-              <div className="text-3xl font-bold text-foreground mb-1">
-                {stats.categories > 0 ? stats.categories : trending.length}
-              </div>
-              <div className="text-sm text-text-secondary">Topics</div>
-            </div>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <a
+              href="/api/insights/export?format=json"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-on-primary rounded-full text-sm font-medium hover:opacity-90 transition-opacity"
+              download
+            >
+              <Download className="w-4 h-4" aria-hidden="true" />
+              Download open data (JSON)
+            </a>
+            <a
+              href="/api/insights/export?format=csv"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-surface border border-elevated text-foreground rounded-full text-sm font-medium hover:bg-elevated/50 transition-colors"
+              download
+            >
+              <Download className="w-4 h-4" aria-hidden="true" />
+              Download tables (CSV)
+            </a>
           </div>
-        )}
+        </header>
 
-        {/* Trending Topics */}
-        {trending.length > 0 && (
-          <section className="mb-8">
-            <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2">
-              <span>🔥</span> Trending Now
-            </h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              {trending.map((topic, i) => (
-                <Link
-                  key={topic.id}
-                  href={`/discover?category=${topic.id}`}
-                  className="bg-surface rounded-xl p-4 border border-elevated hover:border-primary/50 transition-colors"
-                >
-                  <div className="flex justify-between items-start mb-2">
-                    <span className="text-2xl">{getEmoji(topic.name)}</span>
-                    {i < 3 && (
-                      <span className="w-6 h-6 rounded-full bg-amber-500 text-white text-xs font-bold flex items-center justify-center">
-                        {i + 1}
-                      </span>
-                    )}
-                  </div>
-                  <h3 className="font-semibold text-foreground mb-1 truncate">
-                    {topic.name}
-                  </h3>
-                  <p className="text-xs text-text-secondary">
-                    {topic.article_count} articles
-                  </p>
-                  {topic.growth_rate && topic.growth_rate > 0 && (
-                    <div className="flex items-center gap-1 mt-2 text-green-600">
-                      <TrendingUp className="w-3 h-3" />
-                      <span className="text-xs font-medium">
-                        +{Math.round(topic.growth_rate)}%
-                      </span>
-                    </div>
-                  )}
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* Top Journalists */}
-        {authors.length > 0 && (
-          <section>
-            <h2 className="text-xl font-bold text-foreground mb-4 flex items-center gap-2">
-              <span>✍️</span> Top Journalists
-            </h2>
-            <div className="bg-surface rounded-xl border border-elevated divide-y divide-elevated">
-              {authors.map((author, i) => (
-                <Link
-                  key={author.id}
-                  href={`/search?q=${encodeURIComponent(author.name)}`}
-                  className="flex items-center p-4 hover:bg-elevated/50 transition-colors"
-                >
-                  <div
-                    className={`w-8 h-8 rounded-full flex items-center justify-center mr-4 font-bold text-sm ${
-                      i === 0
-                        ? "bg-accent text-on-accent"
-                        : i === 1
-                          ? "bg-elevated text-foreground"
-                          : i === 2
-                            ? "bg-warning text-on-warning"
-                            : "bg-surface text-foreground"
-                    }`}
-                  >
-                    {i + 1}
-                  </div>
-                  <div className="flex-1">
-                    <h3 className="font-medium text-foreground">{author.name}</h3>
-                    <p className="text-xs text-text-secondary">
-                      {author.article_count} articles
-                    </p>
-                  </div>
-                  <ChevronRight className="w-5 h-5 text-text-tertiary" />
-                </Link>
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* Empty State */}
-        {!stats && trending.length === 0 && authors.length === 0 && (
-          <div className="text-center py-16">
-            <span className="text-6xl mb-4 block">📊</span>
-            <h3 className="text-lg font-semibold text-foreground mb-2">
-              No data available
-            </h3>
+        {isEmpty ? (
+          <div className="text-center py-16" role="status">
+            <span className="text-6xl mb-4 block" aria-hidden="true">
+              📊
+            </span>
+            <h3 className="text-lg font-semibold text-foreground mb-2">No data available yet</h3>
             <p className="text-text-secondary">
-              Check back later for insights and analytics
+              Analytics will appear here once the corpus has been populated. Check back shortly.
             </p>
           </div>
+        ) : (
+          <>
+            {/* Corpus summary */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+              <StatTile
+                icon={Newspaper}
+                label="Articles"
+                value={formatNumber(summary.totalArticles)}
+              />
+              <StatTile icon={Radio} label="Sources" value={formatNumber(summary.sources)} />
+              <StatTile
+                icon={Building2}
+                label="Publishers"
+                value={formatNumber(summary.organizations)}
+              />
+              <StatTile
+                icon={Globe2}
+                label="Countries"
+                value={formatNumber(summary.countries)}
+              />
+              <StatTile
+                icon={Sparkles}
+                label="AI-enriched"
+                value={`${summary.aiEnrichedPct}%`}
+                caption="of the corpus"
+              />
+              <StatTile
+                icon={Gauge}
+                label="Avg quality"
+                value={summary.avgQualityScore > 0 ? summary.avgQualityScore.toFixed(2) : '—'}
+                caption="0–1 quality score"
+              />
+              <StatTile
+                icon={CalendarRange}
+                label="Earliest"
+                value={formatDay(summary.earliest)}
+              />
+              <StatTile icon={CalendarRange} label="Latest" value={formatDay(summary.latest)} />
+            </div>
+
+            {/* Publishing volume */}
+            {volume.total > 0 && (
+              <Section
+                title="Publishing volume"
+                caption={`${formatNumber(volume.total)} articles over the last ${volume.days} days (${formatDay(
+                  volume.from
+                )} – ${formatDay(volume.to)}).`}
+              >
+                <div className="bg-surface rounded-2xl border border-elevated p-5">
+                  <VolumeChart series={volume.series} />
+                  <div className="flex justify-between mt-2 text-xs text-text-tertiary font-mono">
+                    <span>{formatDay(volume.from)}</span>
+                    <span>{formatDay(volume.to)}</span>
+                  </div>
+                  {volume.topSources.length > 0 && (
+                    <p className="text-xs text-text-secondary mt-4">
+                      Most active sources in this window:{' '}
+                      {volume.topSources
+                        .slice(0, 5)
+                        .map((s) => `${s.name} (${formatNumber(s.count)})`)
+                        .join(', ')}
+                      .
+                    </p>
+                  )}
+                </div>
+              </Section>
+            )}
+
+            {/* Source / organization leaderboard */}
+            {leaderboard.length > 0 && (
+              <Section
+                title="Media organizations"
+                caption="Sources ranked by output, with average article quality and length, countries covered and last-published time. Click a column to sort."
+              >
+                <SourceLeaderboard rows={leaderboard} />
+              </Section>
+            )}
+
+            <div className="grid md:grid-cols-2 gap-10">
+              {/* Category distribution */}
+              {categories.categories.length > 0 && (
+                <Section
+                  title="Topic distribution"
+                  caption={`Share of ${formatNumber(
+                    categories.totalAssignments
+                  )} category assignments — top ${categories.categories.length} cover ${categories.coverage}%.`}
+                >
+                  <BarList
+                    colorClass="bg-cobalt"
+                    href={(slug) => `/discover?category=${encodeURIComponent(slug)}`}
+                    items={categories.categories.map((c) => ({
+                      key: c.slug,
+                      label: humanize(c.slug),
+                      emoji: getCategoryEmoji(c.slug),
+                      value: c.count,
+                      share: c.share,
+                    }))}
+                  />
+                </Section>
+              )}
+
+              {/* Country coverage */}
+              {countries.countries.length > 0 && (
+                <Section
+                  title="Country coverage"
+                  caption={`Articles by country of publication, across ${countries.countries.length} countries.`}
+                >
+                  <BarList
+                    colorClass="bg-malachite"
+                    items={countries.countries.slice(0, 15).map((c) => ({
+                      key: c.code,
+                      label: c.name,
+                      value: c.count,
+                      share: c.share,
+                    }))}
+                  />
+                </Section>
+              )}
+            </div>
+
+            {/* Sentiment breakdown */}
+            {sentiment.breakdown.length > 0 && (
+              <Section
+                title="Sentiment"
+                caption={`AI-assessed tone. Coverage: ${sentiment.coverage}% of the corpus is enriched with a sentiment label (${formatNumber(
+                  sentiment.total
+                )} articles) — the rest is not yet processed.`}
+              >
+                <div className="bg-surface rounded-2xl border border-elevated p-5 space-y-3">
+                  {sentiment.breakdown.map((s) => {
+                    const style = SENTIMENT_STYLE[s.sentiment] ?? {
+                      bar: 'bg-text-tertiary',
+                      label: humanize(s.sentiment),
+                    }
+                    return (
+                      <div key={s.sentiment} className="flex items-center gap-3">
+                        <div className="w-24 shrink-0 text-sm text-foreground">{style.label}</div>
+                        <div className="flex-1 h-3 rounded-full bg-elevated overflow-hidden">
+                          <div
+                            className={`h-full rounded-full ${style.bar}`}
+                            style={{ width: `${Math.max(2, s.share)}%` }}
+                          />
+                        </div>
+                        <div className="w-28 shrink-0 text-right text-xs text-text-secondary font-mono">
+                          {formatNumber(s.count)} · {s.share}%
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              </Section>
+            )}
+
+            {/* Trending topics */}
+            {topics.length > 0 && (
+              <Section
+                title="Trending topics"
+                caption="Most-tagged topics across the last 7 days."
+              >
+                <div className="flex flex-wrap gap-2">
+                  {topics.map((t) => (
+                    <Link
+                      key={t.tag}
+                      href={`/search?q=${encodeURIComponent(t.tag)}`}
+                      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-container-tanzanite text-on-container-tanzanite text-sm hover:opacity-90 transition-opacity"
+                    >
+                      <TrendingUp className="w-3.5 h-3.5" aria-hidden="true" />
+                      {humanize(t.tag)}
+                      <span className="font-mono text-xs opacity-70">{formatNumber(t.count)}</span>
+                    </Link>
+                  ))}
+                </div>
+              </Section>
+            )}
+
+            <footer className="mt-8 pt-6 border-t border-elevated text-xs text-text-tertiary">
+              Figures are computed live from the Mukoko News corpus and cached for up to 10 minutes.
+              Metrics over enriched subsets (sentiment, quality) are labelled with their coverage.
+              Data generated {formatDay(data.generatedAt)}.
+            </footer>
+          </>
         )}
       </div>
     </ErrorBoundary>
-  );
+  )
 }

--- a/src/app/insights/layout.tsx
+++ b/src/app/insights/layout.tsx
@@ -2,23 +2,24 @@ import type { Metadata } from "next";
 import { getFullUrl } from "@/lib/constants";
 
 export const metadata: Metadata = {
-  title: "Insights",
+  title: "Open Data & Insights",
   description:
-    "Analytics and trending topics across African news. See platform stats, trending categories, and top journalists on Mukoko News.",
+    "A live, public analytics dashboard for African news. Publishing volume, media-organization leaderboard, topic and country coverage, and sentiment — computed from the Mukoko News corpus and free to download as open data (JSON/CSV).",
   alternates: {
     canonical: getFullUrl("/insights"),
   },
   openGraph: {
-    title: "News Insights & Analytics | Mukoko News",
+    title: "Open Data & Insights | Mukoko News",
     description:
-      "Trending topics, analytics, and top journalists across African news.",
+      "Public analytics for African news: publishing volume, source leaderboard, topic and country coverage, sentiment. Open data, free to download.",
     url: getFullUrl("/insights"),
     type: "website",
   },
   twitter: {
     card: "summary",
-    title: "News Insights | Mukoko News",
-    description: "Trending topics and analytics across African news.",
+    title: "Open Data & Insights | Mukoko News",
+    description:
+      "Public analytics for African news, computed from the corpus. Open data, free to download.",
     creator: "@mukokoafrica",
   },
 };

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,40 +1,13 @@
-import InsightsClient, { type Stats, type TrendingCategory } from "./insights-client";
-import {
-  getStatsAction,
-  getTrendingCategoriesAction,
-  getTrendingAuthorsAction,
-} from "@/lib/actions/feed";
+import InsightsClient from './insights-client'
+import { getInsightsBundleAction } from '@/lib/actions/insights'
 
-// ISR: insights are aggregate stats — 5 minutes of staleness is fine, and the
-// cached HTML paints immediately instead of a client-side spinner.
-export const revalidate = 300;
+// ISR: the dashboard is aggregate open-data — 10 minutes of staleness is fine,
+// and the cached HTML paints immediately (server-rendered, no client spinner).
+// The read layer never throws (each metric degrades to an empty-but-typed
+// result), so a degraded cluster renders empty sections rather than a 500.
+export const revalidate = 600
 
 export default async function InsightsPage() {
-  // Failures degrade gracefully: null props make the client component fetch on
-  // mount and show an explicit error state (with retry) if that also fails.
-  const [statsResult, trendingResult, authorsResult] = await Promise.allSettled([
-    getStatsAction(),
-    getTrendingCategoriesAction(8),
-    getTrendingAuthorsAction(5),
-  ]);
-
-  const initialStats: Stats | null =
-    statsResult.status === "fulfilled" ? statsResult.value.database : null;
-  const initialTrending: TrendingCategory[] | null =
-    trendingResult.status === "fulfilled" ? trendingResult.value : null;
-  // Raw payload — normalised in the client (authors can be schema.org objects).
-  const initialAuthors: unknown[] | null =
-    authorsResult.status === "fulfilled" ? authorsResult.value.trending_authors : null;
-
-  if (statsResult.status === "rejected") {
-    console.error("[InsightsPage] Failed to prefetch stats:", statsResult.reason);
-  }
-
-  return (
-    <InsightsClient
-      initialStats={initialStats}
-      initialTrending={initialTrending}
-      initialAuthors={initialAuthors}
-    />
-  );
+  const data = await getInsightsBundleAction()
+  return <InsightsClient data={data} />
 }

--- a/src/lib/__tests__/insights.test.ts
+++ b/src/lib/__tests__/insights.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getPublishingVolume,
+  getSourceLeaderboard,
+  getCategoryDistribution,
+  getCountryCoverage,
+  getSentimentBreakdown,
+  getCorpusSummary,
+  getTopTopics,
+} from '../mongodb/insights'
+import { getDb } from '../mongodb/client'
+
+vi.mock('../mongodb/client', () => ({ getDb: vi.fn() }))
+
+/** A fake aggregation cursor whose toArray resolves the supplied rows. */
+function cursor(rows: unknown[]) {
+  return { toArray: vi.fn().mockResolvedValue(rows) }
+}
+
+type Coll = {
+  aggregate: ReturnType<typeof vi.fn>
+  countDocuments: ReturnType<typeof vi.fn>
+  distinct: ReturnType<typeof vi.fn>
+}
+
+function coll(overrides: Partial<Coll> = {}): Coll {
+  return {
+    aggregate: vi.fn(() => cursor([])),
+    countDocuments: vi.fn().mockResolvedValue(0),
+    distinct: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  }
+}
+
+function useDb(collections: Record<string, Coll>) {
+  const db = {
+    collection: vi.fn((name: string) => {
+      if (!collections[name]) collections[name] = coll()
+      return collections[name]
+    }),
+  }
+  vi.mocked(getDb).mockResolvedValue(db as unknown as never)
+  return collections
+}
+
+const todayKey = new Date().toISOString().slice(0, 10)
+
+beforeEach(() => {
+  vi.mocked(getDb).mockReset()
+})
+
+describe('getPublishingVolume', () => {
+  it('zero-fills a daily series across the window and sums the total', async () => {
+    const articles = coll()
+    articles.aggregate
+      .mockReturnValueOnce(cursor([{ _id: todayKey, count: 5 }])) // day grouping
+      .mockReturnValueOnce(cursor([{ _id: 'src-1', count: 5, name: 'The Herald' }])) // top sources
+    useDb({ articles })
+
+    const result = await getPublishingVolume({ days: 7 })
+
+    expect(result.days).toBe(7)
+    expect(result.series).toHaveLength(7)
+    expect(result.total).toBe(5)
+    // Today's bucket carries the count; earlier days are zero-filled.
+    expect(result.series[result.series.length - 1]).toEqual({ date: todayKey, count: 5 })
+    expect(result.series[0].count).toBe(0)
+    expect(result.topSources).toEqual([{ sourceId: 'src-1', name: 'The Herald', count: 5 }])
+  })
+
+  it('clamps an absurd day count and never throws', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(cursor([]))
+    useDb({ articles })
+    const result = await getPublishingVolume({ days: 99999 })
+    expect(result.days).toBe(365)
+    expect(result.series).toHaveLength(365)
+  })
+
+  it('returns an empty-but-typed result when the DB throws', async () => {
+    vi.mocked(getDb).mockRejectedValue(new Error('atlas down'))
+    const result = await getPublishingVolume({ days: 30 })
+    expect(result.total).toBe(0)
+    expect(result.series).toEqual([])
+    expect(result.topSources).toEqual([])
+  })
+})
+
+describe('getSourceLeaderboard', () => {
+  it('maps grouped rows, joins names/orgs and resolves verification', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        {
+          _id: 'src-1',
+          articleCount: 120,
+          avgQualityScore: 0.8123,
+          avgWordCount: 640.6,
+          countries: ['ZW', 'ZA', null, ''],
+          lastPublished: new Date('2026-06-01T00:00:00Z'),
+          source: [{ name: 'The Herald', mediaOrganizationId: 'org-1', countryCode: 'ZW' }],
+          org: [{ name: 'Zimpapers', verified: true }],
+        },
+        {
+          _id: 'src-2',
+          articleCount: 40,
+          avgQualityScore: null,
+          avgWordCount: null,
+          countries: [],
+          lastPublished: null,
+          source: [{ name: 'Nameless', countryCode: 'KE' }],
+          org: [],
+        },
+      ])
+    )
+    useDb({ articles })
+
+    const rows = await getSourceLeaderboard({ limit: 10 })
+
+    expect(rows[0]).toMatchObject({
+      sourceId: 'src-1',
+      name: 'The Herald',
+      organization: 'Zimpapers',
+      verified: true,
+      articleCount: 120,
+      avgQualityScore: 0.812,
+      avgWordCount: 641,
+      countries: ['ZA', 'ZW'],
+      lastPublished: '2026-06-01T00:00:00.000Z',
+    })
+    // Falls back to the source country code when article-level codes are absent.
+    expect(rows[1]).toMatchObject({
+      name: 'Nameless',
+      verified: false,
+      avgQualityScore: 0,
+      avgWordCount: 0,
+      countries: ['KE'],
+      lastPublished: null,
+    })
+  })
+
+  it('returns [] when the DB throws', async () => {
+    vi.mocked(getDb).mockRejectedValue(new Error('down'))
+    expect(await getSourceLeaderboard({ limit: 5 })).toEqual([])
+  })
+})
+
+describe('getCategoryDistribution', () => {
+  it('computes per-slug counts, shares and top-N coverage', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        {
+          top: [
+            { _id: 'politics', count: 60 },
+            { _id: 'business', count: 40 },
+          ],
+          totals: [{ total: 200 }],
+        },
+      ])
+    )
+    useDb({ articles })
+
+    const result = await getCategoryDistribution()
+    expect(result.totalAssignments).toBe(200)
+    expect(result.categories).toEqual([
+      { slug: 'politics', count: 60, share: 30 },
+      { slug: 'business', count: 40, share: 20 },
+    ])
+    // Top slugs cover (60+40)/200 = 50%.
+    expect(result.coverage).toBe(50)
+  })
+
+  it('returns the empty shape when there are no assignments', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(cursor([{ top: [], totals: [] }]))
+    useDb({ articles })
+    const result = await getCategoryDistribution()
+    expect(result).toEqual({ totalAssignments: 0, coverage: 0, categories: [] })
+  })
+})
+
+describe('getCountryCoverage', () => {
+  it('maps country codes to names and computes shares', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        { _id: 'ZW', count: 75 },
+        { _id: 'ZA', count: 25 },
+        { _id: 'XX', count: 0 },
+      ])
+    )
+    useDb({ articles })
+
+    const result = await getCountryCoverage()
+    expect(result.total).toBe(100)
+    expect(result.countries[0]).toEqual({ code: 'ZW', name: 'Zimbabwe', count: 75, share: 75 })
+    // Unknown code keeps the raw code as its display name.
+    expect(result.countries[2]).toEqual({ code: 'XX', name: 'XX', count: 0, share: 0 })
+  })
+})
+
+describe('getSentimentBreakdown', () => {
+  it('reports per-sentiment counts and corpus coverage', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        { _id: 'positive', count: 30 },
+        { _id: 'neutral', count: 50 },
+        { _id: 'negative', count: 20 },
+      ])
+    )
+    articles.countDocuments.mockResolvedValue(400) // whole corpus
+    useDb({ articles })
+
+    const result = await getSentimentBreakdown()
+    expect(result.total).toBe(100)
+    // 100 enriched-with-sentiment out of 400 total = 25% coverage.
+    expect(result.coverage).toBe(25)
+    expect(result.breakdown[0]).toEqual({ sentiment: 'positive', count: 30, share: 30 })
+  })
+
+  it('returns the empty shape when nothing is enriched', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(cursor([]))
+    articles.countDocuments.mockResolvedValue(400)
+    useDb({ articles })
+    const result = await getSentimentBreakdown()
+    expect(result).toEqual({ total: 0, coverage: 0, breakdown: [] })
+  })
+})
+
+describe('getCorpusSummary', () => {
+  it('aggregates totals, enrichment %, avg quality, date range and distinct countries', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        {
+          totalArticles: [{ n: 1000 }],
+          aiEnriched: [{ n: 750 }],
+          quality: [{ avg: 0.7266 }],
+          range: [
+            { earliest: new Date('2025-01-01T00:00:00Z'), latest: new Date('2026-06-30T00:00:00Z') },
+          ],
+        },
+      ])
+    )
+    articles.distinct.mockResolvedValue(['ZW', 'ZA', 'KE', '', null])
+    const feedSources = coll()
+    feedSources.countDocuments.mockResolvedValue(42)
+    const newsMediaOrganizations = coll()
+    newsMediaOrganizations.countDocuments.mockResolvedValue(30)
+    useDb({ articles, feedSources, newsMediaOrganizations })
+
+    const result = await getCorpusSummary()
+    expect(result).toEqual({
+      totalArticles: 1000,
+      sources: 42,
+      organizations: 30,
+      countries: 3,
+      aiEnrichedPct: 75,
+      avgQualityScore: 0.727,
+      earliest: '2025-01-01T00:00:00.000Z',
+      latest: '2026-06-30T00:00:00.000Z',
+    })
+  })
+
+  it('returns the empty summary when the DB throws', async () => {
+    vi.mocked(getDb).mockRejectedValue(new Error('down'))
+    const result = await getCorpusSummary()
+    expect(result.totalArticles).toBe(0)
+    expect(result.earliest).toBeNull()
+  })
+})
+
+describe('getTopTopics', () => {
+  it('returns tag counts and clamps the limit', async () => {
+    const articles = coll()
+    articles.aggregate.mockReturnValue(
+      cursor([
+        { _id: 'elections', count: 12 },
+        { _id: 'load-shedding', count: 8 },
+      ])
+    )
+    useDb({ articles })
+    const result = await getTopTopics({ limit: 5 })
+    expect(result).toEqual([
+      { tag: 'elections', count: 12 },
+      { tag: 'load-shedding', count: 8 },
+    ])
+  })
+
+  it('returns [] when the DB throws', async () => {
+    vi.mocked(getDb).mockRejectedValue(new Error('down'))
+    expect(await getTopTopics({ limit: 5 })).toEqual([])
+  })
+})

--- a/src/lib/actions/insights.ts
+++ b/src/lib/actions/insights.ts
@@ -1,0 +1,97 @@
+'use server'
+
+/**
+ * Server Actions for the public open-data Insights dashboard.
+ *
+ * These expose the read-only aggregations in `@/lib/mongodb/insights` to the
+ * `/insights` page (server component) and, indirectly, to the open-data export
+ * route. Per the repo's data-flow rule, reads go straight to the `news` DB via
+ * Server Actions — never through the gateway Worker.
+ *
+ * Inputs are clamped in the MongoDB layer (clampInt); the read functions never
+ * throw (each returns an empty-but-typed result on failure), so these thin
+ * wrappers stay side-effect free and safe to call from cached server renders.
+ */
+
+import {
+  getPublishingVolume,
+  getSourceLeaderboard,
+  getCategoryDistribution,
+  getCountryCoverage,
+  getSentimentBreakdown,
+  getCorpusSummary,
+  getTopTopics,
+  type PublishingVolume,
+  type SourceLeaderboardRow,
+  type CategoryDistribution,
+  type CountryCoverage,
+  type SentimentBreakdown,
+  type CorpusSummary,
+  type TopTopic,
+} from '@/lib/mongodb/insights'
+
+export async function getPublishingVolumeAction(days = 30): Promise<PublishingVolume> {
+  return getPublishingVolume({ days })
+}
+
+export async function getSourceLeaderboardAction(limit = 20): Promise<SourceLeaderboardRow[]> {
+  return getSourceLeaderboard({ limit })
+}
+
+export async function getCategoryDistributionAction(): Promise<CategoryDistribution> {
+  return getCategoryDistribution()
+}
+
+export async function getCountryCoverageAction(): Promise<CountryCoverage> {
+  return getCountryCoverage()
+}
+
+export async function getSentimentBreakdownAction(): Promise<SentimentBreakdown> {
+  return getSentimentBreakdown()
+}
+
+export async function getCorpusSummaryAction(): Promise<CorpusSummary> {
+  return getCorpusSummary()
+}
+
+export async function getTopTopicsAction(limit = 10): Promise<TopTopic[]> {
+  return getTopTopics({ limit })
+}
+
+/**
+ * Aggregate everything the dashboard + open-data export need in one call, so
+ * the page and the route share exactly one data contract.
+ */
+export interface InsightsBundle {
+  summary: CorpusSummary
+  volume: PublishingVolume
+  leaderboard: SourceLeaderboardRow[]
+  categories: CategoryDistribution
+  countries: CountryCoverage
+  sentiment: SentimentBreakdown
+  topics: TopTopic[]
+  generatedAt: string
+}
+
+export async function getInsightsBundleAction(): Promise<InsightsBundle> {
+  const [summary, volume, leaderboard, categories, countries, sentiment, topics] =
+    await Promise.all([
+      getCorpusSummary(),
+      getPublishingVolume({ days: 30 }),
+      getSourceLeaderboard({ limit: 20 }),
+      getCategoryDistribution(),
+      getCountryCoverage(),
+      getSentimentBreakdown(),
+      getTopTopics({ limit: 12 }),
+    ])
+  return {
+    summary,
+    volume,
+    leaderboard,
+    categories,
+    countries,
+    sentiment,
+    topics,
+    generatedAt: new Date().toISOString(),
+  }
+}

--- a/src/lib/mongodb/insights.ts
+++ b/src/lib/mongodb/insights.ts
@@ -1,0 +1,545 @@
+/**
+ * Server-side MongoDB aggregations for the public open-data Insights dashboard.
+ *
+ * READ-ONLY. Every export queries the `news` database directly via getDb() and
+ * is wrapped so that any failure (Atlas unreachable, a bad pipeline, a missing
+ * collection) returns an empty-but-typed result instead of throwing to the
+ * page/route. This keeps `/insights` server-rendered and resilient: a degraded
+ * cluster yields empty sections, never a 500.
+ *
+ * Every number is computed from the live corpus. Metrics with partial coverage
+ * (e.g. sentiment, which only exists on AI-enriched articles) carry an explicit
+ * coverage figure so the UI can label them honestly.
+ *
+ * Import only in Server Components, Route Handlers, or Server Actions.
+ */
+
+import { getDb } from './client'
+import { clampInt } from '@/lib/safety'
+import { COUNTRIES } from '@/lib/constants'
+
+// Base visibility filter — mirrors the article read layer (articles.ts): hide
+// rejected/removed documents so public analytics reflect the live catalogue.
+const BASE_MATCH = {
+  status: { $ne: 'rejected' },
+  moderationStatus: { $ne: 'removed' },
+} as const
+
+const COUNTRY_NAMES: Record<string, string> = Object.fromEntries(
+  COUNTRIES.map((c) => [c.code, c.name])
+)
+
+/** Round to `dp` decimal places, returning 0 for null/NaN/undefined. */
+function round(value: unknown, dp = 2): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : 0
+  const f = 10 ** dp
+  return Math.round(n * f) / f
+}
+
+/** YYYY-MM-DD (UTC) for a Date. */
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+// ---------------------------------------------------------------------------
+// Publishing volume
+// ---------------------------------------------------------------------------
+
+export interface VolumePoint {
+  /** UTC calendar day, YYYY-MM-DD. */
+  date: string
+  count: number
+}
+
+export interface PublishingVolume {
+  days: number
+  /** Inclusive UTC day range covered by the series. */
+  from: string
+  to: string
+  /** Total articles published in the window. */
+  total: number
+  /** One point per day, ascending, zero-filled across the whole range. */
+  series: VolumePoint[]
+  /** Top sources by volume in the window (context for the overall series). */
+  topSources: Array<{ sourceId: string; name: string; count: number }>
+}
+
+const EMPTY_VOLUME = (days: number): PublishingVolume => {
+  const to = new Date()
+  const from = new Date(to.getTime() - (days - 1) * 86_400_000)
+  return {
+    days,
+    from: isoDay(from),
+    to: isoDay(to),
+    total: 0,
+    series: [],
+    topSources: [],
+  }
+}
+
+/**
+ * Articles published per UTC day over the last `days` (default 30), plus the
+ * top sources contributing to that window. The daily series is zero-filled so
+ * the chart has a point for every day even when nothing was published.
+ */
+export async function getPublishingVolume({
+  days = 30,
+}: { days?: number } = {}): Promise<PublishingVolume> {
+  const window = clampInt(days, 1, 365, 30)
+  try {
+    const db = await getDb()
+    const now = new Date()
+    // Start of the window: midnight UTC, `window - 1` days back (inclusive of today).
+    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+    start.setUTCDate(start.getUTCDate() - (window - 1))
+
+    const match = { ...BASE_MATCH, datePublished: { $gte: start } }
+    const col = db.collection('articles')
+
+    const [dayRows, sourceRows] = await Promise.all([
+      col
+        .aggregate<{ _id: string; count: number }>([
+          { $match: match },
+          {
+            $group: {
+              _id: { $dateToString: { format: '%Y-%m-%d', date: '$datePublished', timezone: 'UTC' } },
+              count: { $sum: 1 },
+            },
+          },
+        ])
+        .toArray(),
+      col
+        .aggregate<{ _id: string; count: number; name?: string }>([
+          { $match: match },
+          { $group: { _id: '$feedSourceId', count: { $sum: 1 } } },
+          { $sort: { count: -1 } },
+          { $limit: 8 },
+          { $lookup: { from: 'feedSources', localField: '_id', foreignField: '_id', as: 'source' } },
+          { $addFields: { name: { $ifNull: [{ $arrayElemAt: ['$source.name', 0] }, '$_id'] } } },
+          { $project: { count: 1, name: 1 } },
+        ])
+        .toArray(),
+    ])
+
+    const counts = new Map(dayRows.map((r) => [r._id, r.count]))
+    const series: VolumePoint[] = []
+    let total = 0
+    for (let i = 0; i < window; i++) {
+      const d = new Date(start.getTime() + i * 86_400_000)
+      const key = isoDay(d)
+      const count = counts.get(key) ?? 0
+      total += count
+      series.push({ date: key, count })
+    }
+
+    return {
+      days: window,
+      from: series[0]?.date ?? isoDay(start),
+      to: series[series.length - 1]?.date ?? isoDay(now),
+      total,
+      series,
+      topSources: sourceRows.map((r) => ({
+        sourceId: r._id,
+        name: r.name || r._id,
+        count: r.count,
+      })),
+    }
+  } catch (error) {
+    console.error('[insights.getPublishingVolume]', error)
+    return EMPTY_VOLUME(window)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source / organization leaderboard
+// ---------------------------------------------------------------------------
+
+export interface SourceLeaderboardRow {
+  sourceId: string
+  name: string
+  /** Publisher organization display name, when linked. */
+  organization?: string
+  verified: boolean
+  articleCount: number
+  /** Average qualityScore (0..1) over articles that carry one. */
+  avgQualityScore: number
+  avgWordCount: number
+  /** Distinct country codes seen across this source's articles. */
+  countries: string[]
+  lastPublished: string | null
+}
+
+/**
+ * Per-source analytics: article count, average quality/length, countries
+ * covered and last-published time, joined to feedSources (display name) and
+ * newsMediaOrganizations (publisher + verification). This is the "media
+ * organizations" analytics surface.
+ */
+export async function getSourceLeaderboard({
+  limit = 20,
+}: { limit?: number } = {}): Promise<SourceLeaderboardRow[]> {
+  const max = clampInt(limit, 1, 100, 20)
+  try {
+    const db = await getDb()
+    const rows = await db
+      .collection('articles')
+      .aggregate<{
+        _id: string
+        articleCount: number
+        avgQualityScore: number | null
+        avgWordCount: number | null
+        countries: (string | null)[]
+        lastPublished: Date | null
+        source: Array<{ name?: string; mediaOrganizationId?: string; countryCode?: string }>
+        org: Array<{ name?: string; verified?: boolean; isVerified?: boolean; verificationStatus?: string }>
+      }>([
+        { $match: BASE_MATCH },
+        {
+          $group: {
+            _id: '$feedSourceId',
+            articleCount: { $sum: 1 },
+            avgQualityScore: { $avg: '$qualityScore' },
+            avgWordCount: { $avg: '$wordCount' },
+            countries: { $addToSet: '$countryCode' },
+            lastPublished: { $max: '$datePublished' },
+          },
+        },
+        { $sort: { articleCount: -1 } },
+        { $limit: max },
+        { $lookup: { from: 'feedSources', localField: '_id', foreignField: '_id', as: 'source' } },
+        {
+          $lookup: {
+            from: 'newsMediaOrganizations',
+            localField: 'source.mediaOrganizationId',
+            foreignField: '_id',
+            as: 'org',
+          },
+        },
+      ])
+      .toArray()
+
+    return rows.map((r) => {
+      const source = r.source?.[0]
+      const org = r.org?.[0]
+      const verified = Boolean(
+        org?.verified ?? org?.isVerified ?? org?.verificationStatus === 'verified'
+      )
+      const countries = (r.countries ?? [])
+        .filter((c): c is string => typeof c === 'string' && c.trim().length > 0)
+        .sort()
+      // Fall back to the source's own country when article-level codes are absent.
+      if (countries.length === 0 && source?.countryCode) countries.push(source.countryCode)
+      return {
+        sourceId: r._id,
+        name: source?.name || r._id,
+        organization: org?.name || undefined,
+        verified,
+        articleCount: r.articleCount,
+        avgQualityScore: round(r.avgQualityScore, 3),
+        avgWordCount: Math.round(r.avgWordCount ?? 0),
+        countries,
+        lastPublished: r.lastPublished ? new Date(r.lastPublished).toISOString() : null,
+      }
+    })
+  } catch (error) {
+    console.error('[insights.getSourceLeaderboard]', error)
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Category distribution
+// ---------------------------------------------------------------------------
+
+export interface CategoryDistribution {
+  /** Total category assignments across the corpus (an article may carry several). */
+  totalAssignments: number
+  /** Share of all assignments the returned (top) slugs account for. */
+  coverage: number
+  categories: Array<{ slug: string; count: number; share: number }>
+}
+
+const EMPTY_CATEGORY: CategoryDistribution = { totalAssignments: 0, coverage: 0, categories: [] }
+
+/**
+ * Article counts per `engagement.interest_categories` slug (top 15). Share is
+ * expressed against total category *assignments* (articles can hold several),
+ * and `coverage` reports how much of the corpus the returned slugs cover.
+ */
+export async function getCategoryDistribution(): Promise<CategoryDistribution> {
+  try {
+    const db = await getDb()
+    const rows = await db
+      .collection('articles')
+      .aggregate<{ _id: string; count: number }>([
+        { $match: BASE_MATCH },
+        { $unwind: '$engagement.interest_categories' },
+        { $group: { _id: '$engagement.interest_categories', count: { $sum: 1 } } },
+        { $match: { _id: { $type: 'string', $ne: '' } } },
+        { $sort: { count: -1 } },
+        // Compute the grand total, then slice the top 15 in JS from a facet.
+        {
+          $facet: {
+            top: [{ $limit: 15 }],
+            totals: [{ $group: { _id: null, total: { $sum: '$count' } } }],
+          },
+        },
+      ])
+      .toArray()
+
+    const facet = rows[0] as unknown as
+      | { top: Array<{ _id: string; count: number }>; totals: Array<{ total: number }> }
+      | undefined
+    const top = facet?.top ?? []
+    const totalAssignments = facet?.totals?.[0]?.total ?? 0
+    if (totalAssignments === 0) return EMPTY_CATEGORY
+
+    const categories = top.map((r) => ({
+      slug: String(r._id).trim(),
+      count: r.count,
+      share: round((r.count / totalAssignments) * 100, 1),
+    }))
+    const coverage = round(
+      (categories.reduce((s, c) => s + c.count, 0) / totalAssignments) * 100,
+      1
+    )
+    return { totalAssignments, coverage, categories }
+  } catch (error) {
+    console.error('[insights.getCategoryDistribution]', error)
+    return EMPTY_CATEGORY
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Country coverage
+// ---------------------------------------------------------------------------
+
+export interface CountryCoverage {
+  total: number
+  countries: Array<{ code: string; name: string; count: number; share: number }>
+}
+
+const EMPTY_COUNTRY: CountryCoverage = { total: 0, countries: [] }
+
+/**
+ * Article counts per `countryCode`, mapped to display names via COUNTRIES.
+ * Share is expressed against the total number of articles carrying a country.
+ */
+export async function getCountryCoverage(): Promise<CountryCoverage> {
+  try {
+    const db = await getDb()
+    const rows = await db
+      .collection('articles')
+      .aggregate<{ _id: string; count: number }>([
+        { $match: BASE_MATCH },
+        { $group: { _id: '$countryCode', count: { $sum: 1 } } },
+        { $match: { _id: { $type: 'string', $ne: '' } } },
+        { $sort: { count: -1 } },
+        { $limit: 60 },
+      ])
+      .toArray()
+
+    const total = rows.reduce((s, r) => s + r.count, 0)
+    if (total === 0) return EMPTY_COUNTRY
+    return {
+      total,
+      countries: rows.map((r) => {
+        const code = String(r._id).trim().toUpperCase()
+        return {
+          code,
+          name: COUNTRY_NAMES[code] || code,
+          count: r.count,
+          share: round((r.count / total) * 100, 1),
+        }
+      }),
+    }
+  } catch (error) {
+    console.error('[insights.getCountryCoverage]', error)
+    return EMPTY_COUNTRY
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sentiment breakdown
+// ---------------------------------------------------------------------------
+
+export interface SentimentBreakdown {
+  /** Articles carrying a sentiment label (the enriched subset). */
+  total: number
+  /** Share of the whole corpus that has been AI-enriched with a sentiment. */
+  coverage: number
+  breakdown: Array<{ sentiment: string; count: number; share: number }>
+}
+
+const EMPTY_SENTIMENT: SentimentBreakdown = { total: 0, coverage: 0, breakdown: [] }
+
+/**
+ * Counts per `aiSentiment` value over `aiProcessed=true` articles only, with a
+ * `coverage` figure (enriched-with-sentiment / whole corpus) so the thin-data
+ * caveat can be shown in the UI.
+ */
+export async function getSentimentBreakdown(): Promise<SentimentBreakdown> {
+  try {
+    const db = await getDb()
+    const col = db.collection('articles')
+    const [rows, corpusTotal] = await Promise.all([
+      col
+        .aggregate<{ _id: string; count: number }>([
+          { $match: { ...BASE_MATCH, aiProcessed: true, aiSentiment: { $type: 'string', $ne: '' } } },
+          { $group: { _id: '$aiSentiment', count: { $sum: 1 } } },
+          { $sort: { count: -1 } },
+        ])
+        .toArray(),
+      col.countDocuments(BASE_MATCH),
+    ])
+
+    const total = rows.reduce((s, r) => s + r.count, 0)
+    if (total === 0) return { ...EMPTY_SENTIMENT }
+    return {
+      total,
+      coverage: corpusTotal > 0 ? round((total / corpusTotal) * 100, 1) : 0,
+      breakdown: rows.map((r) => ({
+        sentiment: String(r._id).trim().toLowerCase(),
+        count: r.count,
+        share: round((r.count / total) * 100, 1),
+      })),
+    }
+  } catch (error) {
+    console.error('[insights.getSentimentBreakdown]', error)
+    return { ...EMPTY_SENTIMENT }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Corpus summary
+// ---------------------------------------------------------------------------
+
+export interface CorpusSummary {
+  totalArticles: number
+  sources: number
+  organizations: number
+  countries: number
+  /** Percentage of articles with aiProcessed=true. */
+  aiEnrichedPct: number
+  /** Average qualityScore (0..1) over scored articles. */
+  avgQualityScore: number
+  earliest: string | null
+  latest: string | null
+}
+
+const EMPTY_SUMMARY: CorpusSummary = {
+  totalArticles: 0,
+  sources: 0,
+  organizations: 0,
+  countries: 0,
+  aiEnrichedPct: 0,
+  avgQualityScore: 0,
+  earliest: null,
+  latest: null,
+}
+
+/** Headline totals across the corpus for the stat-tile row. */
+export async function getCorpusSummary(): Promise<CorpusSummary> {
+  try {
+    const db = await getDb()
+    const col = db.collection('articles')
+
+    const [facet, sources, organizations, countries] = await Promise.all([
+      col
+        .aggregate<{
+          totalArticles: Array<{ n: number }>
+          aiEnriched: Array<{ n: number }>
+          quality: Array<{ avg: number | null }>
+          range: Array<{ earliest: Date | null; latest: Date | null }>
+        }>([
+          { $match: BASE_MATCH },
+          {
+            $facet: {
+              totalArticles: [{ $count: 'n' }],
+              aiEnriched: [{ $match: { aiProcessed: true } }, { $count: 'n' }],
+              quality: [
+                { $match: { qualityScore: { $type: 'number' } } },
+                { $group: { _id: null, avg: { $avg: '$qualityScore' } } },
+                { $project: { _id: 0, avg: 1 } },
+              ],
+              range: [
+                { $match: { datePublished: { $type: 'date' } } },
+                {
+                  $group: {
+                    _id: null,
+                    earliest: { $min: '$datePublished' },
+                    latest: { $max: '$datePublished' },
+                  },
+                },
+                { $project: { _id: 0, earliest: 1, latest: 1 } },
+              ],
+            },
+          },
+        ])
+        .toArray(),
+      db.collection('feedSources').countDocuments({}),
+      db.collection('newsMediaOrganizations').countDocuments({}),
+      col.distinct('countryCode', BASE_MATCH),
+    ])
+
+    const f = facet[0]
+    const totalArticles = f?.totalArticles?.[0]?.n ?? 0
+    const aiEnriched = f?.aiEnriched?.[0]?.n ?? 0
+    const range = f?.range?.[0]
+    const distinctCountries = (countries as unknown[]).filter(
+      (c): c is string => typeof c === 'string' && c.trim().length > 0
+    )
+
+    return {
+      totalArticles,
+      sources,
+      organizations,
+      countries: distinctCountries.length,
+      aiEnrichedPct: totalArticles > 0 ? round((aiEnriched / totalArticles) * 100, 1) : 0,
+      avgQualityScore: round(f?.quality?.[0]?.avg, 3),
+      earliest: range?.earliest ? new Date(range.earliest).toISOString() : null,
+      latest: range?.latest ? new Date(range.latest).toISOString() : null,
+    }
+  } catch (error) {
+    console.error('[insights.getCorpusSummary]', error)
+    return { ...EMPTY_SUMMARY }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Trending topics
+// ---------------------------------------------------------------------------
+
+export interface TopTopic {
+  tag: string
+  count: number
+}
+
+/**
+ * Trending `engagement.tags` over the last 7 days, ranked by article count.
+ */
+export async function getTopTopics({
+  limit = 10,
+}: { limit?: number } = {}): Promise<TopTopic[]> {
+  const max = clampInt(limit, 1, 50, 10)
+  try {
+    const db = await getDb()
+    const since = new Date(Date.now() - 7 * 86_400_000)
+    const rows = await db
+      .collection('articles')
+      .aggregate<{ _id: string; count: number }>([
+        { $match: { ...BASE_MATCH, datePublished: { $gte: since } } },
+        { $unwind: '$engagement.tags' },
+        { $group: { _id: '$engagement.tags', count: { $sum: 1 } } },
+        { $match: { _id: { $type: 'string', $ne: '' } } },
+        { $sort: { count: -1 } },
+        { $limit: max },
+      ])
+      .toArray()
+
+    return rows.map((r) => ({ tag: String(r._id).trim(), count: r.count }))
+  } catch (error) {
+    console.error('[insights.getTopTopics]', error)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary

Turns `/insights` from generic info into a **real, public, open-data analytics dashboard** for media users and organizations — honoring Mukoko's open-data policy. It stays **server-first + ISR** (`revalidate = 600`), builds on the recent server-first refactor, and computes **every number from the live corpus**. Metrics that only exist over an enriched subset (sentiment, quality) are labelled with their **coverage %** — nothing is fabricated or over-claimed.

Reads go through Server Actions → the `news` DB (never the gateway). The read layer is wrapped so any failure returns an **empty-but-typed** result — a degraded cluster renders empty sections, never a 500 (verified live: with no `MONGODB_URI`, the page and both export formats still return `200`).

## Analytics sections

- **Corpus summary** stat tiles — total articles, sources, publishers, countries, % AI-enriched, avg quality score, earliest/latest publish date.
- **Publishing volume** — articles/day over the last 30 days as a lightweight inline-SVG bar chart (no chart dependency added — recharts is not installed), zero-filled across the window, with the most-active sources noted in prose. Single-hue tanzanite (sequential magnitude).
- **Media organizations leaderboard** — per source: article count, avg quality, avg word count, countries covered, last-published; joined to `feedSources` (display name) and `newsMediaOrganizations` (publisher + verification badge). **Client-sortable** by any column.
- **Topic distribution** — counts per `engagement.interest_categories` slug (top 15) with % share and top-N coverage; cobalt bar list.
- **Country coverage** — counts per `countryCode` mapped to names via `COUNTRIES`; malachite bar list.
- **Sentiment** — counts per `aiSentiment` over `aiProcessed=true` only, with an explicit **coverage %** caveat. Diverging semantics (malachite/neutral/destructive), never color-alone — every bar is labelled.
- **Trending topics** — most-tagged `engagement.tags` over the last 7 days.

Design-system tokens throughout (`bg-surface`, `text-foreground`, mineral + `on-*` utilities); accessible SVG (`role="img"` + `<title>`), sortable table with `aria-label`ed headers, visible **empty** and **error** states.

## Open-data export contract

`GET /api/insights/export` — public, read-only, `runtime = 'nodejs'`, `revalidate = 600`, rate-limited (**20 req/min/IP** via `checkRateLimit`/`getRequestIp` → `429` + `Retry-After: 60`), edge-cached (`Cache-Control: public, s-maxage=600, stale-while-revalidate=1800`).

- `?format=json` (default) → the full `InsightsBundle` (summary, volume, leaderboard, categories, countries, sentiment, topics, `generatedAt`). `Content-Type: application/json`.
- `?format=csv` → one CSV with three RFC-4180-quoted, labelled tables: `## media_organizations`, `## topic_distribution`, `## country_coverage`. `Content-Type: text/csv`, `Content-Disposition: attachment; filename="mukoko-insights.csv"`.

Surfaced on the page via a **"Download open data (JSON)" / "Download tables (CSV)"** affordance; documented in `CLAUDE.md`.

## Data-coverage caveats (kept honest)

- **Sentiment & quality** exist only on AI-enriched articles — both surface a coverage %/label so partial data is never presented as total.
- **Topic shares** are computed against total category *assignments* (an article can carry several), with a top-N coverage figure so the denominator is explicit.
- **Country coverage** shares are against articles that carry a `countryCode`; the leaderboard falls back to a source's own country when article-level codes are absent.
- All figures reflect the visible catalogue (rejected/removed articles excluded, matching the article read layer).

## Layout (screenshots-in-words)

Header ("Open Data & Insights") with the two download pills → a 2×4 grid of stat tiles → a full-width publishing-volume card (SVG bars + date axis + top-sources caption) → the full-width sortable leaderboard table (verified badge beside verified publishers) → a two-column row of Topic distribution and Country coverage bar lists → the Sentiment card (labelled bars + coverage caption) → a wrap of trending-topic chips → a footer noting the live-compute + 10-minute cache and the coverage caveats.

## Tests & verification

- New: `src/lib/__tests__/insights.test.ts` (aggregation shaping, clamps, graceful-failure paths — mongodb client mocked per existing patterns), `src/app/api/insights/__tests__/export-route.test.ts` (JSON + CSV shape, RFC-4180 quoting, **429** rate limit, 500), `src/app/insights/__tests__/insights-page.test.tsx` (mocks `@/lib/actions/insights`, asserts `revalidate === 600`), rewritten `insights-client.test.tsx` (sections, sortable table, sentiment coverage label, empty state).
- **Full suite green: 629 tests / 39 files.** `typecheck`, `lint`, `build` all pass. Build shows `/insights` as `○` prerendered with a `10m` revalidate (server-first + ISR) and `/api/insights/export` as a dynamic Route Handler.
- Verified live on `next start`: JSON `200` (correct cache-control), CSV `200` (three tables), `/insights` `200` — all degrade gracefully with no DB.

## Deviations

- The rebuilt dashboard uses a new metric set, so the previous `normalizeAuthors`/trending-authors path in `insights-client.tsx` was replaced (its unit tests moved to the new pure helpers `formatNumber`/`humanize`/`formatDay`). No other page referenced it.
- "Per top-source" publishing volume is delivered as a lightweight top-sources summary in the same window rather than per-source daily series, to keep the query bounded and the chart legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Abtz4XYKvbMtSD7UoYwbF3)_