### PR TITLE
feat: account-backed engagement, Mzizi density tokens, topic timelines, durable rate limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,13 @@ WORKOS_COOKIE_PASSWORD=your_32_plus_char_random_cookie_password
 # WorkOS org for platform-team access to /admin
 WORKOS_PLATFORM_ORG_ID=org_your_platform_team_org_id
 
+# ── Rate limiting (optional, recommended in production) ───────────────────────
+# When both are set, engagement + open-data-export rate limits are enforced
+# GLOBALLY via Upstash Redis over REST (no SDK). Unset = per-instance in-memory
+# limits only. Create a database at https://console.upstash.com → REST API.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
 # ── External API (widget/resale only) ─────────────────────────────────────────
 # Leave empty — all page reads go through MongoDB Server Actions.
 # Set this only if building the embed widget against an external API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Account-backed saves & likes.** Engagement is now keyed to the signed-in WorkOS user (`user:<id>` subject key) instead of only the anonymous `mukoko_session` cookie, so saved articles and likes follow the account across devices. On the first signed-in interaction (or `/saved` read), anonymous cookie history is claimed for the user — overlaps keep the user's copy (`src/lib/engagement.ts`). `/saved` shows a "sign in to sync" nudge to anonymous readers. The document field stays `sessionId` (an opaque subject key to the gateway/pipeline); counts and aggregation are unchanged.
+- **Developing-story timeline (`/topic/[slug]`).** The Mzizi `nyuchi-timeline` date-railed surface: everything published on a topic in the last 30 days, grouped by day (CAT) with time/title/source rows and thumbnails. Backed by `getTopicTimeline` (matches tag slugs/names, AI categories, and AI keywords) via `getTopicTimelineAction`, ISR-cached (`revalidate = 300`). Reached from new **"Follow the story" tag chips** on the article page and the Insights **trending topics** (previously a plain search link).
+- **Mzizi density system adopted** (`globals.css`): the prime-scale **touch targets** (`--touch-*`: 47px primary / 43px inputs / 37px dense / 31px chips / 56px hero-only), the **icon scale** (`--icon-*`), and density scopes — `comfortable` is the default; `/admin` and `/dashboard` opt into `compact` via `data-density`, which cascades through `--density-touch` and the card/input radii with no per-component changes. Button sizes now ride the touch tokens.
+- **Durable rate limiting.** `checkRateLimit` is now async and enforces a **global** fixed window via the Upstash Redis REST API when `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are set (no SDK dependency, 1.5s timeout, fails OPEN to the in-memory limiter). Without them, behaviour is unchanged (per-instance in-memory window).
+
 ### Changed
 
 - **Sign-in is the WorkOS-HOSTED AuthKit page (owner correction 2026-07-09 — supersedes the 2026-07-02 inline-form doctrine).** Every sign-in entry point (`/sign-in`, `/admin`, `/dashboard`, `/profile`, the publisher claim form) now funnels through `/sign-in` → `/auth/login` → the hosted page. The hosted page owns the whole flow — Magic Auth, passwords, passkeys, and the environment-required **MFA step-up** — and maintains the shared AuthKit session on the auth domain, giving **continuous sign-in across the Mukoko/Nyuchi apps** (all AuthKit applications in one WorkOS environment). See `auth.md`.
@@ -26,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - The embedded inline AuthKit sign-in form (`src/components/auth/inline-sign-in.tsx`) and its Magic Auth / MFA Server Actions (`requestEmailCode`, `verifyEmailCode`, `verifyMfaCode`, `MfaState`). `src/lib/auth/actions.ts` keeps `isSignedIn()` and `signOutAction()`.
+- The `TODO(on-primary)` markers in the error pages — the buttons now use the `text-on-primary` token instead of hardcoded white.
 
 ## [5.5.0] - 2026-07-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ src/
   app/                     # App Router pages (kebab-case dirs)
     page.tsx               # Home feed
     article/[id]/          # Article detail (server page + client component)
+    topic/[slug]/          # Developing-story timeline (Mzizi nyuchi-timeline, ISR 300s)
     discover/ search/ saved/ categories/ sources/ newsbytes/ insights/ analytics/
     admin/                 # RBAC-gated admin app (layout.tsx enforces tier)
     embed/ embed/iframe/   # Embeddable widget renderer
@@ -117,7 +118,7 @@ All news data reads go through Server Actions → MongoDB Atlas (`news` database
 
 ### Data Flow (writes / mutations)
 
-- **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit`, `getRequestIp`). Note the limiter is in-memory per Vercel instance, so limits apply per-instance rather than globally — a shared store (e.g. Redis/Upstash) is the durable upgrade. `src/app/api/health/route.ts` is the health probe.
+- **Engagement** (like / view / save) — Next.js **Route Handlers** under `src/app/api/articles/[id]/{like,view,save}/route.ts` (`POST`, `runtime = 'nodejs'`), rate-limited via `src/lib/rate-limit.ts` (`checkRateLimit` — **async** — and `getRequestIp`). When `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` are set the limit is enforced globally via the Upstash REST API (fixed window, fails open); otherwise it's the in-memory per-instance window. Likes/saves are keyed to an **engagement subject** (`src/lib/engagement.ts`): the signed-in WorkOS user (`user:<id>` — follows the account across devices; anonymous cookie history is claimed on first signed-in interaction) or the `mukoko_session` cookie. The stored field remains `sessionId` — an opaque subject key to the gateway/pipeline. `src/app/api/health/route.ts` is the health probe.
 - **Admin mutations** — `src/lib/admin/gateway.ts` proxies to the gateway Worker's WorkOS-gated `/api/admin/*` endpoints, forwarding the WorkOS access token as a Bearer header so the Worker re-verifies the same RBAC. **This is the only place the frontend touches the gateway.**
 - **Pipeline refresh** — `src/lib/actions/refresh.ts` `triggerFeedCollection()` fire-and-forget `POST`s to `FLY_WORKER_URL/trigger/collect` with `FLY_TRIGGER_TOKEN`.
 - **Open-data export** (read-only, public) — `src/app/api/insights/export/route.ts` (`GET`, `runtime = 'nodejs'`, `revalidate = 600`) returns the aggregated Insights bundle. `?format=json` (default) emits the full `InsightsBundle`; `?format=csv` emits one CSV with three labelled tables — `## media_organizations`, `## topic_distribution`, `## country_coverage` (RFC-4180 quoted). Rate-limited via `checkRateLimit`/`getRequestIp` (20 req/min/IP → `429` + `Retry-After`); edge-cached (`Cache-Control: public, s-maxage=600, stale-while-revalidate=1800`). Linked from the `/insights` page ("Download open data"). This is a plain Route Handler → MongoDB, not a gateway call.
@@ -238,6 +239,8 @@ The MCP OAuth server (`news.mukoko.com/.well-known/oauth-authorization-server`, 
 **Typography**: **Noto Serif** (display/headings, wordmark = lowercase weight 600 — always "mukoko", never capitalised), **Noto Sans** (UI/body), **JetBrains Mono** (code/data/labels) — self-hosted via `next/font/google` in `layout.tsx`, with the CSS variables wired to the `--font-sans/serif/mono` theme tokens in `globals.css`.
 
 **Spacing**: 12px border-radius buttons, 16px cards. WCAG AAA compliant (7:1 contrast).
+
+**Density (Mzizi 4.x)**: `globals.css` defines the prime-scale touch targets (`--touch-*`: 47px primary CTAs, 43px inputs, 37px dense toolbars, 31px chips, 56px hero-only) and icon sizes (`--icon-*`). `comfortable` is the default density; data-dense surfaces (`/admin`, `/dashboard`) opt into `compact` with `data-density="compact"` on a wrapper — the scope overrides `--density-touch` and the card/input radii, which cascade with no per-component changes. Button sizes ride these tokens (`min-h-[var(--density-touch)]`). New interactive elements should use the touch-target minimums, not fixed heights.
 
 CSS variables in `src/app/globals.css`. Use Tailwind classes: `bg-primary`, `text-foreground`, `bg-surface`, and the mineral utilities `bg-tanzanite`, `text-cobalt`, `bg-container-sodalite`, etc. (`components.json` configures the shadcn-style component generator; the theme lives entirely in `globals.css` via `@theme inline` — there is no `tailwind.config.ts`.)
 

--- a/auth.md
+++ b/auth.md
@@ -64,6 +64,10 @@ const { user } = await withAuth()
 - **None of these may reach a client component or the browser bundle.** Keep `withAuth()`, Server Actions, and Route Handlers server-side; pass only non-sensitive, resolved data to client components.
 - Admin mutations forward the user's WorkOS **access token** as a Bearer header to the gateway, which re-verifies the same RBAC — the frontend never trusts its own tier check alone for a mutation.
 
+## Engagement identity
+
+Likes/saves are keyed to an **engagement subject** (`src/lib/engagement.ts`): the signed-in WorkOS user (`user:<workos-user-id>`, resolved server-side via `withAuth()` — never trusted from the client) or the anonymous `mukoko_session` cookie. On the first signed-in interaction the cookie history is claimed for the user (user doc wins on overlap). `withAuth()` failures degrade to anonymous — auth must never break public engagement.
+
 ## Engagement & rate limiting
 
 Engagement Route Handlers (`src/app/api/articles/[id]/{like,view,save}/route.ts`, `runtime = 'nodejs'`) are rate-limited via `checkRateLimit()` + `getRequestIp()` (`src/lib/rate-limit.ts`). The limiter is in-memory per Vercel instance, so limits are enforced per-instance rather than globally — a shared store is the durable upgrade. Keep new public write endpoints behind the same rate-limit guard.

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -59,7 +59,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   }
 
   return (
-    <div className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6">
+    // Mzizi density: admin is a data-dense surface — compact opt-in.
+    <div data-density="compact" className="max-w-[1200px] mx-auto px-4 sm:px-6 py-6">
       {/* Admin top bar */}
       <div className="flex flex-wrap items-center justify-between gap-3 mb-6 pb-4 border-b border-elevated">
         <nav className="flex items-center gap-1">

--- a/src/app/api/articles/[id]/like/route.ts
+++ b/src/app/api/articles/[id]/like/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/mongodb/client'
 import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
+import { resolveEngagementSubject, claimSessionEngagement } from '@/lib/engagement'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
@@ -8,14 +9,15 @@ export const runtime = 'nodejs'
 const RATE_LIMIT_MAX = 10
 const RATE_LIMIT_WINDOW_MS = 60_000
 
-// Session cookie + unique {articleId, sessionId} index prevents double-likes.
-// Replace sessionId with OIDC personId when auth is wired.
+// Unique {articleId, sessionId} index prevents double-likes. The subject key is
+// the signed-in user (`user:<id>`, follows the account across devices) or the
+// anonymous mukoko_session cookie — see src/lib/engagement.ts.
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const ip = getRequestIp(request)
-  if (!checkRateLimit(`like:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+  if (!(await checkRateLimit(`like:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS))) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
@@ -30,9 +32,16 @@ export async function POST(
         { status: 400 }
       )
     }
-    const sessionId = request.cookies.get('mukoko_session')?.value || randomUUID()
+    const cookieSessionId = request.cookies.get('mukoko_session')?.value
+    const subject = await resolveEngagementSubject(cookieSessionId)
+    const sessionId = subject.key ?? randomUUID()
 
     const db = await getDb()
+
+    // First signed-in interaction after anonymous use: claim cookie history.
+    if (subject.isUser && cookieSessionId) {
+      await claimSessionEngagement(db, cookieSessionId, sessionId)
+    }
 
     // Validate article exists
     const article = await db.collection('articles').findOne(
@@ -79,7 +88,8 @@ export async function POST(
       count: likesCount,
     })
 
-    if (!request.cookies.get('mukoko_session')) {
+    // Only anonymous visitors need the session cookie minted.
+    if (!subject.isUser && !request.cookies.get('mukoko_session')) {
       response.cookies.set('mukoko_session', sessionId, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/src/app/api/articles/[id]/save/route.ts
+++ b/src/app/api/articles/[id]/save/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/mongodb/client'
 import { checkRateLimit, getRequestIp } from '@/lib/rate-limit'
+import { resolveEngagementSubject, claimSessionEngagement } from '@/lib/engagement'
 import { randomUUID } from 'crypto'
 
 export const runtime = 'nodejs'
@@ -13,7 +14,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const ip = getRequestIp(request)
-  if (!checkRateLimit(`save:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+  if (!(await checkRateLimit(`save:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS))) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }
@@ -28,9 +29,18 @@ export async function POST(
         { status: 400 }
       )
     }
-    const sessionId = request.cookies.get('mukoko_session')?.value || randomUUID()
+    const cookieSessionId = request.cookies.get('mukoko_session')?.value
+    // Signed-in users get a stable user key so saves follow the account.
+    const subject = await resolveEngagementSubject(cookieSessionId)
+    const sessionId = subject.key ?? randomUUID()
 
     const db = await getDb()
+
+    // First signed-in interaction after anonymous use: claim cookie history.
+    if (subject.isUser && cookieSessionId) {
+      await claimSessionEngagement(db, cookieSessionId, sessionId)
+    }
+
     const savesCol = db.collection('articleSaves')
 
     const existing = await savesCol.findOne({ articleId, sessionId })
@@ -55,7 +65,8 @@ export async function POST(
       message: saved ? 'Article saved' : 'Article unsaved',
     })
 
-    if (!request.cookies.get('mukoko_session')) {
+    // Only anonymous visitors need the session cookie minted.
+    if (!subject.isUser && !request.cookies.get('mukoko_session')) {
       response.cookies.set('mukoko_session', sessionId, {
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/src/app/api/articles/[id]/view/route.ts
+++ b/src/app/api/articles/[id]/view/route.ts
@@ -14,7 +14,7 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const ip = getRequestIp(request)
-  if (!checkRateLimit(`view:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+  if (!(await checkRateLimit(`view:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS))) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }

--- a/src/app/api/insights/export/route.ts
+++ b/src/app/api/insights/export/route.ts
@@ -88,7 +88,7 @@ function toCsv(data: Bundle): string {
 
 export async function GET(request: NextRequest) {
   const ip = getRequestIp(request)
-  if (!checkRateLimit(`insights-export:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)) {
+  if (!(await checkRateLimit(`insights-export:${ip}`, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS))) {
     return NextResponse.json(
       { error: 'Too many requests' },
       { status: 429, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_MS / 1000) } }

--- a/src/app/article/[id]/article-detail-client.tsx
+++ b/src/app/article/[id]/article-detail-client.tsx
@@ -20,7 +20,7 @@ import { type Article } from "@/lib/api";
 import { getArticleAction } from "@/lib/actions/feed";
 import { getArticleUrl } from "@/lib/constants";
 import { imageProxyUrl } from "@/lib/image";
-import { isValidImageUrl } from "@/lib/utils";
+import { isValidImageUrl, topicSlug } from "@/lib/utils";
 import { ArticlePageSkeleton } from "@/components/ui/skeleton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { ArticleJsonLd } from "@/components/ui/json-ld";
@@ -380,6 +380,31 @@ export default function ArticleDetailClient({
 
         {/* Divider */}
         <div className="border-t border-elevated my-8" />
+
+        {/* Follow the story — each tag opens its /topic timeline */}
+        {article.keywords && article.keywords.length > 0 && (
+          <div className="mb-8">
+            <p className="font-mono text-[13px] uppercase tracking-wide text-text-tertiary mb-3">
+              Follow the story
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {article.keywords.slice(0, 6).map((kw) => {
+                const slug = topicSlug(kw.slug || kw.name);
+                if (!slug) return null;
+                return (
+                  <Link
+                    key={kw.id}
+                    href={`/topic/${slug}`}
+                    className="inline-flex min-h-[var(--touch-chip)] items-center gap-1.5 rounded-full border border-elevated bg-surface px-3 py-1 text-sm text-foreground transition-colors hover:border-primary/30 hover:text-primary"
+                  >
+                    <Tag className="w-3.5 h-3.5" aria-hidden="true" />
+                    {kw.name}
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        )}
 
         {/* Action Buttons */}
         <div className="flex items-center gap-4 flex-wrap">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -85,7 +85,12 @@ export default async function DashboardPage() {
     )
   }
 
-  return <PublisherDashboard context={context} />
+  return (
+    // Mzizi density: the publisher dashboard is a data-dense surface.
+    <div data-density="compact">
+      <PublisherDashboard context={context} />
+    </div>
+  )
 }
 
 function Centered({ children }: { children: React.ReactNode }) {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -25,8 +25,7 @@ export default function Error({
         <button
           type="button"
           onClick={() => reset()}
-          // TODO(on-primary): switch to text-on-primary when tokens land
-          className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary/90"
+          className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-on-primary hover:bg-primary/90"
         >
           Try again
         </button>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -31,8 +31,7 @@ export default function GlobalError({
             <button
               type="button"
               onClick={() => reset()}
-              // TODO(on-primary): switch to text-on-primary when tokens land
-              className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary/90"
+              className="mt-6 rounded-button bg-primary px-6 py-2.5 text-sm font-semibold text-on-primary hover:bg-primary/90"
             >
               Try again
             </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -290,6 +290,56 @@
   --color-status-neutral: var(--status-neutral);
 }
 
+/* ── Mzizi density system (styling-density + touch-targets + icon-sizes) ──
+   Three densities. `comfortable` is the Nyuchi default — touch-first consumer
+   surfaces, and the values below are the :root defaults. Data-dense surfaces
+   (/admin, /dashboard) opt into `compact` with data-density="compact" on a
+   wrapper; hero/landing surfaces may request `spacious`. Touch targets are the
+   Bundu prime scale and are MINIMUMS for interactive elements, not fixed
+   heights. Density scopes work by overriding the same custom properties the
+   primitives already consume (--density-touch*, --radius-card, --radius-input),
+   so everything inside the scope inherits the density with no class changes. */
+:root {
+  /* Touch targets (brand_touch_targets — prime px) */
+  --touch-min: 41px; /* absolute minimum; needs ≥6px gap to neighbours */
+  --touch-a11y: 43px; /* inputs + secondary buttons */
+  --touch-default: 47px; /* primary buttons and major CTAs */
+  --touch-hero: 56px; /* hero CTAs ONLY — never in dense UI */
+  --touch-compact: 37px; /* dense toolbars + small inputs */
+  --touch-chip: 31px; /* chips, tags, pickers */
+  --touch-badge: 23px; /* badges/counters — non-interactive */
+
+  /* Icon sizes (brand_icon_sizes) */
+  --icon-xs: 12px;
+  --icon-sm: 16px;
+  --icon-default: 20px;
+  --icon-md: 24px;
+  --icon-lg: 32px;
+  --icon-xl: 40px;
+
+  /* Density knobs — comfortable defaults; scopes below override these */
+  --density-touch: var(--touch-default);
+  --density-touch-input: var(--touch-a11y);
+  --density-icon: var(--icon-default);
+}
+
+/* Data-dense surfaces: admin tables, dashboards, power-user tools. */
+[data-density='compact'] {
+  --density-touch: var(--touch-a11y);
+  --density-touch-input: var(--touch-compact);
+  --density-icon: var(--icon-sm);
+  --radius-card: 12px;
+  --radius-input: 7px;
+}
+
+/* Hero surfaces: landing, onboarding, large-format reading. */
+[data-density='spacious'] {
+  --density-touch: var(--touch-hero);
+  --density-touch-input: var(--touch-default);
+  --density-icon: var(--icon-md);
+  --radius-card: 20px;
+}
+
 /* ── Mzizi N1 semantic status tokens (theme-aware) ─────────────────
    Consumed by the nyuchi brand components (factcheck + credibility
    indicators). Mirrors the mineral roles: success=malachite,

--- a/src/app/insights/insights-client.tsx
+++ b/src/app/insights/insights-client.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react'
 import { ErrorBoundary } from '@/components/ui/error-boundary'
 import { getCategoryEmoji } from '@/lib/constants'
+import { topicSlug } from '@/lib/utils'
 import type { InsightsBundle } from '@/lib/actions/insights'
 
 // ---------------------------------------------------------------------------
@@ -534,7 +535,7 @@ export default function InsightsClient({ data }: { data: InsightsBundle }) {
                   {topics.map((t) => (
                     <Link
                       key={t.tag}
-                      href={`/search?q=${encodeURIComponent(t.tag)}`}
+                      href={`/topic/${topicSlug(t.tag)}`}
                       className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-container-tanzanite text-on-container-tanzanite text-sm hover:opacity-90 transition-opacity"
                     >
                       <TrendingUp className="w-3.5 h-3.5" aria-hidden="true" />

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -2,13 +2,15 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { Bookmark, Loader2, RefreshCw } from "lucide-react";
+import { Bookmark, Loader2, RefreshCw, CloudUpload } from "lucide-react";
+import { useAuth } from "@workos-inc/authkit-nextjs/components";
 import { ArticleCard } from "@/components/article-card";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { type Article } from "@/lib/api";
 import { getSavedArticlesAction } from "@/lib/actions/feed";
 
 function SavedContent() {
+  const { user, loading: authLoading } = useAuth();
   const [savedArticles, setSavedArticles] = useState<Article[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,6 +51,23 @@ function SavedContent() {
           Articles you&apos;ve bookmarked for later reading
         </p>
       </div>
+
+      {/* Anonymous saves live in this browser only — nudge toward the account. */}
+      {!authLoading && !user && (
+        <div className="mb-6 flex flex-wrap items-center gap-3 rounded-2xl border border-elevated bg-surface px-4 py-3 text-sm">
+          <CloudUpload className="w-4 h-4 text-secondary shrink-0" aria-hidden="true" />
+          <span className="text-text-secondary">
+            Saved articles are stored on this device.{" "}
+            <Link
+              href="/sign-in?returnTo=/saved"
+              className="font-medium text-secondary hover:underline"
+            >
+              Sign in
+            </Link>{" "}
+            to keep them across your devices.
+          </span>
+        </div>
+      )}
 
       {savedArticles.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/src/app/topic/[slug]/page.tsx
+++ b/src/app/topic/[slug]/page.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft, Newspaper } from 'lucide-react'
+import { getTopicTimelineAction } from '@/lib/actions/feed'
+import { TopicTimeline } from '@/components/topic-timeline'
+
+// Developing-story surface: everything published on a topic in the last 30
+// days, on the Mzizi date-railed timeline (nyuchi-timeline). Reached from
+// article tags and trending topics. ISR keeps it fresh without per-hit reads.
+export const revalidate = 300
+
+interface TopicPageProps {
+  params: Promise<{ slug: string }>
+}
+
+function topicTitle(slug: string): string {
+  return slug
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+export async function generateMetadata({ params }: TopicPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const title = topicTitle(decodeURIComponent(slug))
+  return {
+    title: `${title} — Ongoing coverage`,
+    description: `Follow the ${title} story as it develops: every report, day by day, from newsrooms across Africa.`,
+  }
+}
+
+export default async function TopicPage({ params }: TopicPageProps) {
+  const { slug } = await params
+  const { topic, articles, total } = await getTopicTimelineAction(decodeURIComponent(slug))
+  const title = topicTitle(topic || decodeURIComponent(slug))
+
+  return (
+    <div className="max-w-[840px] mx-auto px-4 sm:px-6 py-8">
+      <Link
+        href="/discover"
+        className="mb-6 inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-foreground transition-colors focus-visible:outline-none focus-visible:underline"
+      >
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+        Discover
+      </Link>
+
+      <header className="mb-8">
+        <p className="font-mono text-[13px] uppercase tracking-wide text-text-tertiary mb-1">
+          Ongoing coverage
+        </p>
+        <h1 className="font-serif text-3xl sm:text-4xl font-bold text-foreground">{title}</h1>
+        {total > 0 && (
+          <p className="mt-2 text-sm text-text-secondary">
+            {total} {total === 1 ? 'report' : 'reports'} in the last 30 days
+          </p>
+        )}
+      </header>
+
+      {articles.length > 0 ? (
+        <TopicTimeline articles={articles} />
+      ) : (
+        <div className="text-center py-20">
+          <div className="w-20 h-20 bg-surface rounded-full flex items-center justify-center mx-auto mb-6">
+            <Newspaper className="w-10 h-10 text-text-tertiary" aria-hidden="true" />
+          </div>
+          <h2 className="font-serif text-xl font-bold mb-2">No recent coverage</h2>
+          <p className="text-text-secondary mb-6 max-w-md mx-auto">
+            Nothing has been published on this topic in the last 30 days. It may pick up again —
+            check back later.
+          </p>
+          <Link
+            href="/discover"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary font-medium rounded-xl hover:opacity-90 transition-opacity"
+          >
+            Explore other topics
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/__tests__/topic-timeline.test.tsx
+++ b/src/components/__tests__/topic-timeline.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TopicTimeline, groupArticlesByDay } from '../topic-timeline';
+import type { Article } from '@/lib/api';
+
+// The timeline renders in Africa/Harare (CAT, UTC+2) so day rails and times
+// are stable regardless of the server/viewer timezone.
+
+function article(overrides: Partial<Article>): Article {
+  return {
+    id: 'a1',
+    title: 'Test headline',
+    source: 'Test Source',
+    source_id: 's1',
+    slug: 'test-headline',
+    original_url: 'https://example.com/a',
+    published_at: '2026-07-10T08:30:00.000Z',
+    updated_at: '2026-07-10T08:30:00.000Z',
+    ...overrides,
+  } as Article;
+}
+
+describe('groupArticlesByDay', () => {
+  it('groups consecutive articles by CAT calendar day, newest-first order preserved', () => {
+    const days = groupArticlesByDay([
+      article({ id: 'a1', published_at: '2026-07-10T20:00:00.000Z' }),
+      article({ id: 'a2', published_at: '2026-07-10T06:00:00.000Z' }),
+      article({ id: 'a3', published_at: '2026-07-09T12:00:00.000Z' }),
+    ]);
+    expect(days).toHaveLength(2);
+    expect(days[0].articles.map((a) => a.id)).toEqual(['a1', 'a2']);
+    expect(days[1].articles.map((a) => a.id)).toEqual(['a3']);
+    expect(days[0].dayNumber).toBe('10');
+    expect(days[1].dayNumber).toBe('9');
+  });
+
+  it('assigns a late-UTC article to the NEXT CAT day (UTC+2 rollover)', () => {
+    // 23:30 UTC on the 9th is 01:30 CAT on the 10th.
+    const days = groupArticlesByDay([article({ published_at: '2026-07-09T23:30:00.000Z' })]);
+    expect(days[0].dayNumber).toBe('10');
+  });
+
+  it('skips articles with unparseable dates instead of crashing', () => {
+    const days = groupArticlesByDay([
+      article({ id: 'bad', published_at: 'not-a-date' }),
+      article({ id: 'good' }),
+    ]);
+    expect(days).toHaveLength(1);
+    expect(days[0].articles[0].id).toBe('good');
+  });
+});
+
+describe('TopicTimeline', () => {
+  it('renders a date rail and article rows linking to the article pages', () => {
+    render(
+      <TopicTimeline
+        articles={[
+          article({ id: 'a1', title: 'First report' }),
+          article({ id: 'a2', title: 'Second report', published_at: '2026-07-09T10:00:00.000Z' }),
+        ]}
+      />
+    );
+    expect(screen.getByText('First report')).toBeInTheDocument();
+    expect(screen.getByText('Second report')).toBeInTheDocument();
+    const links = screen.getAllByRole('link');
+    expect(links.map((l) => l.getAttribute('href'))).toEqual(['/article/a1', '/article/a2']);
+  });
+
+  it('shows source and category metadata on each row', () => {
+    render(<TopicTimeline articles={[article({ category: 'Politics' })]} />);
+    expect(screen.getByText('Test Source · Politics')).toBeInTheDocument();
+  });
+
+  it('drops unsafe image URLs instead of rendering them', () => {
+    render(
+      <TopicTimeline
+        // eslint-disable-next-line no-script-url
+        articles={[article({ image_url: 'javascript:alert(1)' })]}
+      />
+    );
+    expect(document.querySelector('img')).toBeNull();
+  });
+});

--- a/src/components/topic-timeline.tsx
+++ b/src/components/topic-timeline.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link'
+import Image from 'next/image'
+import { isValidImageUrl } from '@/lib/utils'
+import { imageProxyUrl } from '@/lib/image'
+import type { Article } from '@/lib/api'
+
+// Mzizi `nyuchi-timeline` (4.2.0 signature): a date-railed discovery list.
+// Each day is a left rail (weekday, big day numeral, month) beside a stack of
+// tight horizontal rows — time, title, source · category, right-edge thumbnail.
+// Quiet rows, full 1px borders, muted small metadata. Server component.
+
+// Dates render in Central Africa Time (the primary market) so the server and
+// client always agree — no per-viewer timezone hydration drift.
+const TZ = 'Africa/Harare'
+
+const dayKeyFmt = new Intl.DateTimeFormat('en-CA', {
+  timeZone: TZ,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+const weekdayFmt = new Intl.DateTimeFormat('en-GB', { timeZone: TZ, weekday: 'short' })
+const dayNumFmt = new Intl.DateTimeFormat('en-GB', { timeZone: TZ, day: 'numeric' })
+const monthFmt = new Intl.DateTimeFormat('en-GB', { timeZone: TZ, month: 'short' })
+const timeFmt = new Intl.DateTimeFormat('en-GB', {
+  timeZone: TZ,
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+export interface TimelineDay {
+  /** Stable YYYY-MM-DD key in the display timezone. */
+  key: string
+  weekday: string
+  dayNumber: string
+  month: string
+  articles: Article[]
+}
+
+/** Group articles (assumed newest-first) into display days. Pure — unit tested. */
+export function groupArticlesByDay(articles: Article[]): TimelineDay[] {
+  const days: TimelineDay[] = []
+  let current: TimelineDay | null = null
+  for (const article of articles) {
+    const published = new Date(article.published_at)
+    if (Number.isNaN(published.getTime())) continue
+    const key = dayKeyFmt.format(published)
+    if (!current || current.key !== key) {
+      current = {
+        key,
+        weekday: weekdayFmt.format(published),
+        dayNumber: dayNumFmt.format(published),
+        month: monthFmt.format(published),
+        articles: [],
+      }
+      days.push(current)
+    }
+    current.articles.push(article)
+  }
+  return days
+}
+
+export function TopicTimeline({ articles }: { articles: Article[] }) {
+  const days = groupArticlesByDay(articles)
+
+  return (
+    <div>
+      {days.map((day) => (
+        <section key={day.key} className="flex gap-4 sm:gap-6">
+          {/* Date rail */}
+          <div className="w-14 sm:w-20 shrink-0 pt-4 text-center" aria-hidden="true">
+            <div className="font-mono text-[13px] uppercase tracking-wide text-text-tertiary">
+              {day.weekday}
+            </div>
+            <div className="font-serif text-3xl sm:text-4xl font-semibold leading-tight text-foreground">
+              {day.dayNumber}
+            </div>
+            <div className="font-mono text-[13px] uppercase tracking-wide text-text-tertiary">
+              {day.month}
+            </div>
+          </div>
+
+          {/* Day rows */}
+          <div className="min-w-0 flex-1">
+            {day.articles.map((article) => {
+              const image =
+                article.image_url && isValidImageUrl(article.image_url)
+                  ? imageProxyUrl(article.image_url, { width: 128 })
+                  : null
+              return (
+                <Link
+                  key={article.id}
+                  href={`/article/${article.id}`}
+                  className="flex items-center gap-3 border-t border-elevated py-3 transition-colors hover:bg-elevated/50 focus-visible:outline-none focus-visible:bg-elevated/50"
+                >
+                  <time
+                    dateTime={article.published_at}
+                    className="w-12 shrink-0 font-mono text-[13px] text-text-tertiary"
+                  >
+                    {timeFmt.format(new Date(article.published_at))}
+                  </time>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="line-clamp-2 text-sm font-medium text-foreground">
+                      {article.title}
+                    </h3>
+                    <p className="mt-0.5 truncate text-[13px] text-text-tertiary">
+                      {article.source}
+                      {article.category ? ` · ${article.category}` : ''}
+                    </p>
+                  </div>
+                  {image && (
+                    <Image
+                      src={image}
+                      alt=""
+                      width={64}
+                      height={64}
+                      className="h-16 w-16 shrink-0 rounded-[var(--radius-inner)] object-cover"
+                      unoptimized
+                    />
+                  )}
+                </Link>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -15,11 +15,14 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-on-accent',
         link: 'text-primary underline-offset-4 hover:underline',
       },
+      // Heights are the Mzizi touch-target minimums (globals.css). The default
+      // rides --density-touch, so a data-density="compact" ancestor (admin,
+      // dashboard) shrinks buttons without any per-component class changes.
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 px-3',
-        lg: 'h-11 px-8',
-        icon: 'h-10 w-10',
+        default: 'min-h-[var(--density-touch)] px-4 py-2',
+        sm: 'min-h-[var(--touch-compact)] px-3',
+        lg: 'min-h-[var(--touch-hero)] px-8',
+        icon: 'min-h-[var(--density-touch)] min-w-[var(--density-touch)]',
       },
     },
     defaultVariants: {

--- a/src/lib/__tests__/engagement.test.ts
+++ b/src/lib/__tests__/engagement.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Db } from 'mongodb'
+import {
+  resolveEngagementSubject,
+  claimSessionEngagement,
+  userEngagementKey,
+  USER_KEY_PREFIX,
+} from '../engagement'
+
+const { mockWithAuth } = vi.hoisted(() => ({ mockWithAuth: vi.fn() }))
+
+vi.mock('@workos-inc/authkit-nextjs', () => ({
+  withAuth: mockWithAuth,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockWithAuth.mockResolvedValue({ user: null })
+})
+
+describe('userEngagementKey', () => {
+  it('prefixes the WorkOS user id so key spaces never collide', () => {
+    expect(userEngagementKey('user_123')).toBe(`${USER_KEY_PREFIX}user_123`)
+  })
+})
+
+describe('resolveEngagementSubject', () => {
+  it('returns the stable user key when signed in', async () => {
+    mockWithAuth.mockResolvedValue({ user: { id: 'user_123' } })
+    const subject = await resolveEngagementSubject('cookie-abc')
+    expect(subject).toEqual({ key: 'user:user_123', isUser: true })
+  })
+
+  it('returns the cookie session when anonymous', async () => {
+    const subject = await resolveEngagementSubject('cookie-abc')
+    expect(subject).toEqual({ key: 'cookie-abc', isUser: false })
+  })
+
+  it('returns a null key when anonymous with no cookie', async () => {
+    const subject = await resolveEngagementSubject(undefined)
+    expect(subject).toEqual({ key: null, isUser: false })
+  })
+
+  it('degrades to anonymous when withAuth() throws (auth must never break engagement)', async () => {
+    mockWithAuth.mockRejectedValue(new Error('WorkOS misconfigured'))
+    const subject = await resolveEngagementSubject('cookie-abc')
+    expect(subject).toEqual({ key: 'cookie-abc', isUser: false })
+  })
+})
+
+/** Minimal fake of the two collection surfaces claimSessionEngagement touches. */
+function fakeDb(ownedByCollection: Record<string, string[]>) {
+  const calls: Record<string, { updateMany: unknown[]; deleteMany: unknown[] }> = {}
+  const db = {
+    collection: (name: string) => {
+      calls[name] ??= { updateMany: [], deleteMany: [] }
+      return {
+        find: () => ({
+          map: () => ({
+            toArray: async () => ownedByCollection[name] ?? [],
+          }),
+        }),
+        updateMany: async (filter: unknown, update: unknown) => {
+          calls[name].updateMany.push([filter, update])
+          return { modifiedCount: 0 }
+        },
+        deleteMany: async (filter: unknown) => {
+          calls[name].deleteMany.push(filter)
+          return { deletedCount: 0 }
+        },
+      }
+    },
+  } as unknown as Db
+  return { db, calls }
+}
+
+describe('claimSessionEngagement', () => {
+  it('re-keys cookie docs to the user key and cleans up leftovers in both collections', async () => {
+    const { db, calls } = fakeDb({})
+    await claimSessionEngagement(db, 'cookie-abc', 'user:user_123')
+
+    for (const name of ['articleSaves', 'articleLikes']) {
+      expect(calls[name].updateMany).toEqual([
+        [{ sessionId: 'cookie-abc' }, { $set: { sessionId: 'user:user_123' } }],
+      ])
+      expect(calls[name].deleteMany).toEqual([{ sessionId: 'cookie-abc' }])
+    }
+  })
+
+  it('excludes articles the user already owns from the re-key (user doc wins)', async () => {
+    const { db, calls } = fakeDb({ articleSaves: ['a1', 'a2'] })
+    await claimSessionEngagement(db, 'cookie-abc', 'user:user_123')
+
+    expect(calls['articleSaves'].updateMany).toEqual([
+      [
+        { sessionId: 'cookie-abc', articleId: { $nin: ['a1', 'a2'] } },
+        { $set: { sessionId: 'user:user_123' } },
+      ],
+    ])
+    // Overlapping cookie docs still get dropped.
+    expect(calls['articleSaves'].deleteMany).toEqual([{ sessionId: 'cookie-abc' }])
+  })
+
+  it('no-ops when the cookie key is empty or already the user key', async () => {
+    const { db, calls } = fakeDb({})
+    await claimSessionEngagement(db, '', 'user:user_123')
+    await claimSessionEngagement(db, 'user:user_123', 'user:user_123')
+    expect(Object.keys(calls)).toHaveLength(0)
+  })
+
+  it('swallows collection errors (best-effort, converges on the next interaction)', async () => {
+    const db = {
+      collection: () => {
+        throw new Error('mongo down')
+      },
+    } as unknown as Db
+    await expect(claimSessionEngagement(db, 'cookie-abc', 'user:u')).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/__tests__/feed-actions.test.ts
+++ b/src/lib/__tests__/feed-actions.test.ts
@@ -51,9 +51,27 @@ vi.mock('next/headers', () => ({
   cookies: vi.fn(async () => ({ get: mockCookieGet })),
 }));
 
+// The engagement subject module pulls in authkit (unresolvable in jsdom) — mock
+// it as anonymous by default; individual tests flip it to a signed-in user.
+const mockResolveSubject = vi.fn();
+const mockClaim = vi.fn();
+vi.mock('../engagement', () => ({
+  resolveEngagementSubject: (cookie: string | undefined) => mockResolveSubject(cookie),
+  claimSessionEngagement: (...args: unknown[]) => mockClaim(...args),
+}));
+
+vi.mock('../mongodb/client', () => ({
+  getDb: vi.fn().mockResolvedValue({}),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockCookieGet.mockReturnValue(undefined);
+  mockResolveSubject.mockImplementation(async (cookie: string | undefined) => ({
+    key: cookie ?? null,
+    isUser: false,
+  }));
+  mockClaim.mockResolvedValue(undefined);
 });
 
 describe('getArticlesAction input validation', () => {
@@ -251,5 +269,20 @@ describe('getSavedArticlesAction input validation', () => {
     mockCookieGet.mockReturnValue({ value: 'session-abc-123' });
     await getSavedArticlesAction();
     expect(getSavedArticles).toHaveBeenCalledWith('session-abc-123');
+  });
+
+  it('reads by the stable user key when signed in and claims cookie history', async () => {
+    mockCookieGet.mockReturnValue({ value: 'session-abc-123' });
+    mockResolveSubject.mockResolvedValue({ key: 'user:user_123', isUser: true });
+    await getSavedArticlesAction();
+    expect(mockClaim).toHaveBeenCalledWith(expect.anything(), 'session-abc-123', 'user:user_123');
+    expect(getSavedArticles).toHaveBeenCalledWith('user:user_123');
+  });
+
+  it('reads by the user key with no claim when signed in without a cookie', async () => {
+    mockResolveSubject.mockResolvedValue({ key: 'user:user_123', isUser: true });
+    await getSavedArticlesAction();
+    expect(mockClaim).not.toHaveBeenCalled();
+    expect(getSavedArticles).toHaveBeenCalledWith('user:user_123');
   });
 });

--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,55 +1,118 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { checkRateLimit, getRequestIp } from '../rate-limit';
 
-describe('checkRateLimit', () => {
+// Without Upstash env vars the limiter is the original per-instance in-memory
+// sliding window; with them it becomes a global fixed window over the Upstash
+// REST API, failing OPEN (falling back to memory) on any Redis problem.
+
+describe('checkRateLimit (in-memory fallback)', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('allows requests within the limit', () => {
+  it('allows requests within the limit', async () => {
     // Use unique key per test to avoid shared-state interference
     const key = 'rl-allow-3';
-    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
-    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
-    expect(checkRateLimit(key, 3, 60_000)).toBe(true);
+    await expect(checkRateLimit(key, 3, 60_000)).resolves.toBe(true);
+    await expect(checkRateLimit(key, 3, 60_000)).resolves.toBe(true);
+    await expect(checkRateLimit(key, 3, 60_000)).resolves.toBe(true);
   });
 
-  it('blocks the request once the limit is reached', () => {
+  it('blocks the request once the limit is reached', async () => {
     const key = 'rl-block-after-2';
-    checkRateLimit(key, 2, 60_000);
-    checkRateLimit(key, 2, 60_000);
-    expect(checkRateLimit(key, 2, 60_000)).toBe(false);
+    await checkRateLimit(key, 2, 60_000);
+    await checkRateLimit(key, 2, 60_000);
+    await expect(checkRateLimit(key, 2, 60_000)).resolves.toBe(false);
   });
 
-  it('allows again after the sliding window expires', () => {
+  it('allows again after the sliding window expires', async () => {
     const key = 'rl-window-expire';
-    checkRateLimit(key, 1, 1_000);
-    expect(checkRateLimit(key, 1, 1_000)).toBe(false); // blocked
+    await checkRateLimit(key, 1, 1_000);
+    await expect(checkRateLimit(key, 1, 1_000)).resolves.toBe(false); // blocked
 
     vi.advanceTimersByTime(1_001); // advance past the 1 s window
-    expect(checkRateLimit(key, 1, 1_000)).toBe(true);  // allowed again
+    await expect(checkRateLimit(key, 1, 1_000)).resolves.toBe(true); // allowed again
   });
 
-  it('tracks different keys independently', () => {
+  it('tracks different keys independently', async () => {
     const keyA = 'rl-key-a-independent';
     const keyB = 'rl-key-b-independent';
-    checkRateLimit(keyA, 1, 60_000); // exhaust keyA
-    expect(checkRateLimit(keyA, 1, 60_000)).toBe(false);
-    expect(checkRateLimit(keyB, 1, 60_000)).toBe(true); // keyB is unaffected
+    await checkRateLimit(keyA, 1, 60_000); // exhaust keyA
+    await expect(checkRateLimit(keyA, 1, 60_000)).resolves.toBe(false);
+    await expect(checkRateLimit(keyB, 1, 60_000)).resolves.toBe(true); // keyB unaffected
   });
 
-  it('counts only calls inside the active window', () => {
+  it('counts only calls inside the active window', async () => {
     const key = 'rl-partial-window';
-    checkRateLimit(key, 2, 1_000);      // call at t=0
+    await checkRateLimit(key, 2, 1_000); // call at t=0
     vi.advanceTimersByTime(500);
-    checkRateLimit(key, 2, 1_000);      // call at t=500ms — both in window
+    await checkRateLimit(key, 2, 1_000); // call at t=500ms — both in window
 
-    vi.advanceTimersByTime(600);        // now at t=1100ms: t=0 call expired
-    expect(checkRateLimit(key, 2, 1_000)).toBe(true); // only 1 active call remains
+    vi.advanceTimersByTime(600); // now at t=1100ms: t=0 call expired
+    await expect(checkRateLimit(key, 2, 1_000)).resolves.toBe(true); // only 1 active call
+  });
+});
+
+describe('checkRateLimit (Upstash REST backend)', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    vi.unstubAllGlobals();
+  });
+
+  function upstashResponse(count: number) {
+    return {
+      ok: true,
+      json: async () => [{ result: count }, { result: 1 }],
+    } as Response;
+  }
+
+  it('allows when the Redis count is within the limit', async () => {
+    fetchMock.mockResolvedValue(upstashResponse(3));
+    await expect(checkRateLimit('rl-redis-ok', 5, 60_000)).resolves.toBe(true);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://fake.upstash.io/pipeline');
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer test-token',
+    });
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body[0][0]).toBe('INCR');
+    expect(body[1][0]).toBe('PEXPIRE');
+  });
+
+  it('blocks when the Redis count exceeds the limit', async () => {
+    fetchMock.mockResolvedValue(upstashResponse(6));
+    await expect(checkRateLimit('rl-redis-block', 5, 60_000)).resolves.toBe(false);
+  });
+
+  it('fails open to the in-memory limiter when the request errors', async () => {
+    fetchMock.mockRejectedValue(new Error('redis down'));
+    await expect(checkRateLimit('rl-redis-down', 5, 60_000)).resolves.toBe(true);
+  });
+
+  it('fails open when Upstash returns a non-OK status', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 } as Response);
+    await expect(checkRateLimit('rl-redis-500', 5, 60_000)).resolves.toBe(true);
+  });
+
+  it('fails open on an unexpected payload shape', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ nope: true }) } as Response);
+    await expect(checkRateLimit('rl-redis-shape', 5, 60_000)).resolves.toBe(true);
   });
 });
 

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -452,3 +452,12 @@ describe('Security - unicode and encoding attacks', () => {
     expect(result).toContain('url(');
   });
 });
+
+describe('topicSlug', () => {
+  it('normalises names and slugs to the /topic route contract', async () => {
+    const { topicSlug } = await import('../utils');
+    expect(topicSlug('Zimbabwe Elections')).toBe('zimbabwe-elections');
+    expect(topicSlug('  load--shedding! ')).toBe('load-shedding');
+    expect(topicSlug('---')).toBe('');
+  });
+});

--- a/src/lib/actions/feed.ts
+++ b/src/lib/actions/feed.ts
@@ -11,7 +11,9 @@
  */
 
 import { cookies } from 'next/headers'
-import { getArticles, getArticleById, getNewsByteArticles, searchArticles, getSavedArticles } from '@/lib/mongodb/articles'
+import { getDb } from '@/lib/mongodb/client'
+import { resolveEngagementSubject, claimSessionEngagement } from '@/lib/engagement'
+import { getArticles, getArticleById, getNewsByteArticles, searchArticles, getSavedArticles, getTopicTimeline } from '@/lib/mongodb/articles'
 import { getCategories, getTrendingCategories } from '@/lib/mongodb/categories'
 import { getSources, getStats, getTrendingAuthors } from '@/lib/mongodb/sources'
 import {
@@ -160,6 +162,29 @@ export async function getSavedArticlesAction() {
   const cookieStore = await cookies()
   const sessionId = cookieStore.get('mukoko_session')?.value
   const safeSessionId = parseOrDefault(idSchema, sessionId, null)
+
+  // Signed-in users read by their stable user key (saves follow the account);
+  // any anonymous cookie history is claimed for the user on the way through.
+  const subject = await resolveEngagementSubject(safeSessionId ?? undefined)
+  if (subject.isUser && subject.key) {
+    if (safeSessionId) {
+      await claimSessionEngagement(await getDb(), safeSessionId, subject.key)
+    }
+    return getSavedArticles(subject.key)
+  }
+
   if (!safeSessionId) return { articles: [] as Article[] }
   return getSavedArticles(safeSessionId)
+}
+
+/** Topic slugs are enrichment-generated: lowercase words joined by hyphens. */
+const topicSlugRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
+export async function getTopicTimelineAction(slug: string, days = 30) {
+  const trimmed = typeof slug === 'string' ? slug.trim().toLowerCase().slice(0, 64) : ''
+  if (!topicSlugRe.test(trimmed)) {
+    return { topic: trimmed, articles: [] as Article[], total: 0 }
+  }
+  const result = await getTopicTimeline(trimmed, { days: clampInt(days, 1, 90, 30) })
+  return { topic: trimmed, ...result }
 }

--- a/src/lib/engagement.ts
+++ b/src/lib/engagement.ts
@@ -1,0 +1,81 @@
+import type { Db } from 'mongodb'
+
+// ── Engagement subject keys ──────────────────────────────────────────────────
+//
+// articleSaves / articleLikes documents are keyed by a `sessionId` string. For
+// anonymous visitors that is the `mukoko_session` cookie value; for signed-in
+// users it is a stable `user:<workos-user-id>` key, which is what makes saves
+// and likes follow the account across devices. The field name stays
+// `sessionId` (the gateway and pipeline treat it as an opaque subject key and
+// only ever aggregate by articleId), and the `user:` prefix keeps the two key
+// spaces from ever colliding.
+
+export const USER_KEY_PREFIX = 'user:'
+
+export function userEngagementKey(userId: string): string {
+  return `${USER_KEY_PREFIX}${userId}`
+}
+
+export interface EngagementSubject {
+  /** Subject key to store/query with, or null when anonymous with no cookie. */
+  key: string | null
+  /** True when the key is the signed-in user's stable key. */
+  isUser: boolean
+}
+
+/**
+ * Resolve who is engaging: the WorkOS user when signed in, else the anonymous
+ * cookie session. `withAuth()` failures degrade to anonymous — an auth
+ * misconfig must never break public engagement.
+ */
+export async function resolveEngagementSubject(
+  cookieSessionId: string | undefined
+): Promise<EngagementSubject> {
+  try {
+    // Lazy import: authkit is a server-only module — loading it at call time
+    // keeps this file importable from anything that transitively touches the
+    // actions layer (tests, client bundles that tree-shake the call away).
+    const { withAuth } = await import('@workos-inc/authkit-nextjs')
+    const { user } = await withAuth()
+    if (user) return { key: userEngagementKey(user.id), isUser: true }
+  } catch (err) {
+    console.error('[ENGAGEMENT] withAuth() failed; treating as anonymous', err)
+  }
+  return { key: cookieSessionId ?? null, isUser: false }
+}
+
+const CLAIMABLE_COLLECTIONS = ['articleSaves', 'articleLikes'] as const
+
+/**
+ * Claim anonymous cookie-keyed engagement for the signed-in user: re-key
+ * non-conflicting docs to the user key, then drop whatever remains under the
+ * cookie key (overlaps where the user already saved/liked the same article —
+ * the user doc wins). Idempotent and best-effort: a partial failure converges
+ * on the next signed-in interaction, and errors never propagate to the caller.
+ */
+export async function claimSessionEngagement(
+  db: Db,
+  cookieSessionId: string,
+  userKey: string
+): Promise<void> {
+  if (!cookieSessionId || cookieSessionId === userKey) return
+  for (const name of CLAIMABLE_COLLECTIONS) {
+    try {
+      const col = db.collection(name)
+      const owned = await col
+        .find({ sessionId: userKey }, { projection: { articleId: 1 } })
+        .map((d) => d.articleId as string)
+        .toArray()
+      await col.updateMany(
+        {
+          sessionId: cookieSessionId,
+          ...(owned.length > 0 ? { articleId: { $nin: owned } } : {}),
+        },
+        { $set: { sessionId: userKey } }
+      )
+      await col.deleteMany({ sessionId: cookieSessionId })
+    } catch (err) {
+      console.error(`[ENGAGEMENT] claiming ${name} for user failed`, err)
+    }
+  }
+}

--- a/src/lib/mongodb/articles.ts
+++ b/src/lib/mongodb/articles.ts
@@ -412,3 +412,55 @@ export async function getSavedArticles(sessionId: string): Promise<{ articles: A
   const articleMap = new Map(docs.map(d => [d._id, toArticle(d, sourceMap.get(d.feedSourceId))]))
   return { articles: articleIds.map(id => articleMap.get(id)).filter(Boolean) as Article[] }
 }
+
+// ── Topic timeline (developing-story surface) ────────────────────────────────
+
+/**
+ * Articles matching a topic slug across the enrichment surfaces — tag slugs
+ * (string or object elements), AI-classified categories, and AI keywords —
+ * within a recency window, newest first. Backs the /topic/[slug] timeline;
+ * day-grouping happens in the component layer.
+ */
+export async function getTopicTimeline(
+  slug: string,
+  params: { days?: number; limit?: number } = {}
+): Promise<{ articles: Article[]; total: number }> {
+  const db = await getDb()
+  const days = clampInt(params.days, 1, 90, 30)
+  const limit = clampInt(params.limit, 1, MAX_LIMIT, 100)
+
+  const esc = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  // A slug like "zimbabwe-elections" should also match the tag/keyword name
+  // form "zimbabwe elections" regardless of how enrichment cased it.
+  const slugRe = new RegExp(`^${esc(slug)}$`, 'i')
+  const nameRe = new RegExp(`^${esc(slug.replace(/-/g, ' '))}$`, 'i')
+
+  const since = new Date(Date.now() - days * 86_400_000)
+  const filter: Filter<MongoArticle> = {
+    status: { $ne: 'rejected' },
+    moderationStatus: { $ne: 'removed' },
+    datePublished: { $gte: since },
+    $or: [
+      // engagement.tags elements are plain slugs/names or {slug, name} objects
+      { 'engagement.tags': { $in: [slugRe, nameRe] } },
+      { 'engagement.tags.slug': slugRe },
+      { 'engagement.tags.name': nameRe },
+      { 'engagement.interest_categories': slugRe },
+      { aiKeywords: { $in: [slugRe, nameRe] } },
+    ] as never,
+  }
+
+  const col = db.collection<MongoArticle>('articles')
+  const [docs, total] = await Promise.all([
+    col.find(filter).sort({ datePublished: -1 }).limit(limit).toArray(),
+    col.countDocuments(filter),
+  ])
+
+  const sourceIds = [...new Set(docs.map(d => d.feedSourceId))]
+  const sources = await db.collection<MongoFeedSource>('feedSources')
+    .find({ _id: { $in: sourceIds } })
+    .toArray()
+  const sourceMap = new Map(sources.map(s => [s._id, s]))
+
+  return { articles: docs.map(d => toArticle(d, sourceMap.get(d.feedSourceId))), total }
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,18 +1,18 @@
 /**
- * In-memory sliding window rate limiter.
+ * Rate limiter with a durable Upstash Redis backend and an in-memory fallback.
  *
- * Works within a single Vercel Fluid Compute instance. The fly-worker's own
- * rate limiter is the global guard for collection triggers; this protects
- * individual MongoDB fetch routes from per-IP burst traffic.
+ * When UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN are set, limits are
+ * enforced globally via a fixed-window INCR+PEXPIRE over the Upstash REST API
+ * (no SDK dependency). Without them — or if Redis errors — the check degrades
+ * to the original per-instance in-memory sliding window, so limits still apply
+ * per Vercel instance rather than globally. Public reads fail OPEN: a limiter
+ * outage must never take the endpoints down with it.
  */
 
 const windows = new Map<string, number[]>();
 
-export function checkRateLimit(
-  key: string,
-  max = 3,
-  windowMs = 60_000
-): boolean {
+/** Per-instance sliding window — the fallback and the no-Redis default. */
+function checkRateLimitMemory(key: string, max: number, windowMs: number): boolean {
   const now = Date.now();
   const cutoff = now - windowMs;
   const prev = windows.get(key) ?? [];
@@ -26,6 +26,64 @@ export function checkRateLimit(
   active.push(now);
   windows.set(key, active);
   return true;
+}
+
+/** Global fixed window via Upstash REST. Returns null when Redis is unusable. */
+async function checkRateLimitRedis(
+  key: string,
+  max: number,
+  windowMs: number
+): Promise<boolean | null> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+
+  // Fixed window: bucket the key by window so INCR counts one window at a time;
+  // PEXPIRE NX arms the TTL only on the first hit of the window.
+  const bucket = `rl:${key}:${Math.floor(Date.now() / windowMs)}`;
+  try {
+    const res = await fetch(`${url.replace(/\/$/, '')}/pipeline`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify([
+        ['INCR', bucket],
+        ['PEXPIRE', bucket, String(windowMs), 'NX'],
+      ]),
+      // A slow limiter must not stall the request path.
+      signal: AbortSignal.timeout(1500),
+    });
+    if (!res.ok) {
+      console.error(`[RATE-LIMIT] Upstash responded ${res.status}; falling back to memory`);
+      return null;
+    }
+    const results = (await res.json()) as Array<{ result?: unknown; error?: string }>;
+    const count = Number(results?.[0]?.result);
+    if (!Number.isFinite(count)) {
+      console.error('[RATE-LIMIT] unexpected Upstash payload; falling back to memory');
+      return null;
+    }
+    return count <= max;
+  } catch (err) {
+    console.error('[RATE-LIMIT] Upstash request failed; falling back to memory', err);
+    return null;
+  }
+}
+
+/**
+ * True when the caller is within the limit. Durable (Upstash) when configured,
+ * per-instance in-memory otherwise.
+ */
+export async function checkRateLimit(
+  key: string,
+  max = 3,
+  windowMs = 60_000
+): Promise<boolean> {
+  const redisVerdict = await checkRateLimitRedis(key, max, windowMs);
+  if (redisVerdict !== null) return redisVerdict;
+  return checkRateLimitMemory(key, max, windowMs);
 }
 
 export function getRequestIp(request: Request): string {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -141,3 +141,16 @@ export function stripHtml(input: string | undefined | null): string {
     .replace(/\n{3,}/g, '\n\n')
     .trim();
 }
+
+/**
+ * Normalise a tag/keyword (display name or stored slug) into a /topic/[slug]
+ * path segment — lowercase words joined by single hyphens, matching the
+ * validation in getTopicTimelineAction.
+ */
+export function topicSlug(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
## Why

The MVP-completion pass, in the owner-approved priority order (1 → 4 → 3 → 2 → 5 from the gap audit). The reader loop was already complete; this ships the signed-in loop, the new Mzizi 4.x design tokens, the developing-story surface, and the durable limiter.

## What changed

### 1. Account-backed saves & likes (the auth payoff)
- New `src/lib/engagement.ts`: likes/saves are keyed to an **engagement subject** — the signed-in WorkOS user (`user:<id>`, resolved server-side via `withAuth()`) or the anonymous `mukoko_session` cookie. Saves now follow the account across devices.
- On the first signed-in interaction (or a `/saved` read), anonymous cookie history is **claimed** for the user: non-conflicting docs re-keyed, overlaps keep the user's copy. Idempotent, best-effort, converges on retry.
- The stored field stays `sessionId` — an opaque subject key to the gateway/pipeline; counts and aggregations are unchanged, and the `user:` prefix keeps key spaces disjoint.
- `/saved` shows a "sign in to keep them across devices" nudge to anonymous readers.

### 2. Mzizi density system (new tokens)
- `globals.css` gains the prime-scale **touch targets** (`--touch-*`: 47/43/37/31px + 56px hero-only), the **icon scale** (`--icon-*`), and density scopes: `comfortable` default; `/admin` + `/dashboard` opt into **compact** via `data-density="compact"`, which cascades through `--density-touch` and the card/input radii with zero per-component changes; `spacious` available for hero surfaces.
- Button sizes ride the tokens (`min-h-[var(--density-touch)]`) so compact surfaces shrink automatically.

### 3. Developing-story timeline `/topic/[slug]` (new Mzizi `nyuchi-timeline` component)
- Date-railed day groups (weekday / big numeral / month, rendered in CAT so server and client always agree) beside tight rows: time, title, source · category, right-edge proxied thumbnail.
- Backed by `getTopicTimeline` — matches tag slugs and names, AI-classified categories, and AI keywords over a 30-day window — exposed via the validated `getTopicTimelineAction`; ISR (`revalidate = 300`).
- Entry points: **"Follow the story" chips** on the article page (from `article.keywords`) and Insights **trending topics** (previously a plain search link). Shared `topicSlug()` normaliser in `utils`.

### 4. Durable rate limiting
- `checkRateLimit` is now **async**: with `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN` set it enforces a **global** fixed window via the Upstash REST pipeline (`INCR` + `PEXPIRE NX`, no SDK dependency, 1.5s timeout); on any Redis problem it **fails open** to the original in-memory per-instance window. Unset env = behaviour unchanged.
- All four call sites (like/view/save/insights-export) updated; `.env.example` documents the new vars.

### 5. Small debts
- Error-page buttons use the `text-on-primary` token; `TODO(on-primary)` markers removed. (The admin analytics page turned out to already be backed by live Mongo aggregates — its "not tracked yet" note is honest and stays.)

Docs: `CHANGELOG.md`, `CLAUDE.md` (directory map, engagement/rate-limit flow, density section), `auth.md` (engagement identity).

## Deployment note

To activate global rate limits, add `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` to Vercel env. Everything else needs no config.

## Testing

- **675 tests / 46 files pass** (new: engagement subject + claim migration, topic timeline grouping/rendering incl. CAT day-rollover and unsafe-image cases, Upstash allow/block/fail-open paths, `topicSlug`)
- `npm run typecheck`, `npm run lint`, `npm run build` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113jJUqEQnhpqFB3PTh2RfA

---
_Generated by [Claude Code](https://claude.ai/code/session_0113jJUqEQnhpqFB3PTh2RfA)_